### PR TITLE
Add Kimi Code OAuth provider integration and fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,3 +85,62 @@ jobs:
 
       - name: Run SwiftPM tests
         run: swift test --package-path apps/macos/Cybara
+
+  darwin-x64-cli-build:
+    name: Build CLI darwin-x64
+    if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
+    needs: quality
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Install root dependencies
+        run: bash scripts/ci-install.sh --ignore-scripts && bun run scripts/postinstall.ts
+
+      - name: Build Darwin x64 CLI
+        env:
+          CYBARA_BUILD_COMMIT: ${{ github.sha }}
+        run: |
+          bun run scripts/build-standalone-cli.ts bun-darwin-x64 cybara-darwin-x64
+
+      - name: Upload Darwin x64 CLI
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: ci-cybara-darwin-x64
+          path: cybara-darwin-x64
+          retention-days: 7
+
+  darwin-x64-cli-smoke:
+    name: Smoke CLI darwin-x64
+    if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
+    needs: darwin-x64-cli-build
+    runs-on: macos-26
+    timeout-minutes: 10
+    steps:
+      - name: Download Darwin x64 CLI
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: ci-cybara-darwin-x64
+
+      - name: Ensure Rosetta is available
+        run: |
+          if ! arch -x86_64 /usr/bin/true; then
+            sudo softwareupdate --install-rosetta --agree-to-license
+          fi
+
+      - name: Run Darwin x64 CLI lifecycle
+        run: |
+          chmod +x cybara-darwin-x64
+          export HOME="$RUNNER_TEMP/cybara-darwin-x64-home"
+          mkdir -p "$HOME"
+          ./cybara-darwin-x64 version
+          ./cybara-darwin-x64 start -d
+          ./cybara-darwin-x64 status
+          ./cybara-darwin-x64 stop

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,9 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 10
     steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
       - name: Download Darwin x64 CLI
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
@@ -136,11 +139,6 @@ jobs:
           fi
 
       - name: Run Darwin x64 CLI lifecycle
-        run: |
-          chmod +x cybara-darwin-x64
-          export HOME="$RUNNER_TEMP/cybara-darwin-x64-home"
-          mkdir -p "$HOME"
-          ./cybara-darwin-x64 version
-          ./cybara-darwin-x64 start -d
-          ./cybara-darwin-x64 status
-          ./cybara-darwin-x64 stop
+        env:
+          CYBARA_SMOKE_HOME: ${{ runner.temp }}/cybara-darwin-x64-home
+        run: bash scripts/smoke-standalone-cli.sh ./cybara-darwin-x64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,29 +49,23 @@ jobs:
   build-cli:
     name: CLI ${{ matrix.target }}
     needs: quality
-    runs-on: ${{ matrix.runner }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         include:
           - target: linux-x64
             artifact: cybara-linux-x64
-            runner: ubuntu-latest
           - target: linux-arm64
             artifact: cybara-linux-arm64
-            runner: ubuntu-latest
           - target: darwin-x64
             artifact: cybara-darwin-x64
-            runner: macos-26
           - target: darwin-arm64
             artifact: cybara-darwin-arm64
-            runner: ubuntu-latest
           - target: windows-x64
             artifact: cybara-windows-x64.exe
-            runner: ubuntu-latest
           - target: windows-arm64
             artifact: cybara-windows-arm64.exe
-            runner: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -93,22 +87,32 @@ jobs:
         env:
           CYBARA_BUILD_COMMIT: ${{ github.sha }}
         run: |
-          bun build src/main.ts --compile '--env=CYBARA_BUILD_*' --target=bun-${{ matrix.target }} --outfile=${{ matrix.artifact }} --external electron --external @aws-sdk/client-s3
-      - name: Smoke-test Darwin x64 CLI
-        if: matrix.target == 'darwin-x64'
-        run: |
-          export HOME="$RUNNER_TEMP/cybara-darwin-x64-home"
-          mkdir -p "$HOME"
-          ./${{ matrix.artifact }} version
-          ./${{ matrix.artifact }} start -d
-          ./${{ matrix.artifact }} status
-          ./${{ matrix.artifact }} stop
+          bun build src/main.ts --compile '--env=CYBARA_BUILD_*' --target=bun-${{ matrix.target }} --outfile=${{ matrix.artifact }} --external electron --external @aws-sdk/client-s3 --external @huggingface/transformers --external kokoro-js --external onnxruntime-node --external onnxruntime-web
       - name: Upload CLI artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ matrix.artifact }}
           path: ${{ matrix.artifact }}
           retention-days: 30
+
+  smoke-cli-darwin-x64:
+    name: Smoke CLI darwin-x64
+    needs: build-cli
+    runs-on: macos-26
+    steps:
+      - name: Download Darwin x64 CLI artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: cybara-darwin-x64
+      - name: Run Darwin x64 CLI lifecycle
+        run: |
+          chmod +x cybara-darwin-x64
+          export HOME="$RUNNER_TEMP/cybara-darwin-x64-home"
+          mkdir -p "$HOME"
+          ./cybara-darwin-x64 version
+          ./cybara-darwin-x64 start -d
+          ./cybara-darwin-x64 status
+          ./cybara-darwin-x64 stop
 
   # ── Tauri desktop apps (platform-native builds) ────────────────────────────
   build-tauri:
@@ -851,7 +855,7 @@ jobs:
   # ── Create GitHub Release with CLI binaries + checksums ─────────────────────
   release:
     name: Create Release
-    needs: [build-cli, build-mobile]
+    needs: [build-cli, smoke-cli-darwin-x64, build-mobile]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,23 +49,29 @@ jobs:
   build-cli:
     name: CLI ${{ matrix.target }}
     needs: quality
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - target: linux-x64
             artifact: cybara-linux-x64
+            runner: ubuntu-latest
           - target: linux-arm64
             artifact: cybara-linux-arm64
+            runner: ubuntu-latest
           - target: darwin-x64
             artifact: cybara-darwin-x64
+            runner: macos-26
           - target: darwin-arm64
             artifact: cybara-darwin-arm64
+            runner: ubuntu-latest
           - target: windows-x64
             artifact: cybara-windows-x64.exe
+            runner: ubuntu-latest
           - target: windows-arm64
             artifact: cybara-windows-arm64.exe
+            runner: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -88,6 +94,15 @@ jobs:
           CYBARA_BUILD_COMMIT: ${{ github.sha }}
         run: |
           bun build src/main.ts --compile '--env=CYBARA_BUILD_*' --target=bun-${{ matrix.target }} --outfile=${{ matrix.artifact }} --external electron --external @aws-sdk/client-s3
+      - name: Smoke-test Darwin x64 CLI
+        if: matrix.target == 'darwin-x64'
+        run: |
+          export HOME="$RUNNER_TEMP/cybara-darwin-x64-home"
+          mkdir -p "$HOME"
+          ./${{ matrix.artifact }} version
+          ./${{ matrix.artifact }} start -d
+          ./${{ matrix.artifact }} status
+          ./${{ matrix.artifact }} stop
       - name: Upload CLI artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,19 +100,16 @@ jobs:
     needs: build-cli
     runs-on: macos-26
     steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Download Darwin x64 CLI artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: cybara-darwin-x64
       - name: Run Darwin x64 CLI lifecycle
-        run: |
-          chmod +x cybara-darwin-x64
-          export HOME="$RUNNER_TEMP/cybara-darwin-x64-home"
-          mkdir -p "$HOME"
-          ./cybara-darwin-x64 version
-          ./cybara-darwin-x64 start -d
-          ./cybara-darwin-x64 status
-          ./cybara-darwin-x64 stop
+        env:
+          CYBARA_SMOKE_HOME: ${{ runner.temp }}/cybara-darwin-x64-home
+        run: bash scripts/smoke-standalone-cli.sh ./cybara-darwin-x64
 
   # ── Tauri desktop apps (platform-native builds) ────────────────────────────
   build-tauri:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
         env:
           CYBARA_BUILD_COMMIT: ${{ github.sha }}
         run: |
-          bun build src/main.ts --compile '--env=CYBARA_BUILD_*' --target=bun-${{ matrix.target }} --outfile=${{ matrix.artifact }} --external electron --external @aws-sdk/client-s3 --external @huggingface/transformers --external kokoro-js --external onnxruntime-node --external onnxruntime-web
+          bun run scripts/build-standalone-cli.ts bun-${{ matrix.target }} ${{ matrix.artifact }}
       - name: Upload CLI artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:

--- a/knip.json
+++ b/knip.json
@@ -15,6 +15,7 @@
         "@typescript/native",
         "@vtsls/language-server",
         "bash-language-server",
+        "kokoro-js",
         "react-doctor",
         "typescript-language-server",
         "vscode-langservers-extracted",

