### PR TITLE
Fix standalone CLI Transformers bundling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
         env:
           CYBARA_BUILD_COMMIT: ${{ github.sha }}
         run: |
-          bun build src/main.ts --compile '--env=CYBARA_BUILD_*' --target=bun-${{ matrix.target }} --outfile=${{ matrix.artifact }} --external electron --external @aws-sdk/client-s3 --external onnxruntime-node --external onnxruntime-web --external @huggingface/transformers
+          bun build src/main.ts --compile '--env=CYBARA_BUILD_*' --target=bun-${{ matrix.target }} --outfile=${{ matrix.artifact }} --external electron --external @aws-sdk/client-s3
       - name: Upload CLI artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:

--- a/scripts/package.ts
+++ b/scripts/package.ts
@@ -68,7 +68,7 @@ export async function runPackage(): Promise<void> {
   const binaryPath = join(RELEASE_DIR, BINARY_NAME);
 
   try {
-    await $`bun build src/main.ts --compile ${buildEnvironment} --outfile ${binaryPath} --target bun --external electron --external @aws-sdk/client-s3 --external @huggingface/transformers --external kokoro-js --external playwright --external playwright-core --external onnxruntime-node --external onnxruntime-web`;
+    await $`bun build src/main.ts --compile ${buildEnvironment} --outfile ${binaryPath} --target bun --external electron --external @aws-sdk/client-s3`;
     console.log(`   ✓ Binary compiled: ${binaryPath}`);
   } catch (error) {
     console.error("   ✗ Binary compilation failed:", error);

--- a/tests/runtime/app-release-surfaces.test.ts
+++ b/tests/runtime/app-release-surfaces.test.ts
@@ -185,6 +185,19 @@ describe("app release surface wiring", () => {
     );
   });
 
+  test("CLI release binaries bundle the Transformers runtime", () => {
+    const workflow = read(".github/workflows/release.yml");
+    const compileCommand = workflow
+      .split("\n")
+      .find((line) => line.includes("bun build src/main.ts --compile"));
+
+    expect(compileCommand).toContain("--external electron");
+    expect(compileCommand).toContain("--external @aws-sdk/client-s3");
+    expect(compileCommand).not.toContain("--external @huggingface/transformers");
+    expect(compileCommand).not.toContain("--external onnxruntime-node");
+    expect(compileCommand).not.toContain("--external onnxruntime-web");
+  });
+
   test("release workflow runs native macOS unit tests when XCTest is available", () => {
     const workflow = read(".github/workflows/release.yml");
 

--- a/tests/runtime/compiled-cli-startup.test.ts
+++ b/tests/runtime/compiled-cli-startup.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+function currentBunTarget(): string {
+  const platform = process.platform === "win32" ? "windows" : process.platform;
+  return `bun-${platform}-${process.arch}`;
+}
+
+describe("compiled CLI startup", () => {
+  test("runs without an adjacent Transformers runtime", () => {
+    const directory = mkdtempSync(join(tmpdir(), "cybara-compiled-cli-startup-"));
+    const binary = join(directory, process.platform === "win32" ? "cybara.exe" : "cybara");
+    const home = join(directory, "home");
+    mkdirSync(home, { recursive: true });
+
+    try {
+      const build = Bun.spawnSync(
+        [
+          process.execPath,
+          "build",
+          join(process.cwd(), "src", "main.ts"),
+          "--compile",
+          `--target=${currentBunTarget()}`,
+          `--outfile=${binary}`,
+          "--external",
+          "electron",
+          "--external",
+          "@aws-sdk/client-s3",
+        ],
+        { cwd: process.cwd() }
+      );
+      expect(build.exitCode).toBe(0);
+
+      const environment = { ...process.env, HOME: home, USERPROFILE: home };
+      const version = Bun.spawnSync([binary, "version"], { cwd: directory, env: environment });
+      expect(version.exitCode).toBe(0);
+      expect(version.stdout.toString()).toMatch(/^cybara v\d+\.\d+\.\d+/);
+      expect(version.stderr.toString()).not.toContain("Cannot find module");
+
+      const help = Bun.spawnSync([binary, "help"], { cwd: directory, env: environment });
+      expect(help.exitCode).toBe(0);
+      expect(help.stdout.toString()).toContain("CYBARA CLI");
+      expect(help.stderr.toString()).not.toContain("Cannot find module");
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/runtime/package-scripts.test.ts
+++ b/tests/runtime/package-scripts.test.ts
@@ -115,7 +115,9 @@ describe("package.json script wiring", () => {
     const standaloneBuild = packageScript
       .split("\n")
       .find((line) => line.includes("bun build src/main.ts --compile"));
-    expect(standaloneBuild).toContain("--external @huggingface/transformers");
+    expect(standaloneBuild).not.toContain("--external @huggingface/transformers");
+    expect(standaloneBuild).not.toContain("--external onnxruntime-node");
+    expect(standaloneBuild).not.toContain("--external onnxruntime-web");
     expect(standaloneBuild).not.toContain("--external tiny-secp256k1");
     expect(packageScript).toContain("--outdir ${DIST_DIR} --entry-naming cli.js");
 


### PR DESCRIPTION
## What does this PR do?

## How was it tested?
- [ ] `bun test` passes
- [ ] `bunx tsc --noEmit` passes (and `cd ui && bunx tsc --noEmit` for UI changes)
- [ ] Verified against a running gateway (if behavior changed)

## Checklist
- [ ] No secrets/keys in the diff
- [ ] Follows the import/style rules in CLAUDE.md

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Release CLI binaries grow and ship native ONNX/Transformers code paths; behavior change is limited to packaging/startup, but regressions would affect every downloaded CLI user.
> 
> **Overview**
> Standalone **compiled** CLI builds no longer treat `@huggingface/transformers`, `onnxruntime-node`, or `onnxruntime-web` as externals, so those runtimes are embedded in the release binary instead of requiring a sibling `node_modules` tree.
> 
> The same narrowed `--external` list is applied in **`.github/workflows/release.yml`** (cross-compiled CLI artifacts) and **`scripts/package.ts`** (local `--compile` step). Non-compile `dist/` bundling in `package.ts` is unchanged and still externalizes Transformers/Playwright/etc.
> 
> Tests lock this in: **`app-release-surfaces`** and **`package-scripts`** assert the compile command only externalizes `electron` and `@aws-sdk/client-s3`, and **`compiled-cli-startup`** compiles and runs `version`/`help` from an isolated temp dir without adjacent Transformers files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c66b727ec0da9295b9240d75ad6c0e7b6ccd3f11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- GITZILLA_SUMMARY -->
> [!NOTE]
> **Low Risk**
>
> **Overview**
> This PR fixes standalone CLI Transformers bundling by ensuring the `transformers` package is treated as an external dependency in the Bun build configuration, preventing it from being inlined into the standalone CLI binary. The release workflow (`release.yml`) and packaging script (`scripts/package.ts`) are updated to exclude Transformers from bundling, addressing issues with the standalone binary's size or runtime behavior. The changes are accompanied by new and updated tests covering compiled CLI startup, package scripts, and app release surfaces to verify the fix.
>
> <sup>Written by [Gitzilla](https://gitzilla.ai) for commit c66b727. This will update automatically on new runs. Configure in the [Gitzilla dashboard](https://gitzilla.ai/dashboard).</sup>
<!-- /GITZILLA_SUMMARY -->