--- a/scripts/build-standalone-cli.ts
+++ b/scripts/build-standalone-cli.ts
@@ -1,0 +1,48 @@
+export interface StandaloneCliBuildOptions {
+  target: string;
+  outfile: string;
+  cwd?: string;
+}
+
+const EXTERNAL_PACKAGES = [
+  "electron",
+  "@aws-sdk/client-s3",
+  "@huggingface/transformers",
+  "kokoro-js",
+  "onnxruntime-node",
+  "onnxruntime-web",
+];
+
+export function standaloneCliBuildArgs(target: string, outfile: string): string[] {
+  return [
+    process.execPath,
+    "build",
+    "src/main.ts",
+    "--compile",
+    "--env=CYBARA_BUILD_*",
+    `--target=${target}`,
+    `--outfile=${outfile}`,
+    ...EXTERNAL_PACKAGES.flatMap((packageName) => ["--external", packageName]),
+  ];
+}
+
+export async function buildStandaloneCli(options: StandaloneCliBuildOptions): Promise<void> {
+  const processHandle = Bun.spawn(standaloneCliBuildArgs(options.target, options.outfile), {
+    cwd: options.cwd ?? process.cwd(),
+    env: process.env,
+    stdin: "inherit",
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  const exitCode = await processHandle.exited;
+  if (exitCode !== 0) throw new Error(`Standalone CLI build failed with exit code ${exitCode}`);
+}
+
+if (import.meta.main) {
+  const target = process.argv[2]?.trim();
+  const outfile = process.argv[3]?.trim();
+  if (!target || !outfile) {
+    throw new Error("Usage: bun run scripts/build-standalone-cli.ts <target> <outfile>");
+  }
+  await buildStandaloneCli({ target, outfile });
+}

--- a/scripts/package.ts
+++ b/scripts/package.ts
@@ -14,6 +14,7 @@ import {
 import { join } from "path";
 import { readGitCommit } from "../src/core/build-info";
 import { getCuaDriverTarget, installCuaDriverAt } from "../src/core/cua-driver-runtime";
+import { buildStandaloneCli } from "./build-standalone-cli";
 
 const DIST_DIR = "dist";
 const RELEASE_DIR = "release";
@@ -25,7 +26,6 @@ export async function runPackage(): Promise<void> {
     process.env.GITHUB_SHA?.trim() ||
     (await readGitCommit(process.cwd()));
   if (buildCommit) process.env.CYBARA_BUILD_COMMIT = buildCommit;
-  const buildEnvironment = "--env=CYBARA_BUILD_*";
   console.log("\n🚀 Cybara Packaging Script\n");
 
   console.log("📁 Cleaning release directory...");
@@ -68,7 +68,7 @@ export async function runPackage(): Promise<void> {
   const binaryPath = join(RELEASE_DIR, BINARY_NAME);
 
   try {
-    await $`bun build src/main.ts --compile ${buildEnvironment} --outfile ${binaryPath} --target bun --external electron --external @aws-sdk/client-s3 --external @huggingface/transformers --external kokoro-js --external onnxruntime-node --external onnxruntime-web`;
+    await buildStandaloneCli({ target: "bun", outfile: binaryPath });
     console.log(`   ✓ Binary compiled: ${binaryPath}`);
   } catch (error) {
     console.error("   ✗ Binary compilation failed:", error);

--- a/scripts/package.ts
+++ b/scripts/package.ts
@@ -68,7 +68,7 @@ export async function runPackage(): Promise<void> {
   const binaryPath = join(RELEASE_DIR, BINARY_NAME);
 
   try {
-    await $`bun build src/main.ts --compile ${buildEnvironment} --outfile ${binaryPath} --target bun --external electron --external @aws-sdk/client-s3`;
+    await $`bun build src/main.ts --compile ${buildEnvironment} --outfile ${binaryPath} --target bun --external electron --external @aws-sdk/client-s3 --external @huggingface/transformers --external kokoro-js --external onnxruntime-node --external onnxruntime-web`;
     console.log(`   ✓ Binary compiled: ${binaryPath}`);
   } catch (error) {
     console.error("   ✗ Binary compilation failed:", error);

--- a/scripts/smoke-standalone-cli.sh
+++ b/scripts/smoke-standalone-cli.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -euo pipefail
+
+BINARY="${1:?Standalone CLI binary path is required}"
+chmod +x "$BINARY"
+export HOME="${CYBARA_SMOKE_HOME:-${RUNNER_TEMP:-/tmp}/cybara-standalone-smoke-home}"
+mkdir -p "$HOME"
+
+"$BINARY" version
+"$BINARY" start -d
+
+ready=0
+for attempt in {1..15}; do
+  if "$BINARY" status; then
+    ready=1
+    break
+  fi
+  sleep 2
+done
+
+if [ "$ready" -ne 1 ]; then
+  "$BINARY" daemon-logs || true
+  "$BINARY" stop || true
+  exit 1
+fi
+
+"$BINARY" stop

--- a/src/api/provider-oauth-device.ts
+++ b/src/api/provider-oauth-device.ts
@@ -6,6 +6,7 @@ import {
   startMiniMaxPortalOAuth,
 } from "./provider-oauth-minimax";
 import { pollCursorOAuth, startCursorOAuth } from "./provider-oauth-cursor";
+import { kimiCodeIdentityHeaders } from "../core/providers/kimi-code";
 
 interface DeviceOAuthConfig {
   clientId?: string;
@@ -34,6 +35,7 @@ function deviceOAuthHeaders(providerType: ProviderType): Record<string, string> 
           "x-grok-client-version": appVersion,
         }
       : {}),
+    ...(providerType === "kimi-code-oauth" ? kimiCodeIdentityHeaders() : {}),
   };
 }
 
@@ -52,6 +54,17 @@ function isTrustedXaiOAuthEndpoint(endpoint: string): boolean {
 function validateOAuthEndpoint(providerType: string, endpoint: string, label: string): string {
   if (providerType === "xai-oauth" && !isTrustedXaiOAuthEndpoint(endpoint)) {
     throw new Error(`Validation error: xAI OAuth discovery returned an untrusted ${label}`);
+  }
+  if (providerType === "kimi-code-oauth") {
+    try {
+      const parsed = new URL(endpoint);
+      const trustedOrigins = label.includes("verification URI")
+        ? new Set(["https://auth.kimi.com", "https://www.kimi.com"])
+        : new Set(["https://auth.kimi.com"]);
+      if (!trustedOrigins.has(parsed.origin)) throw new Error();
+    } catch {
+      throw new Error(`Validation error: Kimi OAuth returned an untrusted ${label}`);
+    }
   }
   return endpoint;
 }
@@ -143,7 +156,7 @@ export async function startProviderDeviceCodeOAuth(
     headers: deviceOAuthHeaders(resolvedProviderType),
     body: new URLSearchParams({
       client_id: oauthConfig.clientId,
-      scope: oauthConfig.scope || "",
+      ...(oauthConfig.scope ? { scope: oauthConfig.scope } : {}),
       ...(resolvedProviderType === "xai-oauth" ? { referrer: "grok-build" } : {}),
     }),
   });
@@ -160,11 +173,6 @@ export async function startProviderDeviceCodeOAuth(
     expires_in: number;
     interval: number;
   };
-  const verificationUri = validateOAuthEndpoint(
-    resolvedProviderType,
-    json.verification_uri,
-    "device verification URI"
-  );
   const verificationUriComplete =
     typeof json.verification_uri_complete === "string" && json.verification_uri_complete.trim()
       ? validateOAuthEndpoint(
@@ -173,6 +181,13 @@ export async function startProviderDeviceCodeOAuth(
           "complete device verification URI"
         )
       : undefined;
+  const verificationUri = validateOAuthEndpoint(
+    resolvedProviderType,
+    typeof json.verification_uri === "string" && json.verification_uri.trim()
+      ? json.verification_uri
+      : verificationUriComplete || "",
+    "device verification URI"
+  );
 
   return {
     device_code: json.device_code,
@@ -215,11 +230,16 @@ export async function pollProviderDeviceCodeOAuth(body: unknown): Promise<Record
 
   if (res.ok && typeof json.access_token === "string") {
     const refreshToken = typeof json.refresh_token === "string" ? json.refresh_token : undefined;
-    if (resolvedProviderType === "xai-oauth" && !refreshToken) {
+    if (
+      (resolvedProviderType === "xai-oauth" || resolvedProviderType === "kimi-code-oauth") &&
+      !refreshToken
+    ) {
       return {
         status: "error",
         error:
-          "xAI OAuth did not return a refresh token. Re-run login; if it keeps happening, xAI rejected offline_access for this OAuth client.",
+          resolvedProviderType === "xai-oauth"
+            ? "xAI OAuth did not return a refresh token. Re-run login; if it keeps happening, xAI rejected offline_access for this OAuth client."
+            : "Kimi OAuth did not return a refresh token. Re-run login and authorize the coding-plan account again.",
       };
     }
     const expiresIn =

--- a/src/core/llm/reasoning.ts
+++ b/src/core/llm/reasoning.ts
@@ -40,6 +40,7 @@ const ADAPTIVE_THINKING_PROVIDERS = new Set([
   "minimax-portal",
   "minimax-portal-cn",
 ]);
+const KIMI_CODE_PROVIDERS = new Set(["kimi-code", "kimi-code-oauth", "kimi-coding", "kimi-oauth"]);
 
 const GPT_5_EFFORTS: ReasoningEffort[] = ["minimal", "low", "medium", "high"];
 const GPT_51_EFFORTS: ReasoningEffort[] = ["low", "medium", "high"];
@@ -126,6 +127,9 @@ export function supportedReasoningEfforts(
     return [];
   }
   const modelId = normalizeModelId(model);
+  if (KIMI_CODE_PROVIDERS.has(provider) && modelId === "k3") {
+    return ["max"];
+  }
   if (provider === "anthropic" || provider === "anthropic_vertex") {
     return resolveAnthropicModelEfforts(modelId);
   }

--- a/src/core/local-speech.ts
+++ b/src/core/local-speech.ts
@@ -132,6 +132,10 @@ interface TransformersRuntimeModule {
   env: { cacheDir: string };
 }
 
+async function importOptionalModule(specifier: string): Promise<unknown> {
+  return await import(specifier);
+}
+
 interface LocalAsrResult {
   text?: string;
 }
@@ -487,7 +491,7 @@ async function importKokoro(): Promise<KokoroModule> {
   if (entries) {
     return (await import(pathToFileURL(entries.kokoro).href)) as unknown as KokoroModule;
   }
-  return (await import("kokoro-js")) as unknown as KokoroModule;
+  return (await importOptionalModule("kokoro-js")) as KokoroModule;
 }
 
 async function importLocalTransformers(): Promise<LocalTransformersModule> {

--- a/src/core/model-discovery.ts
+++ b/src/core/model-discovery.ts
@@ -71,6 +71,21 @@ function endpointModel(value: unknown): ModelsDevModel | undefined {
   };
 }
 
+function staticModelDefaults(providerType: string, modelId: string): ModelsDevModel | undefined {
+  const model = providers[providerType as ProviderType]?.models?.find(
+    (candidate: { id: string }) => candidate.id.toLowerCase() === modelId.toLowerCase()
+  );
+  if (!model) return undefined;
+  return {
+    id: model.id,
+    name: model.name,
+    contextWindow: model.context,
+    maxTokens: model.maxTokens,
+    reasoning: model.reasoning,
+    input: [...model.input],
+  };
+}
+
 function normalizeInputTypes(value: unknown): string[] {
   if (Array.isArray(value))
     return value.filter((entry): entry is string => typeof entry === "string");
@@ -221,6 +236,7 @@ async function runProviderDiscovery(
       catalogModels.map((model) => [model.id.trim().toLowerCase(), model] as const)
     );
     const found = endpointModels.map((model) => ({
+      ...staticModelDefaults(providerType, model.id),
       ...catalogById.get(model.id.toLowerCase()),
       ...model,
     }));

--- a/src/core/model-discovery.ts
+++ b/src/core/model-discovery.ts
@@ -31,6 +31,46 @@ export interface ModelDiscoveryOptions {
 const discoveryCache = new Map<string, { fetchedAt: number; result: DiscoveryResult }>();
 const discoveryInFlight = new Map<string, Promise<DiscoveryResult>>();
 
+function positiveInteger(value: unknown): number | undefined {
+  const number = typeof value === "number" ? value : Number(value);
+  return Number.isInteger(number) && number > 0 ? number : undefined;
+}
+
+function endpointModel(value: unknown): ModelsDevModel | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const model = value as Record<string, unknown>;
+  if (typeof model.id !== "string" || !model.id.trim()) return undefined;
+  const id = model.id.trim();
+  const displayName =
+    typeof model.display_name === "string" && model.display_name.trim()
+      ? model.display_name.trim()
+      : undefined;
+  const contextWindow = positiveInteger(model.context_length);
+  const maxTokens = positiveInteger(model.max_output_tokens);
+  const hasInputCapabilities =
+    Object.hasOwn(model, "supports_image_in") || Object.hasOwn(model, "supports_video_in");
+  const input = hasInputCapabilities
+    ? [
+        "text",
+        ...(model.supports_image_in === true ? ["image"] : []),
+        ...(model.supports_video_in === true ? ["video"] : []),
+      ]
+    : undefined;
+  return {
+    id,
+    ...(displayName ? { name: displayName } : {}),
+    ...(contextWindow ? { contextWindow } : {}),
+    ...(maxTokens ? { maxTokens } : {}),
+    ...(Object.hasOwn(model, "supports_reasoning")
+      ? { reasoning: model.supports_reasoning === true }
+      : {}),
+    ...(Object.hasOwn(model, "supports_tool_use")
+      ? { toolCall: model.supports_tool_use !== false }
+      : {}),
+    ...(input ? { input } : {}),
+  };
+}
+
 function normalizeInputTypes(value: unknown): string[] {
   if (Array.isArray(value))
     return value.filter((entry): entry is string => typeof entry === "string");
@@ -161,19 +201,15 @@ async function runProviderDiscovery(
   try {
     const response = await request(`${baseUrl}/models`, {
       headers: {
+        ...(provider.headers || {}),
         ...(auth ? { Authorization: `Bearer ${auth}` } : {}),
-        "User-Agent": "cybara-model-discovery",
       },
       signal: AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
     });
     if (!response.ok) return discoverViaModelsDev(providerId, providerType, discoverCatalog);
-    const data = (await response.json()) as { data?: Array<{ id?: unknown }> };
+    const data = (await response.json()) as { data?: unknown[] };
     const endpointModels = (data.data || [])
-      .flatMap((model) =>
-        typeof model?.id === "string" && model.id.trim()
-          ? [{ id: model.id.trim(), name: model.id.trim() }]
-          : []
-      )
+      .flatMap((model) => endpointModel(model) ?? [])
       .slice(0, MAX_MODELS_PER_PROVIDER);
     if (endpointModels.length === 0) {
       return discoverViaModelsDev(providerId, providerType, discoverCatalog);
@@ -184,7 +220,10 @@ async function runProviderDiscovery(
     const catalogById = new Map(
       catalogModels.map((model) => [model.id.trim().toLowerCase(), model] as const)
     );
-    const found = endpointModels.map((model) => catalogById.get(model.id.toLowerCase()) ?? model);
+    const found = endpointModels.map((model) => ({
+      ...catalogById.get(model.id.toLowerCase()),
+      ...model,
+    }));
     const persisted = persistModels(providerId, found);
     providerManager.setAuthoritativeModels(
       providerId,

--- a/src/core/models-dev.ts
+++ b/src/core/models-dev.ts
@@ -46,6 +46,7 @@ export const PROVIDER_TO_MODELS_DEV: Record<string, string> = {
   cohere: "cohere",
   moonshot: "moonshotai",
   "kimi-code": "moonshotai",
+  "kimi-code-oauth": "moonshotai",
   minimax: "minimax",
   "z.ai": "zai",
   "z.ai-coding": "zai",

--- a/src/core/provider-oauth.ts
+++ b/src/core/provider-oauth.ts
@@ -23,6 +23,7 @@ export interface ProviderOAuthConfig {
   discoveryUrl?: string;
   deviceCodeDiscoveryUrl?: string;
   specialFlow?: "cursor";
+  identityHeaders?: "kimi-code";
 }
 
 export interface OAuthTokenPayload {

--- a/src/core/provider-plans.ts
+++ b/src/core/provider-plans.ts
@@ -160,6 +160,7 @@ const CODING_PLAN_PROVIDER_TYPES = new Set<string>([
   "z.ai-coding",
   "alibaba-coding-plan",
   "kimi-code",
+  "kimi-code-oauth",
   "opencode_zen",
   "opencode-go",
   "kilocode",
@@ -177,6 +178,7 @@ const AUTOMATIC_PLAN_PROVIDER_TYPES = new Set<string>([
   "z.ai",
   "z.ai-coding",
   "kimi-code",
+  "kimi-code-oauth",
   "xai-oauth",
 ]);
 
@@ -265,6 +267,11 @@ const EXTERNAL_PLAN_SOURCE_CATALOG: Record<string, ExternalPlanSourceInfo> = {
     mode: "provider_api",
     label: "Kimi usage source",
     hint: "Use Kimi coding tokens or usage APIs; cookies should remain opt-in.",
+  },
+  "kimi-code-oauth": {
+    mode: "oauth_api",
+    label: "Kimi coding plan usage",
+    hint: "Uses the connected Kimi coding-plan account and refreshable OAuth credentials.",
   },
   opencode_zen: {
     mode: "browser_cookie",

--- a/src/core/provider-usage-source.ts
+++ b/src/core/provider-usage-source.ts
@@ -2,6 +2,7 @@ import { spawn, type ChildProcessWithoutNullStreams } from "child_process";
 import { createHash } from "node:crypto";
 import { createInterface } from "readline";
 import { createLogger } from "./logger";
+import { kimiCodeIdentityHeaders } from "./providers/kimi-code";
 
 const log = createLogger("ProviderUsage");
 
@@ -693,12 +694,20 @@ function kimiWindowKind(
   const unit = String(
     window?.timeUnit ?? window?.time_unit ?? entry.timeUnit ?? entry.time_unit ?? ""
   ).toLowerCase();
+  const durationMinutes =
+    unit.includes("minute") && duration !== undefined
+      ? duration
+      : unit.includes("hour") && duration !== undefined
+        ? duration * 60
+        : unit.includes("day") && duration !== undefined
+          ? duration * 1440
+          : undefined;
   if (label === "all" || label.includes("weekly") || label.includes("week")) return "weekly";
   if (label.includes("monthly") || label.includes("month")) return "monthly";
   if (label.includes("5h") || label.includes("5-hour") || label.includes("5 hour"))
     return "fiveHour";
-  if (duration === 5 && unit.includes("hour")) return "fiveHour";
-  if (duration === 7 && unit.includes("day")) return "weekly";
+  if (durationMinutes === 300) return "fiveHour";
+  if (durationMinutes === 10080) return "weekly";
   if (duration === 1 && unit.includes("month")) return "monthly";
   return undefined;
 }
@@ -737,7 +746,10 @@ export function parseKimiUsageResponse(body: unknown, now: number): LiveProvider
     if (!record) continue;
     const detail = asRecord(record.detail) ?? record;
     const window = asRecord(record.window) ?? {};
-    assignWindow(kimiWindowKind(detail, window), { ...window, ...detail });
+    assignWindow(kimiWindowKind(record, window) ?? kimiWindowKind(detail, window), {
+      ...window,
+      ...detail,
+    });
   }
 
   if (!windows.fiveHour && !windows.weekly && !windows.monthly) return null;
@@ -1245,7 +1257,7 @@ async function fetchKimiUsage(token: string, baseUrl?: string): Promise<LiveProv
       headers: {
         Authorization: `Bearer ${token}`,
         Accept: "application/json",
-        "User-Agent": "KimiCLI/1.6",
+        ...kimiCodeIdentityHeaders(),
       },
       signal: AbortSignal.timeout(10_000),
     });
@@ -1300,7 +1312,10 @@ export async function fetchLiveProviderUsage(
         value = await fetchMiniMaxUsage(credential, provider.baseUrl);
       } else if (provider.providerType === "z.ai" || provider.providerType === "z.ai-coding") {
         value = await fetchZaiUsage(credential, provider.baseUrl);
-      } else if (provider.providerType === "kimi-code") {
+      } else if (
+        provider.providerType === "kimi-code" ||
+        provider.providerType === "kimi-code-oauth"
+      ) {
         value = await fetchKimiUsage(credential, provider.baseUrl);
       } else if (provider.providerType === "xai-oauth") {
         value = looksLikeOAuthToken(provider.accessToken)

--- a/src/core/providers.ts
+++ b/src/core/providers.ts
@@ -5,6 +5,7 @@ import { foundationProviderCatalog } from "./providers/catalog-foundation";
 import { integrationProviderCatalog } from "./providers/catalog-integrations";
 import { accountOAuthProviders } from "./providers/account-oauth";
 import { parseOAuthTokenPayload, type ProviderOAuthConfig } from "./provider-oauth";
+import { isKimiCodeProvider, kimiCodeIdentityHeaders } from "./providers/kimi-code";
 
 export const providers = {
   ...foundationProviderCatalog,
@@ -28,6 +29,8 @@ const PROVIDER_TYPE_ALIASES: Record<string, ProviderType> = {
   "z-ai": "z.ai",
   "zai-coding": "z.ai-coding",
   "kimi-coding": "kimi-code",
+  "kimi-oauth": "kimi-code-oauth",
+  "kimi-code-subscription": "kimi-code-oauth",
   "moonshot-ai": "moonshot",
   moonshotai: "moonshot",
   "minimax-cn": "minimax",
@@ -79,10 +82,13 @@ class ProviderManager {
       (dbProvider.provider === "xai-oauth" && normalizedBaseUrl === "https://api.x.ai/v1")
         ? staticConfig.baseUrl
         : dbProvider.base_url;
+    const staticHeaders = (staticConfig as { headers?: Record<string, string> }).headers;
     return {
       ...dbProvider,
       base_url: baseUrl,
-      headers: (staticConfig as { headers?: Record<string, string> }).headers,
+      headers: isKimiCodeProvider(dbProvider.provider)
+        ? { ...staticHeaders, ...kimiCodeIdentityHeaders() }
+        : staticHeaders,
     };
   }
 
@@ -214,13 +220,14 @@ class ProviderManager {
             "Content-Type": json ? "application/json" : "application/x-www-form-urlencoded",
             ...(cursor ? { Authorization: `Bearer ${provider.refresh_token}` } : {}),
             ...oauth.refreshHeaders,
+            ...(oauth.identityHeaders === "kimi-code" ? kimiCodeIdentityHeaders() : {}),
           },
           body: json ? JSON.stringify(cursor ? {} : fields) : new URLSearchParams(fields),
           signal: AbortSignal.timeout(30_000),
         });
       let response = await request();
       if (
-        provider.provider === "xai-oauth" &&
+        (provider.provider === "xai-oauth" || provider.provider === "kimi-code-oauth") &&
         (response.status === 429 || response.status >= 500)
       ) {
         const retryAfter = Number(response.headers.get("retry-after"));
@@ -408,12 +415,20 @@ class ProviderManager {
       const key = model.id.toLowerCase();
       const existing = cachedByModelId.get(key);
       if (existing) {
+        const genericFallback =
+          (existing.model_name || "").trim().toLowerCase() ===
+            existing.model_id.trim().toLowerCase() &&
+          existing.context_window === 128000 &&
+          existing.max_tokens === 8192;
         merged.push({
           ...existing,
-          model_name: existing.model_name || model.name,
-          context_window: existing.context_window ?? model.context,
-          max_tokens: existing.max_tokens ?? model.maxTokens,
-          reasoning: existing.reasoning ?? model.reasoning,
+          model_name: genericFallback ? model.name : existing.model_name || model.name,
+          context_window: genericFallback
+            ? model.context
+            : (existing.context_window ?? model.context),
+          max_tokens: genericFallback ? model.maxTokens : (existing.max_tokens ?? model.maxTokens),
+          reasoning: genericFallback ? model.reasoning : (existing.reasoning ?? model.reasoning),
+          input_types: genericFallback ? [...model.input] : existing.input_types,
         });
         seen.add(key);
         continue;
@@ -581,8 +596,11 @@ export function getDefaultModel(providerType: string): string {
     opencode_zen: "claude-opus-4-8",
     opencode: "claude-opus-4-8",
     moonshot: "kimi-k2.6",
-    "kimi-code": "kimi-for-coding",
-    "kimi-coding": "kimi-for-coding",
+    "kimi-code": "k3",
+    "kimi-coding": "k3",
+    "kimi-code-oauth": "k3",
+    "kimi-oauth": "k3",
+    "kimi-code-subscription": "k3",
     "qwen-portal": "qwen3.5-plus",
     synthetic: "hf:zai-org/GLM-5",
     "openai-codex": "gpt-5.6-sol",

--- a/src/core/providers/account-oauth.ts
+++ b/src/core/providers/account-oauth.ts
@@ -1,4 +1,11 @@
 import { foundationProviderCatalog } from "./catalog-foundation";
+import {
+  KIMI_CODE_BASE_URL,
+  KIMI_CODE_DEVICE_CODE_URL,
+  KIMI_CODE_OAUTH_CLIENT_ID,
+  KIMI_CODE_TOKEN_URL,
+  kimiCodeModels,
+} from "./kimi-code";
 
 type SubscriptionInput = "text" | "image";
 type SubscriptionModelTuple = readonly [
@@ -214,5 +221,20 @@ export const accountOAuthProviders = {
       refreshMode: "standard" as const,
     },
     models: gitlabDuoModels,
+  },
+  "kimi-code-oauth": {
+    name: "Kimi Code Subscription",
+    baseUrl: KIMI_CODE_BASE_URL,
+    api: "openai-completions",
+    authType: "oauth",
+    oauthFlow: "device_code" as const,
+    oauthConfig: {
+      clientId: KIMI_CODE_OAUTH_CLIENT_ID,
+      deviceCodeUrl: KIMI_CODE_DEVICE_CODE_URL,
+      tokenUrl: KIMI_CODE_TOKEN_URL,
+      refreshMode: "standard" as const,
+      identityHeaders: "kimi-code" as const,
+    },
+    models: kimiCodeModels,
   },
 } as const;

--- a/src/core/providers/catalog-foundation.ts
+++ b/src/core/providers/catalog-foundation.ts
@@ -1,4 +1,5 @@
 import { MINIMAX_OAUTH_CLIENT_ID, MINIMAX_OAUTH_SCOPE } from "./minimax-oauth";
+import { KIMI_CODE_BASE_URL, kimiCodeModels } from "./kimi-code";
 
 const miniMaxPortalModels = [
   {
@@ -811,20 +812,10 @@ export const foundationProviderCatalog = {
   },
   "kimi-code": {
     name: "Kimi Code",
-    baseUrl: "https://api.kimi.com/coding/v1",
+    baseUrl: KIMI_CODE_BASE_URL,
     api: "openai-completions",
     authType: "api_key",
-    headers: { "User-Agent": "KimiCLI/0.77" },
-    models: [
-      {
-        id: "kimi-for-coding",
-        name: "Kimi For Coding",
-        context: 262144,
-        maxTokens: 32768,
-        reasoning: true,
-        input: ["text"],
-      },
-    ],
+    models: kimiCodeModels,
   },
   "qwen-portal": {
     name: "Qwen Portal",

--- a/src/core/providers/kimi-code.ts
+++ b/src/core/providers/kimi-code.ts
@@ -1,0 +1,104 @@
+import { randomUUID } from "crypto";
+import { chmodSync, existsSync, readFileSync, writeFileSync } from "fs";
+import { arch, hostname, release, type } from "os";
+import { join } from "path";
+import { getAppVersion } from "../build-info";
+import { secureDir } from "../paths";
+
+export const KIMI_CODE_BASE_URL = "https://api.kimi.com/coding/v1";
+export const KIMI_CODE_OAUTH_CLIENT_ID = "17e5f671-d194-4dfb-9706-5516cb48c098";
+export const KIMI_CODE_DEVICE_CODE_URL = "https://auth.kimi.com/api/oauth/device_authorization";
+export const KIMI_CODE_TOKEN_URL = "https://auth.kimi.com/api/oauth/token";
+
+export const kimiCodeModels = [
+  {
+    id: "k3",
+    name: "Kimi K3",
+    context: 1_048_576,
+    maxTokens: 32_768,
+    reasoning: true,
+    input: ["text"] as const,
+  },
+  {
+    id: "kimi-for-coding",
+    name: "Kimi K2.7 Code",
+    context: 262_144,
+    maxTokens: 32_768,
+    reasoning: true,
+    input: ["text", "image"] as const,
+  },
+  {
+    id: "kimi-for-coding-highspeed",
+    name: "Kimi K2.7 Code High Speed",
+    context: 262_144,
+    maxTokens: 32_768,
+    reasoning: true,
+    input: ["text", "image"] as const,
+  },
+] as const;
+
+const deviceIdPath = join(secureDir, "kimi-code-device-id");
+let inMemoryDeviceId: string | undefined;
+
+function asciiHeader(value: string, fallback: string): string {
+  const cleaned = Array.from(value)
+    .filter((character) => {
+      const code = character.charCodeAt(0);
+      return code >= 32 && code <= 126;
+    })
+    .join("")
+    .trim();
+  return cleaned || fallback;
+}
+
+function readDeviceId(): string | undefined {
+  if (inMemoryDeviceId) return inMemoryDeviceId;
+  try {
+    const value = readFileSync(deviceIdPath, "utf8").trim();
+    if (value) {
+      inMemoryDeviceId = value;
+      return value;
+    }
+  } catch {}
+  return undefined;
+}
+
+function createDeviceId(): string {
+  const existing = readDeviceId();
+  if (existing) return existing;
+  const created = randomUUID();
+  if (process.env.NODE_ENV === "test") {
+    inMemoryDeviceId = created;
+    return created;
+  }
+  try {
+    writeFileSync(deviceIdPath, created, { mode: 0o600, flag: "wx" });
+    chmodSync(deviceIdPath, 0o600);
+    inMemoryDeviceId = created;
+    return created;
+  } catch {
+    if (existsSync(deviceIdPath)) {
+      const raced = readDeviceId();
+      if (raced) return raced;
+    }
+    inMemoryDeviceId = created;
+    return created;
+  }
+}
+
+export function kimiCodeIdentityHeaders(): Record<string, string> {
+  const version = asciiHeader(getAppVersion(), "unknown");
+  return {
+    "User-Agent": `Cybara/${version}`,
+    "X-Msh-Platform": "kimi_code_cli",
+    "X-Msh-Version": version,
+    "X-Msh-Device-Name": asciiHeader(hostname(), "unknown"),
+    "X-Msh-Device-Model": asciiHeader(`${type()} ${release()} ${arch()}`, "unknown"),
+    "X-Msh-Os-Version": asciiHeader(release(), "unknown"),
+    "X-Msh-Device-Id": createDeviceId(),
+  };
+}
+
+export function isKimiCodeProvider(providerType: string): boolean {
+  return providerType === "kimi-code" || providerType === "kimi-code-oauth";
+}

--- a/src/core/session-context.ts
+++ b/src/core/session-context.ts
@@ -533,12 +533,25 @@ export function getContextWindow(model?: string): number {
 
   try {
     const dbModel = tables.providerModels.getByModelId(model);
-    if (dbModel?.context_window && dbModel.context_window > 0) {
+    const dbModelIsGenericFallback =
+      dbModel?.model_name?.trim().toLowerCase() === dbModel?.model_id?.trim().toLowerCase() &&
+      dbModel?.context_window === 128000 &&
+      dbModel?.max_tokens === 8192;
+    if (dbModel?.context_window && dbModel.context_window > 0 && !dbModelIsGenericFallback) {
       return dbModel.context_window;
     }
     if (model !== modelLower) {
       const dbModelLower = tables.providerModels.getByModelId(modelLower);
-      if (dbModelLower?.context_window && dbModelLower.context_window > 0) {
+      const dbModelLowerIsGenericFallback =
+        dbModelLower?.model_name?.trim().toLowerCase() ===
+          dbModelLower?.model_id?.trim().toLowerCase() &&
+        dbModelLower?.context_window === 128000 &&
+        dbModelLower?.max_tokens === 8192;
+      if (
+        dbModelLower?.context_window &&
+        dbModelLower.context_window > 0 &&
+        !dbModelLowerIsGenericFallback
+      ) {
         return dbModelLower.context_window;
       }
     }
@@ -564,6 +577,8 @@ export function getContextWindow(model?: string): number {
     { pattern: "gpt-4", tokens: 128_000 },
     { pattern: "o1", tokens: 200_000 },
     { pattern: "o3", tokens: 200_000 },
+    { pattern: "kimi-code-oauth/k3", tokens: 1_048_576 },
+    { pattern: "kimi-code/k3", tokens: 1_048_576 },
     { pattern: "kimi-for-coding", tokens: 262_144 },
     { pattern: "kimi-code", tokens: 262_144 },
     { pattern: "kimi", tokens: 256_000 },

--- a/tests/api/provider-oauth-kimi.test.ts
+++ b/tests/api/provider-oauth-kimi.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  pollProviderDeviceCodeOAuth,
+  startProviderDeviceCodeOAuth,
+} from "../../src/api/provider-oauth-device";
+
+const originalFetch = globalThis.fetch;
+
+describe("Kimi coding-plan OAuth", () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("uses the official device form, token form, and identity headers", async () => {
+    const requests: Array<{ url: string; body: URLSearchParams; headers: Headers }> = [];
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      requests.push({
+        url: String(input),
+        body: new URLSearchParams(String(init?.body || "")),
+        headers: new Headers(init?.headers),
+      });
+      if (String(input).endsWith("device_authorization")) {
+        return Response.json({
+          device_code: "kimi-device-code",
+          user_code: "KIMI-CODE",
+          verification_uri: "https://www.kimi.com/code/device",
+          verification_uri_complete: "https://www.kimi.com/code/device?user_code=KIMI-CODE",
+          expires_in: 600,
+          interval: 5,
+        });
+      }
+      return Response.json({
+        access_token: "kimi-access-token",
+        refresh_token: "kimi-refresh-token",
+        expires_in: 3600,
+      });
+    }) as typeof fetch;
+
+    const start = await startProviderDeviceCodeOAuth({ providerType: "kimi-code-oauth" });
+    const poll = await pollProviderDeviceCodeOAuth({
+      providerType: "kimi-code-oauth",
+      deviceCode: "kimi-device-code",
+    });
+
+    expect(start).toMatchObject({
+      user_code: "KIMI-CODE",
+      verification_uri_complete: "https://www.kimi.com/code/device?user_code=KIMI-CODE",
+    });
+    expect(poll).toMatchObject({
+      status: "success",
+      access_token: "kimi-access-token",
+      refresh_token: "kimi-refresh-token",
+    });
+    expect(requests.map((request) => request.url)).toEqual([
+      "https://auth.kimi.com/api/oauth/device_authorization",
+      "https://auth.kimi.com/api/oauth/token",
+    ]);
+    expect(requests[0]?.body.get("client_id")).toBe("17e5f671-d194-4dfb-9706-5516cb48c098");
+    expect(requests[0]?.body.has("scope")).toBe(false);
+    expect(requests[1]?.body.get("grant_type")).toBe(
+      "urn:ietf:params:oauth:grant-type:device_code"
+    );
+    expect(requests[0]?.headers.get("User-Agent")).toMatch(/^Cybara\//);
+    expect(requests[0]?.headers.get("X-Msh-Platform")).toBe("kimi_code_cli");
+    expect(requests[0]?.headers.get("X-Msh-Device-Id")).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  test("rejects untrusted verification URLs", async () => {
+    globalThis.fetch = (async () =>
+      Response.json({
+        device_code: "kimi-device-code",
+        user_code: "KIMI-CODE",
+        verification_uri: "https://attacker.example/verify",
+        verification_uri_complete: "https://attacker.example/verify?user_code=KIMI-CODE",
+        expires_in: 600,
+        interval: 5,
+      })) as typeof fetch;
+
+    expect(startProviderDeviceCodeOAuth({ providerType: "kimi-code-oauth" })).rejects.toThrow(
+      "Kimi OAuth returned an untrusted complete device verification URI"
+    );
+  });
+
+  test("requires a refresh token", async () => {
+    globalThis.fetch = (async () =>
+      Response.json({ access_token: "kimi-access-token", expires_in: 3600 })) as typeof fetch;
+
+    const response = await pollProviderDeviceCodeOAuth({
+      providerType: "kimi-code-oauth",
+      deviceCode: "kimi-device-code",
+    });
+
+    expect(response).toEqual({
+      status: "error",
+      error:
+        "Kimi OAuth did not return a refresh token. Re-run login and authorize the coding-plan account again.",
+    });
+  });
+});

--- a/tests/core/agent-helper-modules.test.ts
+++ b/tests/core/agent-helper-modules.test.ts
@@ -40,4 +40,12 @@ describe("agent helper modules", () => {
     expect(resolveModelMaxOutputTokens("openai", undefined, "gpt-5.6-luna")).toBe(128000);
     expect(resolveModelMaxOutputTokens("openai-codex", undefined, "gpt-5.6-luna")).toBe(128000);
   });
+
+  test("resolves Kimi coding-plan context limits from the model catalog", () => {
+    expect(resolveModelContextWindowTokens("kimi-code-oauth", undefined, "k3")).toBe(1_048_576);
+    expect(resolveModelMaxOutputTokens("kimi-code-oauth", undefined, "k3")).toBe(32_768);
+    expect(resolveModelContextWindowTokens("kimi-code-oauth", undefined, "kimi-for-coding")).toBe(
+      262_144
+    );
+  });
 });

--- a/tests/core/agent-provider-compatible-routing.test.ts
+++ b/tests/core/agent-provider-compatible-routing.test.ts
@@ -186,7 +186,9 @@ describe("Agent provider Google and compatible routing", () => {
 
     expect(result.content).toBe("kimi-ok");
     expect(requestHeaders.get("Authorization")).toBe("Bearer kimi-test-key");
-    expect(requestHeaders.get("User-Agent")).toBe("KimiCLI/0.77");
+    expect(requestHeaders.get("User-Agent")).toMatch(/^Cybara\//);
+    expect(requestHeaders.get("X-Msh-Platform")).toBe("kimi_code_cli");
+    expect(requestHeaders.get("X-Msh-Device-Id")).toMatch(/^[0-9a-f-]{36}$/);
   });
 
   test("routes openai-codex-responses providers to codex responses endpoint", async () => {

--- a/tests/core/model-discovery.test.ts
+++ b/tests/core/model-discovery.test.ts
@@ -122,4 +122,46 @@ describe("provider model discovery", () => {
     ]);
     expect(providerManager.getModels(provider.id)[0]?.context_window).toBe(372000);
   });
+
+  test("persists Kimi coding-plan model capabilities from the authenticated endpoint", async () => {
+    const provider = providerManager.create({
+      provider: "kimi-code-oauth",
+      name: "Kimi Code Discovery Test",
+      access_token: "kimi-oauth-token",
+    });
+    createdProviderIds.push(provider.id);
+    let headers = new Headers();
+
+    const result = await discoverProviderModels(provider.id, {
+      request: async (_input, init) => {
+        headers = new Headers(init?.headers);
+        return Response.json({
+          data: [
+            {
+              id: "k3",
+              display_name: "Kimi K3",
+              context_length: 1_048_576,
+              supports_reasoning: true,
+              supports_image_in: true,
+              supports_video_in: false,
+              supports_tool_use: true,
+              think_efforts: { support: true, valid_efforts: ["max"], default_effort: "max" },
+            },
+          ],
+        });
+      },
+      discoverCatalog: async () => [],
+    });
+
+    expect(result.source).toBe("endpoint");
+    expect(headers.get("Authorization")).toBe("Bearer kimi-oauth-token");
+    expect(headers.get("User-Agent")).toMatch(/^Cybara\//);
+    expect(headers.get("X-Msh-Platform")).toBe("kimi_code_cli");
+    const discovered = providerManager.getModels(provider.id)[0];
+    expect(discovered?.model_id).toBe("k3");
+    expect(discovered?.model_name).toBe("Kimi K3");
+    expect(discovered?.context_window).toBe(1_048_576);
+    expect(Boolean(discovered?.reasoning)).toBe(true);
+    expect(discovered?.input_types).toBe('["text","image"]');
+  });
 });

--- a/tests/core/model-discovery.test.ts
+++ b/tests/core/model-discovery.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { resolveModelMaxOutputTokens } from "../../src/core/agent-model-limits";
 import { discoverProviderModels } from "../../src/core/model-discovery";
 import { providerManager } from "../../src/core/providers";
 
@@ -161,7 +162,9 @@ describe("provider model discovery", () => {
     expect(discovered?.model_id).toBe("k3");
     expect(discovered?.model_name).toBe("Kimi K3");
     expect(discovered?.context_window).toBe(1_048_576);
+    expect(discovered?.max_tokens).toBe(32_768);
     expect(Boolean(discovered?.reasoning)).toBe(true);
     expect(discovered?.input_types).toBe('["text","image"]');
+    expect(resolveModelMaxOutputTokens("kimi-code-oauth", provider.id, "k3")).toBe(32_768);
   });
 });

--- a/tests/core/oauth-token-refresh.test.ts
+++ b/tests/core/oauth-token-refresh.test.ts
@@ -302,4 +302,41 @@ describe("OAuth token refresh (openai-codex)", () => {
     expect(refreshed?.access_token).toBe("fresh-minimax-token");
     expect(refreshed?.refresh_token).toBe("fresh-minimax-refresh");
   });
+
+  test("refreshes Kimi coding-plan tokens with stable device identity", async () => {
+    const provider = providerManager.create({
+      provider: "kimi-code-oauth",
+      name: "Kimi Code OAuth Test",
+      access_token: "stale-kimi-token",
+      refresh_token: "kimi-refresh",
+      expires_at: Date.now() - 1000,
+    });
+    createdProviderIds.push(provider.id);
+    let request: RequestInit | undefined;
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      expect(String(input)).toBe("https://auth.kimi.com/api/oauth/token");
+      request = init;
+      return Response.json({
+        access_token: "fresh-kimi-token",
+        refresh_token: "fresh-kimi-refresh",
+        expires_in: 3600,
+      });
+    }) as typeof fetch;
+
+    const refreshed = await providerManager.refreshOAuthCredentialsIfNeeded(
+      providerManager.getWithCredentials(provider.id)
+    );
+    const body = new URLSearchParams(String(request?.body || ""));
+    const headers = new Headers(request?.headers);
+
+    expect(body.get("grant_type")).toBe("refresh_token");
+    expect(body.get("refresh_token")).toBe("kimi-refresh");
+    expect(body.get("client_id")).toBe("17e5f671-d194-4dfb-9706-5516cb48c098");
+    expect(body.has("scope")).toBe(false);
+    expect(headers.get("User-Agent")).toMatch(/^Cybara\//);
+    expect(headers.get("X-Msh-Platform")).toBe("kimi_code_cli");
+    expect(headers.get("X-Msh-Device-Id")).toMatch(/^[0-9a-f-]{36}$/);
+    expect(refreshed?.access_token).toBe("fresh-kimi-token");
+    expect(refreshed?.refresh_token).toBe("fresh-kimi-refresh");
+  });
 });

--- a/tests/core/provider-usage-source.test.ts
+++ b/tests/core/provider-usage-source.test.ts
@@ -327,6 +327,24 @@ describe("parseKimiUsageResponse", () => {
     expect(result?.fiveHour?.usedPercent).toBe(20);
     expect(parseKimiUsageResponse({ data: [{ name: "unknown" }] }, 1)).toBeNull();
   });
+
+  test("maps current minute-based Kimi coding-plan limit windows", () => {
+    const result = parseKimiUsageResponse(
+      {
+        usage: { used: 120, limit: 1000 },
+        limits: [
+          {
+            detail: { used: 22, limit: 100 },
+            window: { duration: 300, timeUnit: "MINUTE" },
+          },
+        ],
+      },
+      902
+    );
+
+    expect(result?.weekly?.usedPercent).toBe(12);
+    expect(result?.fiveHour?.usedPercent).toBe(22);
+  });
 });
 
 describe("parseGrokUsageResponse", () => {

--- a/tests/core/providers-defaults.test.ts
+++ b/tests/core/providers-defaults.test.ts
@@ -39,7 +39,8 @@ describe("Provider model defaults and API-family parity", () => {
     expect(getDefaultModel("longcat")).toBe("LongCat-2.0");
     expect(getDefaultModel("github_copilot")).toBe("gpt-5.5");
     expect(getDefaultModel("github-copilot")).toBe("gpt-5.5");
-    expect(getDefaultModel("kimi-coding")).toBe("kimi-for-coding");
+    expect(getDefaultModel("kimi-coding")).toBe("k3");
+    expect(getDefaultModel("kimi-code-oauth")).toBe("k3");
     expect(getDefaultModel("qianfan")).toBe("deepseek-v3.2");
     expect(getDefaultModel("xai")).toBe("grok-4.3");
     expect(getDefaultModel("xai-oauth")).toBe("grok-build");
@@ -65,6 +66,7 @@ describe("Provider model defaults and API-family parity", () => {
     expect(resolveProviderType("opencode")).toBe("opencode_zen");
     expect(resolveProviderType("zai")).toBe("z.ai");
     expect(resolveProviderType("kimi-coding")).toBe("kimi-code");
+    expect(resolveProviderType("kimi-oauth")).toBe("kimi-code-oauth");
     expect(resolveProviderType("grok-oauth")).toBe("xai-oauth");
     expect(resolveProviderType("grok-build")).toBe("xai-oauth");
     expect(resolveProviderType("bailian-token-plan")).toBe("qwen-token-plan");
@@ -149,6 +151,16 @@ describe("Provider model defaults and API-family parity", () => {
     expect(providers.devin.oauthFlow).toBeUndefined();
     expect(providers.devin.models.length).toBe(59);
     expect(providers["gitlab-duo"].models.length).toBe(10);
+    expect(providers["kimi-code-oauth"].oauthFlow).toBe("device_code");
+    expect(providers["kimi-code-oauth"].oauthConfig.clientId).toBe(
+      "17e5f671-d194-4dfb-9706-5516cb48c098"
+    );
+    expect(providers["kimi-code-oauth"].models.map((model) => model.id)).toEqual([
+      "k3",
+      "kimi-for-coding",
+      "kimi-for-coding-highspeed",
+    ]);
+    expect(providers["kimi-code-oauth"].models[0]?.context).toBe(1_048_576);
     expect(providers.meta.models.some((model) => model.id === "muse-spark-1.1")).toBe(true);
     expect(providers.ds4.models.some((model) => model.id === "deepseek-v4-flash")).toBe(true);
     expect(providers.inferrs.models.some((model) => model.id === "google/gemma-4-E2B-it")).toBe(
@@ -449,6 +461,36 @@ describe("Provider model defaults and API-family parity", () => {
     const modelIds = providerManager.getModels(providerId).map((model) => model.model_id);
     expect(modelIds).toContain("gemini-3.1-pro-preview");
     expect(modelIds).toContain("gemini-3-pro-preview");
+
+    db.query("DELETE FROM provider_models WHERE provider_id = ?").run(providerId);
+    tables.providers.delete(providerId);
+  });
+
+  test("replaces generic cached K3 metadata with the current catalog limits", () => {
+    const providerId = `kimi-cache-${crypto.randomUUID()}`;
+    tables.providers.create({
+      id: providerId,
+      provider: "kimi-code-oauth",
+      name: "Kimi Cache Test",
+      base_url: providers["kimi-code-oauth"].baseUrl,
+      is_default: false,
+    });
+    tables.providerModels.upsert({
+      id: `${providerId}-fallback`,
+      provider_id: providerId,
+      model_id: "k3",
+      model_name: "k3",
+      context_window: 128000,
+      max_tokens: 8192,
+      reasoning: false,
+      input_types: ["text"],
+    });
+
+    const model = providerManager.getModels(providerId).find((entry) => entry.model_id === "k3");
+    expect(model?.model_name).toBe("Kimi K3");
+    expect(model?.context_window).toBe(1_048_576);
+    expect(model?.max_tokens).toBe(32_768);
+    expect(Boolean(model?.reasoning)).toBe(true);
 
     db.query("DELETE FROM provider_models WHERE provider_id = ?").run(providerId);
     tables.providers.delete(providerId);

--- a/tests/core/reasoning-levels.test.ts
+++ b/tests/core/reasoning-levels.test.ts
@@ -112,6 +112,12 @@ describe("reasoning level support matrix", () => {
     expect(supportedReasoningEfforts("minimax-portal", "minimax-m3")).toEqual([]);
   });
 
+  test("Kimi K3 uses the current max-only reasoning contract", () => {
+    expect(supportedReasoningEfforts("kimi-code", "k3")).toEqual(["max"]);
+    expect(supportedReasoningEfforts("kimi-code-oauth", "k3")).toEqual(["max"]);
+    expect(coerceReasoningEffort("high", "kimi-code-oauth", "k3")).toBe("max");
+  });
+
   test("unknown openai model gets low/medium/high", () => {
     expect(supportedReasoningEfforts("openai", "o3-pro")).toEqual(["low", "medium", "high"]);
   });

--- a/tests/core/reasoning.test.ts
+++ b/tests/core/reasoning.test.ts
@@ -30,6 +30,9 @@ describe("openAICompatReasoningParams (per-provider shapes)", () => {
   test("default OpenAI-style reasoning_effort", () => {
     expect(openAICompatReasoningParams("openai", "high")).toEqual({ reasoning_effort: "high" });
     expect(openAICompatReasoningParams("xai", "low")).toEqual({ reasoning_effort: "low" });
+    expect(openAICompatReasoningParams("kimi-code-oauth", "max", "k3")).toEqual({
+      reasoning_effort: "max",
+    });
   });
 
   test("MiniMax M3 omits explicit reasoning effort", () => {

--- a/tests/core/session-context-model-window.test.ts
+++ b/tests/core/session-context-model-window.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import db, { tables } from "../../src/core/database";
+import { getContextWindow } from "../../src/core/session-context";
+
+describe("session context model window", () => {
+  test("ignores stale generic discovery limits for Kimi K3", () => {
+    const providerId = `kimi-context-${crypto.randomUUID()}`;
+    tables.providers.create({
+      id: providerId,
+      provider: "kimi-code-oauth",
+      name: "Kimi Context Test",
+      base_url: "https://api.kimi.com/coding/v1",
+      is_default: false,
+    });
+    tables.providerModels.upsert({
+      id: `${providerId}-fallback`,
+      provider_id: providerId,
+      model_id: "k3",
+      model_name: "k3",
+      context_window: 128000,
+      max_tokens: 8192,
+      reasoning: false,
+      input_types: ["text"],
+    });
+
+    expect(getContextWindow("k3")).toBe(1_048_576);
+
+    db.query("DELETE FROM provider_models WHERE provider_id = ?").run(providerId);
+    tables.providers.delete(providerId);
+  });
+});

--- a/tests/runtime/app-release-surfaces.test.ts
+++ b/tests/runtime/app-release-surfaces.test.ts
@@ -185,7 +185,7 @@ describe("app release surface wiring", () => {
     );
   });
 
-  test("CLI release binaries bundle the Transformers runtime", () => {
+  test("CLI release binaries keep architecture-specific ML runtimes optional", () => {
     const workflow = read(".github/workflows/release.yml");
     const compileCommand = workflow
       .split("\n")
@@ -193,21 +193,21 @@ describe("app release surface wiring", () => {
 
     expect(compileCommand).toContain("--external electron");
     expect(compileCommand).toContain("--external @aws-sdk/client-s3");
-    expect(compileCommand).not.toContain("--external @huggingface/transformers");
-    expect(compileCommand).not.toContain("--external onnxruntime-node");
-    expect(compileCommand).not.toContain("--external onnxruntime-web");
+    expect(compileCommand).toContain("--external @huggingface/transformers");
+    expect(compileCommand).toContain("--external kokoro-js");
+    expect(compileCommand).toContain("--external onnxruntime-node");
+    expect(compileCommand).toContain("--external onnxruntime-web");
   });
 
-  test("Darwin x64 CLI builds and starts on a macOS runner", () => {
+  test("Darwin x64 release artifact is smoke-tested on a macOS runner", () => {
     const workflow = read(".github/workflows/release.yml");
 
-    expect(workflow).toContain("runs-on: ${{ matrix.runner }}");
-    expect(workflow).toMatch(/target: darwin-x64\s+artifact: cybara-darwin-x64\s+runner: macos-26/);
-    expect(workflow).toContain("name: Smoke-test Darwin x64 CLI");
-    expect(workflow).toContain("if: matrix.target == 'darwin-x64'");
-    expect(workflow).toContain("./${{ matrix.artifact }} start -d");
-    expect(workflow).toContain("./${{ matrix.artifact }} status");
-    expect(workflow).toContain("./${{ matrix.artifact }} stop");
+    expect(workflow).toContain("smoke-cli-darwin-x64:");
+    expect(workflow).toContain("name: cybara-darwin-x64");
+    expect(workflow).toContain("./cybara-darwin-x64 start -d");
+    expect(workflow).toContain("./cybara-darwin-x64 status");
+    expect(workflow).toContain("./cybara-darwin-x64 stop");
+    expect(workflow).toContain("needs: [build-cli, smoke-cli-darwin-x64, build-mobile]");
   });
 
   test("release workflow runs native macOS unit tests when XCTest is available", () => {

--- a/tests/runtime/app-release-surfaces.test.ts
+++ b/tests/runtime/app-release-surfaces.test.ts
@@ -185,18 +185,12 @@ describe("app release surface wiring", () => {
     );
   });
 
-  test("CLI release binaries keep architecture-specific ML runtimes optional", () => {
+  test("CLI release binaries use the shared standalone build", () => {
     const workflow = read(".github/workflows/release.yml");
-    const compileCommand = workflow
-      .split("\n")
-      .find((line) => line.includes("bun build src/main.ts --compile"));
 
-    expect(compileCommand).toContain("--external electron");
-    expect(compileCommand).toContain("--external @aws-sdk/client-s3");
-    expect(compileCommand).toContain("--external @huggingface/transformers");
-    expect(compileCommand).toContain("--external kokoro-js");
-    expect(compileCommand).toContain("--external onnxruntime-node");
-    expect(compileCommand).toContain("--external onnxruntime-web");
+    expect(workflow).toContain(
+      "bun run scripts/build-standalone-cli.ts bun-${{ matrix.target }} ${{ matrix.artifact }}"
+    );
   });
 
   test("Darwin x64 release artifact is smoke-tested on a macOS runner", () => {
@@ -208,6 +202,21 @@ describe("app release surface wiring", () => {
     expect(workflow).toContain("./cybara-darwin-x64 status");
     expect(workflow).toContain("./cybara-darwin-x64 stop");
     expect(workflow).toContain("needs: [build-cli, smoke-cli-darwin-x64, build-mobile]");
+  });
+
+  test("dev CI cross-compiles and smoke-tests the Darwin x64 CLI artifact", () => {
+    const workflow = read(".github/workflows/ci.yml");
+
+    expect(workflow).toContain("darwin-x64-cli-build:");
+    expect(workflow).toContain(
+      "bun run scripts/build-standalone-cli.ts bun-darwin-x64 cybara-darwin-x64"
+    );
+    expect(workflow).toContain("name: ci-cybara-darwin-x64");
+    expect(workflow).toContain("darwin-x64-cli-smoke:");
+    expect(workflow).toContain("arch -x86_64 /usr/bin/true");
+    expect(workflow).toContain("./cybara-darwin-x64 start -d");
+    expect(workflow).toContain("./cybara-darwin-x64 status");
+    expect(workflow).toContain("./cybara-darwin-x64 stop");
   });
 
   test("release workflow runs native macOS unit tests when XCTest is available", () => {

--- a/tests/runtime/app-release-surfaces.test.ts
+++ b/tests/runtime/app-release-surfaces.test.ts
@@ -198,6 +198,18 @@ describe("app release surface wiring", () => {
     expect(compileCommand).not.toContain("--external onnxruntime-web");
   });
 
+  test("Darwin x64 CLI builds and starts on a macOS runner", () => {
+    const workflow = read(".github/workflows/release.yml");
+
+    expect(workflow).toContain("runs-on: ${{ matrix.runner }}");
+    expect(workflow).toMatch(/target: darwin-x64\s+artifact: cybara-darwin-x64\s+runner: macos-26/);
+    expect(workflow).toContain("name: Smoke-test Darwin x64 CLI");
+    expect(workflow).toContain("if: matrix.target == 'darwin-x64'");
+    expect(workflow).toContain("./${{ matrix.artifact }} start -d");
+    expect(workflow).toContain("./${{ matrix.artifact }} status");
+    expect(workflow).toContain("./${{ matrix.artifact }} stop");
+  });
+
   test("release workflow runs native macOS unit tests when XCTest is available", () => {
     const workflow = read(".github/workflows/release.yml");
 

--- a/tests/runtime/app-release-surfaces.test.ts
+++ b/tests/runtime/app-release-surfaces.test.ts
@@ -198,9 +198,7 @@ describe("app release surface wiring", () => {
 
     expect(workflow).toContain("smoke-cli-darwin-x64:");
     expect(workflow).toContain("name: cybara-darwin-x64");
-    expect(workflow).toContain("./cybara-darwin-x64 start -d");
-    expect(workflow).toContain("./cybara-darwin-x64 status");
-    expect(workflow).toContain("./cybara-darwin-x64 stop");
+    expect(workflow).toContain("bash scripts/smoke-standalone-cli.sh ./cybara-darwin-x64");
     expect(workflow).toContain("needs: [build-cli, smoke-cli-darwin-x64, build-mobile]");
   });
 
@@ -214,9 +212,7 @@ describe("app release surface wiring", () => {
     expect(workflow).toContain("name: ci-cybara-darwin-x64");
     expect(workflow).toContain("darwin-x64-cli-smoke:");
     expect(workflow).toContain("arch -x86_64 /usr/bin/true");
-    expect(workflow).toContain("./cybara-darwin-x64 start -d");
-    expect(workflow).toContain("./cybara-darwin-x64 status");
-    expect(workflow).toContain("./cybara-darwin-x64 stop");
+    expect(workflow).toContain("bash scripts/smoke-standalone-cli.sh ./cybara-darwin-x64");
   });
 
   test("release workflow runs native macOS unit tests when XCTest is available", () => {

--- a/tests/runtime/compiled-cli-startup.test.ts
+++ b/tests/runtime/compiled-cli-startup.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { standaloneCliBuildArgs } from "../../scripts/build-standalone-cli";
 
 function currentBunTarget(): string {
   const platform = process.platform === "win32" ? "windows" : process.platform;
@@ -16,29 +17,9 @@ describe("compiled CLI startup", () => {
     mkdirSync(home, { recursive: true });
 
     try {
-      const build = Bun.spawnSync(
-        [
-          process.execPath,
-          "build",
-          join(process.cwd(), "src", "main.ts"),
-          "--compile",
-          `--target=${currentBunTarget()}`,
-          `--outfile=${binary}`,
-          "--external",
-          "electron",
-          "--external",
-          "@aws-sdk/client-s3",
-          "--external",
-          "@huggingface/transformers",
-          "--external",
-          "kokoro-js",
-          "--external",
-          "onnxruntime-node",
-          "--external",
-          "onnxruntime-web",
-        ],
-        { cwd: process.cwd() }
-      );
+      const build = Bun.spawnSync(standaloneCliBuildArgs(currentBunTarget(), binary), {
+        cwd: process.cwd(),
+      });
       expect(build.exitCode).toBe(0);
 
       const environment = { ...process.env, HOME: home, USERPROFILE: home };

--- a/tests/runtime/compiled-cli-startup.test.ts
+++ b/tests/runtime/compiled-cli-startup.test.ts
@@ -28,6 +28,14 @@ describe("compiled CLI startup", () => {
           "electron",
           "--external",
           "@aws-sdk/client-s3",
+          "--external",
+          "@huggingface/transformers",
+          "--external",
+          "kokoro-js",
+          "--external",
+          "onnxruntime-node",
+          "--external",
+          "onnxruntime-web",
         ],
         { cwd: process.cwd() }
       );

--- a/tests/runtime/package-scripts.test.ts
+++ b/tests/runtime/package-scripts.test.ts
@@ -112,14 +112,7 @@ describe("package.json script wiring", () => {
     expect(packageScript).toContain("--external @huggingface/transformers");
     expect(packageScript).toContain("--external onnxruntime-node");
     expect(packageScript).toContain("--external onnxruntime-web");
-    const standaloneBuild = packageScript
-      .split("\n")
-      .find((line) => line.includes("bun build src/main.ts --compile"));
-    expect(standaloneBuild).toContain("--external @huggingface/transformers");
-    expect(standaloneBuild).toContain("--external kokoro-js");
-    expect(standaloneBuild).toContain("--external onnxruntime-node");
-    expect(standaloneBuild).toContain("--external onnxruntime-web");
-    expect(standaloneBuild).not.toContain("--external tiny-secp256k1");
+    expect(packageScript).toContain("buildStandaloneCli");
     expect(packageScript).toContain("--outdir ${DIST_DIR} --entry-naming cli.js");
 
     expect(pkg.scripts?.["tauri:dev"]).toContain("bun run tauri:sidecar");

--- a/tests/runtime/package-scripts.test.ts
+++ b/tests/runtime/package-scripts.test.ts
@@ -115,9 +115,10 @@ describe("package.json script wiring", () => {
     const standaloneBuild = packageScript
       .split("\n")
       .find((line) => line.includes("bun build src/main.ts --compile"));
-    expect(standaloneBuild).not.toContain("--external @huggingface/transformers");
-    expect(standaloneBuild).not.toContain("--external onnxruntime-node");
-    expect(standaloneBuild).not.toContain("--external onnxruntime-web");
+    expect(standaloneBuild).toContain("--external @huggingface/transformers");
+    expect(standaloneBuild).toContain("--external kokoro-js");
+    expect(standaloneBuild).toContain("--external onnxruntime-node");
+    expect(standaloneBuild).toContain("--external onnxruntime-web");
     expect(standaloneBuild).not.toContain("--external tiny-secp256k1");
     expect(packageScript).toContain("--outdir ${DIST_DIR} --entry-naming cli.js");
 

--- a/tests/scripts/build-standalone-cli.test.ts
+++ b/tests/scripts/build-standalone-cli.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { standaloneCliBuildArgs } from "../../scripts/build-standalone-cli";
+
+describe("standalone CLI build", () => {
+  test("keeps architecture-specific ML runtimes external", () => {
+    const args = standaloneCliBuildArgs("bun-darwin-x64", "cybara-darwin-x64");
+
+    expect(args).toContain("--target=bun-darwin-x64");
+    expect(args).toContain("--outfile=cybara-darwin-x64");
+    expect(args).toContain("@huggingface/transformers");
+    expect(args).toContain("kokoro-js");
+    expect(args).toContain("onnxruntime-node");
+    expect(args).toContain("onnxruntime-web");
+    expect(args).not.toContain("tiny-secp256k1");
+  });
+});

--- a/tests/scripts/smoke-standalone-cli.test.ts
+++ b/tests/scripts/smoke-standalone-cli.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+describe("standalone CLI smoke script", () => {
+  test("waits for daemon readiness and preserves failure diagnostics", () => {
+    const source = readFileSync(
+      join(import.meta.dir, "..", "..", "scripts", "smoke-standalone-cli.sh"),
+      "utf8"
+    );
+
+    expect(source).toContain("for attempt in {1..15}");
+    expect(source).toContain('if "$BINARY" status');
+    expect(source).toContain('"$BINARY" daemon-logs || true');
+    expect(source).toContain('"$BINARY" stop || true');
+  });
+});

--- a/tests/ui/update-settings.test.ts
+++ b/tests/ui/update-settings.test.ts
@@ -10,6 +10,10 @@ const updateSettings = readFileSync(
 const routes = readFileSync(join(root, "src", "api", "routes.ts"), "utf8");
 const buildScript = readFileSync(join(root, "scripts", "build-sidecar.ts"), "utf8");
 const packageScript = readFileSync(join(root, "scripts", "package.ts"), "utf8");
+const standaloneBuildScript = readFileSync(
+  join(root, "scripts", "build-standalone-cli.ts"),
+  "utf8"
+);
 const releaseWorkflow = readFileSync(join(root, ".github", "workflows", "release.yml"), "utf8");
 const nativeSettings = readFileSync(
   join(root, "apps", "macos", "Cybara", "Sources", "Cybara", "NativeSettingsScreen.swift"),
@@ -30,11 +34,12 @@ describe("desktop update settings", () => {
     expect(buildScript).toContain("process.env.CYBARA_BUILD_COMMIT = buildCommit");
     expect(buildScript).toContain('const buildEnvironment = "--env=CYBARA_BUILD_*"');
     expect(buildScript).toContain("${buildEnvironment}");
-    expect(packageScript).toContain('const buildEnvironment = "--env=CYBARA_BUILD_*"');
-    expect(packageScript).toContain("${buildEnvironment}");
-    expect(releaseWorkflow).toContain("'--env=CYBARA_BUILD_*'");
+    expect(packageScript).toContain("process.env.CYBARA_BUILD_COMMIT = buildCommit");
+    expect(packageScript).toContain("buildStandaloneCli");
+    expect(standaloneBuildScript).toContain('"--env=CYBARA_BUILD_*"');
+    expect(releaseWorkflow).toContain("scripts/build-standalone-cli.ts");
     expect(buildScript).not.toContain("--compile --env=CYBARA_BUILD_*");
-    expect(packageScript).not.toContain("--compile --env=CYBARA_BUILD_*");
+    expect(standaloneBuildScript).not.toContain("--compile --env=CYBARA_BUILD_*");
   });
 
   test("keeps native macOS update settings in parity", () => {

--- a/ui/src/components/ProviderIcon.tsx
+++ b/ui/src/components/ProviderIcon.tsx
@@ -80,6 +80,7 @@ const PROVIDER_ICONS: Record<string, IconType> = {
   moonshot: Moonshot,
   kimi: Kimi,
   "kimi-code": Kimi,
+  "kimi-code-oauth": Kimi,
   qwen: Qwen,
   "qwen-portal": Qwen,
   alibaba: Alibaba,


### PR DESCRIPTION
Introduces a dedicated `kimi-code-oauth` provider and shared Kimi constants/models, including device-code OAuth setup, identity headers, and stable device ID handling. Tightens OAuth safety for Kimi by enforcing trusted `auth.kimi.com` verification endpoints and requiring refresh tokens, and applies Kimi identity headers to auth, usage, and model-discovery requests. Updates provider aliases/defaults (K3), reasoning behavior (K3 max-only), context-window handling, plan/usage source wiring, and UI icon mapping, with new and expanded tests covering OAuth flow, token refresh, discovery, routing, and defaults.

## What does this PR do?

## How was it tested?
- [x] `bun test` passes
- [x] `bunx tsc --noEmit` passes (and `cd ui && bunx tsc --noEmit` for UI changes)
- [x] Verified against a running gateway (if behavior changed)

## Checklist
- [x] No secrets/keys in the diff
- [x] Follows the import/style rules in CLAUDE.md

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New OAuth provider and credential/identity handling touch auth and outbound API behavior; release is gated on new darwin-x64 smoke tests, but coverage is extensive.
> 
> **Overview**
> Adds a **`kimi-code-oauth`** subscription provider with device-code login, shared Kimi models/constants in `kimi-code.ts`, and **`kimiCodeIdentityHeaders()`** (stable device ID + `X-Msh-*`) on OAuth, API calls, usage, and model discovery. OAuth is tightened with **trusted `auth.kimi.com` / `www.kimi.com` verification URLs**, **no empty `scope` on device start**, and **mandatory refresh tokens**; token refresh retries on 429/5xx like xAI.
> 
> **Kimi Code** API-key and OAuth catalogs move to **K3** defaults with updated models; **K3** gets **max-only** reasoning, richer **`/models`** discovery (capabilities + provider headers), and logic to **ignore/replace stale generic 128k/8192 cached metadata** for context limits.
> 
> Release and dev CI now **build via `scripts/build-standalone-cli.ts`** (shared externals for transformers/kokoro/onnx), **`smoke-standalone-cli.sh`** lifecycle checks, and **darwin-x64 cross-build + macOS smoke** (Rosetta on dev CI); **release** waits on **smoke-cli-darwin-x64** before publishing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 983baf708754657a81cbe0040f8efb274b699d66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- GITZILLA_SUMMARY -->
> [!NOTE]
> **Medium Risk**
>
> **Overview**
> This PR introduces Kimi Code as a dedicated OAuth provider alongside shared Kimi-related constants, models, and a device-code OAuth setup with stable device ID handling and identity headers. It tightens OAuth safety for Kimi by restricting verification endpoints to trusted `auth.kimi.com` hosts and requiring refresh tokens, while applying Kimi identity headers across auth, usage, and model-discovery requests. Provider aliases/defaults are updated (K3), reasoning behavior is constrained to K3 max-only, context-window handling is refined, and plan/usage source wiring plus UI components are adjusted to support the new provider. Supporting changes include CI/release workflow updates, standalone CLI build scripts, OAuth and session-context plumbing, and extensive test coverage for the new behavior.
>
> <sup>Written by [Gitzilla](https://gitzilla.ai) for commit 983baf7. This will update automatically on new runs. Configure in the [Gitzilla dashboard](https://gitzilla.ai/dashboard).</sup>
<!-- /GITZILLA_SUMMARY -->