### PR TITLE
New release

### DIFF
--- a/plugins/blender-workflows/cybara-plugin.json
+++ b/plugins/blender-workflows/cybara-plugin.json
@@ -1,0 +1,14 @@
+{
+  "schemaVersion": 1,
+  "id": "blender-workflows",
+  "name": "Blender Workflows",
+  "version": "1.0.0",
+  "description": "Scene inspection, focused editing, rendering, and visual validation workflows for Blender MCP.",
+  "author": "Cybara",
+  "homepage": "https://github.com/ahujasid/blender-mcp",
+  "contributions": {
+    "skills": {
+      "dirs": ["skills"]
+    }
+  }
+}

--- a/plugins/blender-workflows/skills/blender-mcp/SKILL.md
+++ b/plugins/blender-workflows/skills/blender-mcp/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: blender-mcp
+description: Create, inspect, render, and validate Blender scenes through the configured Blender MCP server.
+metadata: {"cybara":{"homepage":"https://github.com/ahujasid/blender-mcp","os":["darwin","linux","win32"],"requires":{"anyBins":["uvx","blender-mcp"]}}}
+---
+
+# Blender MCP
+
+Use the configured Blender MCP server for Blender scene work instead of controlling the Blender interface indirectly.
+
+## Setup
+
+1. Install the Blender server from Settings > MCP Servers > Browse Registry.
+2. Open the server's Setup link and download `addon.py`.
+3. In Blender, open Preferences > Add-ons, choose Install, select `addon.py`, and enable the add-on.
+4. Open Blender's 3D View sidebar, select BlenderMCP, and connect the add-on.
+5. Start the Blender MCP server in Cybara.
+
+## Workflow
+
+1. Call `get_scene_info` before changing an existing scene.
+2. Call `get_object_info` for objects whose transforms, materials, modifiers, or hierarchy matter.
+3. Make focused changes with `execute_blender_code` rather than one large script.
+4. Call `get_viewport_screenshot` after meaningful visual changes.
+5. Save the `.blend` file before destructive operations and after validated milestones.
+6. Use absolute paths for renders and report every saved file path.
+
+## Validation
+
+- Confirm object names, transforms, materials, lights, cameras, and render settings from scene data.
+- Inspect a viewport screenshot after geometry, material, lighting, or camera changes.
+- Render a representative frame when the requested result depends on final render output.
+- Do not claim completion when only the script executed; verify the resulting scene.
+
+## Safety
+
+- Treat `execute_blender_code` as host code execution with access to Blender and local files.
+- Never execute untrusted scripts or downloaded code.
+- Confirm before deleting scene collections, overwriting project files, or changing external assets.
+- Keep optional online asset integrations disabled unless the user explicitly requests and configures them.
+
+## Troubleshooting
+
+- Connection refused: confirm Blender is open, the add-on is enabled, and BlenderMCP is connected.
+- Server start failure: confirm `uvx` is installed and visible to Cybara.
+- Timeout: split the operation into smaller calls and inspect the scene between calls.
+- Conflicting sessions: use one active Blender MCP server for the Blender instance.

--- a/scripts/build-sidecar.ts
+++ b/scripts/build-sidecar.ts
@@ -122,17 +122,32 @@ export function getHostTargetFor(platformName: string, archName: string): Target
   const p = platformName;
   const a = archName;
   if (p === "darwin" && a === "arm64")
-    return { bunTarget: "bun-darwin-arm64", tauriSuffix: "aarch64-apple-darwin" };
+    return {
+      bunTarget: "bun-darwin-arm64",
+      tauriSuffix: "aarch64-apple-darwin",
+    };
   if (p === "darwin" && a === "x64")
     return { bunTarget: "bun-darwin-x64", tauriSuffix: "x86_64-apple-darwin" };
   if (p === "linux" && a === "x64")
-    return { bunTarget: "bun-linux-x64", tauriSuffix: "x86_64-unknown-linux-gnu" };
+    return {
+      bunTarget: "bun-linux-x64",
+      tauriSuffix: "x86_64-unknown-linux-gnu",
+    };
   if (p === "linux" && a === "arm64")
-    return { bunTarget: "bun-linux-arm64", tauriSuffix: "aarch64-unknown-linux-gnu" };
+    return {
+      bunTarget: "bun-linux-arm64",
+      tauriSuffix: "aarch64-unknown-linux-gnu",
+    };
   if (p === "win32" && a === "x64")
-    return { bunTarget: "bun-windows-x64", tauriSuffix: "x86_64-pc-windows-msvc" };
+    return {
+      bunTarget: "bun-windows-x64",
+      tauriSuffix: "x86_64-pc-windows-msvc",
+    };
   if (p === "win32" && a === "arm64")
-    return { bunTarget: "bun-windows-arm64", tauriSuffix: "aarch64-pc-windows-msvc" };
+    return {
+      bunTarget: "bun-windows-arm64",
+      tauriSuffix: "aarch64-pc-windows-msvc",
+    };
 
   throw new Error(`Unsupported platform: ${p}/${a}`);
 }
@@ -153,12 +168,30 @@ export function getHostTarget(): Target {
 }
 
 const BUN_TARGET_MAP: Record<string, Target> = {
-  "bun-darwin-arm64": { bunTarget: "bun-darwin-arm64", tauriSuffix: "aarch64-apple-darwin" },
-  "bun-darwin-x64": { bunTarget: "bun-darwin-x64", tauriSuffix: "x86_64-apple-darwin" },
-  "bun-linux-x64": { bunTarget: "bun-linux-x64", tauriSuffix: "x86_64-unknown-linux-gnu" },
-  "bun-linux-arm64": { bunTarget: "bun-linux-arm64", tauriSuffix: "aarch64-unknown-linux-gnu" },
-  "bun-windows-x64": { bunTarget: "bun-windows-x64", tauriSuffix: "x86_64-pc-windows-msvc" },
-  "bun-windows-arm64": { bunTarget: "bun-windows-arm64", tauriSuffix: "aarch64-pc-windows-msvc" },
+  "bun-darwin-arm64": {
+    bunTarget: "bun-darwin-arm64",
+    tauriSuffix: "aarch64-apple-darwin",
+  },
+  "bun-darwin-x64": {
+    bunTarget: "bun-darwin-x64",
+    tauriSuffix: "x86_64-apple-darwin",
+  },
+  "bun-linux-x64": {
+    bunTarget: "bun-linux-x64",
+    tauriSuffix: "x86_64-unknown-linux-gnu",
+  },
+  "bun-linux-arm64": {
+    bunTarget: "bun-linux-arm64",
+    tauriSuffix: "aarch64-unknown-linux-gnu",
+  },
+  "bun-windows-x64": {
+    bunTarget: "bun-windows-x64",
+    tauriSuffix: "x86_64-pc-windows-msvc",
+  },
+  "bun-windows-arm64": {
+    bunTarget: "bun-windows-arm64",
+    tauriSuffix: "aarch64-pc-windows-msvc",
+  },
 };
 
 export function resolveTarget(): Target {
@@ -402,7 +435,9 @@ function installSharedOnnxRuntime(
   });
 
   copyPackageJson("onnxruntime-web", targetNodeModulesDir);
-  copyPackageDirectory("onnxruntime-web", "dist", targetNodeModulesDir, { omitSourceMaps: true });
+  copyPackageDirectory("onnxruntime-web", "dist", targetNodeModulesDir, {
+    omitSourceMaps: true,
+  });
 
   return copyOnnxRuntimeNodeRuntime(targetNodeModulesDir, runtimeTarget);
 }
@@ -448,7 +483,9 @@ export function copyTransformersRuntime(
   });
 
   copyPackageJson("kokoro-js", targetNodeModulesDir);
-  copyPackageDirectory("kokoro-js", "dist", targetNodeModulesDir, { omitSourceMaps: true });
+  copyPackageDirectory("kokoro-js", "dist", targetNodeModulesDir, {
+    omitSourceMaps: true,
+  });
   copyPackageDirectory("kokoro-js", "voices", targetNodeModulesDir);
   copyPackageFromRoot(NODE_MODULES_ROOT, "phonemizer", targetNodeModulesDir, ["dist"]);
 
@@ -683,7 +720,9 @@ export default instance.exports;
   const packagedRuntimeDir = join(TAURI_BIN_DIR, "runtime");
   await installBunRuntimeAt(packagedRuntimeDir, target.bunTarget);
   rmSync(join(packagedRuntimeDir, "local-speech-worker.ts"), { force: true });
-  rmSync(join(packagedRuntimeDir, "local-speech-worker-protocol.ts"), { force: true });
+  rmSync(join(packagedRuntimeDir, "local-speech-worker-protocol.ts"), {
+    force: true,
+  });
   await copyFilePortable(
     join(import.meta.dirname, "..", "src", "core", "local-speech-worker.mjs"),
     join(packagedRuntimeDir, "local-speech-worker.mjs")
@@ -705,6 +744,12 @@ export default instance.exports;
     removeAndCopyDirectory(packagedCuaDriverDir, join(dir, "cua-driver"));
   }
   console.log(`  📦 Copied computer-use driver v${CUA_DRIVER_VERSION}`);
+
+  const bundledPluginsDir = join(import.meta.dirname, "..", "plugins");
+  for (const dir of [RELEASE_DIR, TAURI_BIN_DIR, tauriDebugDir]) {
+    removeAndCopyDirectory(bundledPluginsDir, join(dir, "plugins"));
+  }
+  console.log("  📦 Copied bundled plugins");
 
   // Copy secp256k1.wasm alongside the binary
   if (existsSync(wasmSource)) {

--- a/scripts/package-native-macos.ts
+++ b/scripts/package-native-macos.ts
@@ -31,6 +31,7 @@ const SIDEcar_ONNX_PATH = join(ROOT, "release", "onnxruntime");
 const SIDEcar_NODE_MODULES_PATH = join(ROOT, "release", "node_modules");
 const SIDEcar_RUNTIME_PATH = join(ROOT, "release", "runtime");
 const SIDEcar_CUA_DRIVER_PATH = join(ROOT, "release", "cua-driver");
+const SIDEcar_PLUGINS_PATH = join(ROOT, "release", "plugins");
 const UI_DIST_PATH = join(ROOT, "ui", "dist");
 const ICON_SOURCE_PATH = join(ROOT, "cybara.png");
 
@@ -124,6 +125,7 @@ export interface NativeMacOSSidecarLayout {
   nodeModulesDir: string;
   runtimeDir: string;
   cuaDriverDir: string;
+  pluginsDir: string;
 }
 
 export function createNativeMacOSSidecarLayout(contentsPath: string): NativeMacOSSidecarLayout {
@@ -138,6 +140,7 @@ export function createNativeMacOSSidecarLayout(contentsPath: string): NativeMacO
     nodeModulesDir: join(resourceDir, "node_modules"),
     runtimeDir: join(resourceDir, "runtime"),
     cuaDriverDir: join(resourceDir, "cua-driver"),
+    pluginsDir: join(resourceDir, "plugins"),
   };
 }
 
@@ -575,6 +578,10 @@ export async function packageNativeMacOSApp(): Promise<NativeMacOSPackageResult>
 
   if (existsSync(SIDEcar_CUA_DRIVER_PATH)) {
     copyDirectory(SIDEcar_CUA_DRIVER_PATH, sidecarLayout.cuaDriverDir);
+  }
+
+  if (existsSync(SIDEcar_PLUGINS_PATH)) {
+    copyDirectory(SIDEcar_PLUGINS_PATH, sidecarLayout.pluginsDir);
   }
 
   ensureDirectory(dirname(sidecarLayout.uiDistDir));

--- a/scripts/package.ts
+++ b/scripts/package.ts
@@ -80,6 +80,9 @@ export async function runPackage(): Promise<void> {
   cpSync(uiDistSrc, releaseUiPath, { recursive: true });
   console.log("   ✓ UI assets bundled with binary");
 
+  cpSync("plugins", join(RELEASE_DIR, "plugins"), { recursive: true });
+  console.log("   ✓ Bundled plugins copied");
+
   const driverTarget = getCuaDriverTarget(platform, arch);
   if (!driverTarget) throw new Error(`Unsupported computer-use target: ${platform}/${arch}`);
   await installCuaDriverAt(join(RELEASE_DIR, "cua-driver"), driverTarget);

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -41,22 +41,13 @@
       "bin/node_modules": "node_modules",
       "bin/runtime": "runtime",
       "bin/cua-driver": "cua-driver",
+      "bin/plugins": "plugins",
       "bin/docker/sandbox-browser": "docker/sandbox-browser",
       "bin/ui/dist": "ui/dist",
       "bin/secp256k1.wasm": "secp256k1.wasm"
     },
-    "targets": [
-      "dmg",
-      "app",
-      "msi",
-      "nsis",
-      "deb",
-      "rpm",
-      "appimage"
-    ],
-    "externalBin": [
-      "bin/cybara"
-    ],
+    "targets": ["dmg", "app", "msi", "nsis", "deb", "rpm", "appimage"],
+    "externalBin": ["bin/cybara"],
     "fileAssociations": [
       {
         "ext": [

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -171,6 +171,15 @@ import {
   setProviderPlanMonitoringConfig,
 } from "../core/provider-plans";
 import {
+  createProviderAccountPool,
+  deleteProviderAccountPool,
+  listProviderAccountPools,
+  removeProviderFromAccountPools,
+  type ProviderAccountPool,
+  type ProviderAccountPoolInput,
+  updateProviderAccountPool,
+} from "../core/provider-account-pool";
+import {
   type ProviderType,
   providerManager,
   providers,
@@ -371,6 +380,54 @@ async function runGoldenReplay(
 }
 
 registerEvalReplayExecutor(runGoldenReplay);
+
+function providerAccountPoolResponse(pool: ProviderAccountPool): Record<string, unknown> {
+  return {
+    id: pool.id,
+    name: pool.name,
+    provider: pool.provider,
+    enabled: pool.enabled,
+    routing_mode: pool.accounts.some((account) => account.priority !== undefined)
+      ? "priority_then_usage"
+      : "usage",
+    accounts: pool.accounts.map((account) => {
+      const provider = providerManager.get(account.providerId);
+      return {
+        provider_id: account.providerId,
+        provider_name: provider?.name ?? account.providerId,
+        priority: account.priority ?? null,
+      };
+    }),
+  };
+}
+
+function providerAccountPoolInput(body: unknown): ProviderAccountPoolInput {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    throw new Error("Validation error: Provider pool body is required");
+  }
+  const record = body as Record<string, unknown>;
+  const accounts = Array.isArray(record.accounts)
+    ? record.accounts.flatMap((entry) => {
+        if (!entry || typeof entry !== "object" || Array.isArray(entry)) return [];
+        const account = entry as Record<string, unknown>;
+        const providerId = normalizeOptionalString(account.provider_id ?? account.providerId);
+        return providerId
+          ? [
+              {
+                providerId,
+                priority: typeof account.priority === "number" ? account.priority : undefined,
+              },
+            ]
+          : [];
+      })
+    : [];
+  return {
+    name: normalizeOptionalString(record.name) || "",
+    provider: normalizeOptionalString(record.provider) || "",
+    enabled: record.enabled !== false,
+    accounts,
+  };
+}
 
 async function runQuickIntelligenceBenchmark(runId: string, agentId: string): Promise<void> {
   let workspaceDir: string | null = null;
@@ -1138,6 +1195,8 @@ const routes: Record<string, RouteHandler> = {
         provider: agent.provider,
         provider_id: agent.provider_id,
         provider_type: agent.provider_type,
+        provider_pool_id: agent.provider_pool_id,
+        provider_pool_name: agent.provider_pool_name,
         fallback_provider_id: agent.fallback_provider_id,
         status: agent.status,
         created_at: agent.created_at,
@@ -1363,6 +1422,24 @@ const routes: Record<string, RouteHandler> = {
   },
 
   "GET /api/providers": () => providerManager.list(),
+  "GET /api/provider-account-pools": () =>
+    listProviderAccountPools().map(providerAccountPoolResponse),
+  "POST /api/provider-account-pools": (body) =>
+    providerAccountPoolResponse(
+      createProviderAccountPool(providerAccountPoolInput(body), providerManager.list())
+    ),
+  "PUT /api/provider-account-pools/:id": (body, params) => {
+    const pool = updateProviderAccountPool(
+      params!.id,
+      providerAccountPoolInput(body),
+      providerManager.list()
+    );
+    if (!pool) throw new Error("Provider account pool not found");
+    return providerAccountPoolResponse(pool);
+  },
+  "DELETE /api/provider-account-pools/:id": (_body, params) => ({
+    success: deleteProviderAccountPool(params!.id),
+  }),
   "GET /api/providers/available": () => [
     ...Object.entries(providers).map(([key, value]) => ({
       id: key,
@@ -1662,6 +1739,7 @@ const routes: Record<string, RouteHandler> = {
         api_key: apiKey,
         access_token: accessToken,
         base_url: normalizedBaseUrl || pluginProvider.baseUrl,
+        settings: providerSettings,
         is_default: data.is_default === true,
       });
       for (const model of pluginProvider.models) {
@@ -1718,7 +1796,12 @@ const routes: Record<string, RouteHandler> = {
     }
 
     if ("settings" in data) {
-      const providerSettings = normalizeProviderSettings(existing.provider, data.settings);
+      const providerSettings = normalizeProviderSettings(existing.provider, {
+        ...(existing.settings || {}),
+        ...((data.settings && typeof data.settings === "object" && !Array.isArray(data.settings)
+          ? data.settings
+          : {}) as Record<string, unknown>),
+      });
       if (existing.provider === "devin" && !providerSettings) {
         throw new Error("Validation error: Devin organization ID is invalid");
       }
@@ -1777,7 +1860,10 @@ const routes: Record<string, RouteHandler> = {
   },
   "DELETE /api/providers/:id": (_body, params) => {
     const success = providerManager.delete(params!.id);
-    if (success) invalidateCachedRoute("GET /api/provider-plans/status");
+    if (success) {
+      removeProviderFromAccountPools(params!.id);
+      invalidateCachedRoute("GET /api/provider-plans/status");
+    }
     return { success };
   },
   "GET /api/providers/:id/models": async (_body, params) => {

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -173,6 +173,7 @@ import {
 import {
   createProviderAccountPool,
   deleteProviderAccountPool,
+  getProviderAccountPool,
   listProviderAccountPools,
   removeProviderFromAccountPools,
   type ProviderAccountPool,
@@ -401,7 +402,10 @@ function providerAccountPoolResponse(pool: ProviderAccountPool): Record<string, 
   };
 }
 
-function providerAccountPoolInput(body: unknown): ProviderAccountPoolInput {
+function providerAccountPoolInput(
+  body: unknown,
+  existing?: ProviderAccountPool
+): ProviderAccountPoolInput {
   if (!body || typeof body !== "object" || Array.isArray(body)) {
     throw new Error("Validation error: Provider pool body is required");
   }
@@ -420,11 +424,11 @@ function providerAccountPoolInput(body: unknown): ProviderAccountPoolInput {
             ]
           : [];
       })
-    : [];
+    : (existing?.accounts ?? []);
   return {
-    name: normalizeOptionalString(record.name) || "",
-    provider: normalizeOptionalString(record.provider) || "",
-    enabled: record.enabled !== false,
+    name: normalizeOptionalString(record.name) || existing?.name || "",
+    provider: normalizeOptionalString(record.provider) || existing?.provider || "",
+    enabled: typeof record.enabled === "boolean" ? record.enabled : existing?.enabled !== false,
     accounts,
   };
 }
@@ -1429,9 +1433,11 @@ const routes: Record<string, RouteHandler> = {
       createProviderAccountPool(providerAccountPoolInput(body), providerManager.list())
     ),
   "PUT /api/provider-account-pools/:id": (body, params) => {
+    const existing = getProviderAccountPool(params!.id);
+    if (!existing) throw new Error("Provider account pool not found");
     const pool = updateProviderAccountPool(
       params!.id,
-      providerAccountPoolInput(body),
+      providerAccountPoolInput(body, existing),
       providerManager.list()
     );
     if (!pool) throw new Error("Provider account pool not found");

--- a/src/cli/commands/help.ts
+++ b/src/cli/commands/help.ts
@@ -61,7 +61,8 @@ export function rawHelp(version: string, apiBase: string): void {
   console.log("    provider list         List configured providers");
   console.log("    provider available    Show available types");
   console.log("    provider add <type>   Add provider (--name, --key, --token, --default)");
-  console.log("    provider update <id>  Update provider");
+  console.log("    provider update <id>  Update provider credentials and defaults");
+  console.log("    provider pool         Manage named same-provider account pools");
   console.log("    provider delete <id>  Delete provider");
   console.log("    provider models <id>  List provider models");
   console.log("    provider discover     Discover Ollama models");

--- a/src/cli/commands/provider-commands.ts
+++ b/src/cli/commands/provider-commands.ts
@@ -47,7 +47,7 @@ export interface ProviderPoolFlags {
   name?: string;
   provider?: string;
   enabled?: boolean;
-  accounts: Array<{ provider_id: string; priority?: number }>;
+  accounts?: Array<{ provider_id: string; priority?: number }>;
 }
 
 interface CliProviderCommands {
@@ -341,7 +341,7 @@ export function createCliProviderCommands(
     let name: string | undefined;
     let provider: string | undefined;
     let enabled: boolean | undefined;
-    const accounts: ProviderPoolFlags["accounts"] = [];
+    const accounts: NonNullable<ProviderPoolFlags["accounts"]> = [];
     for (let index = 0; index < args.length; index += 1) {
       const flag = args[index];
       if (flag === "--name" || flag === "-n") name = args[++index];
@@ -367,7 +367,12 @@ export function createCliProviderCommands(
         }
       }
     }
-    return { name, provider, enabled, accounts };
+    return {
+      ...(name !== undefined ? { name } : {}),
+      ...(provider !== undefined ? { provider } : {}),
+      ...(enabled !== undefined ? { enabled } : {}),
+      ...(accounts.length > 0 ? { accounts } : {}),
+    };
   };
 
   const poolList = async (): Promise<void> => {

--- a/src/cli/commands/provider-commands.ts
+++ b/src/cli/commands/provider-commands.ts
@@ -12,6 +12,7 @@ export interface ProviderInfo {
   name: string;
   is_default: boolean;
   config?: Record<string, unknown>;
+  settings?: Record<string, unknown>;
 }
 
 export interface AvailableProviderInfo {
@@ -33,6 +34,22 @@ export interface ProviderFlags {
   oauth: boolean;
 }
 
+export interface ProviderAccountPoolInfo {
+  id: string;
+  name: string;
+  provider: string;
+  enabled: boolean;
+  routing_mode: "usage" | "priority_then_usage";
+  accounts: Array<{ provider_id: string; provider_name?: string; priority: number | null }>;
+}
+
+export interface ProviderPoolFlags {
+  name?: string;
+  provider?: string;
+  enabled?: boolean;
+  accounts: Array<{ provider_id: string; priority?: number }>;
+}
+
 interface CliProviderCommands {
   add: (
     type: string,
@@ -48,6 +65,11 @@ interface CliProviderCommands {
   list: () => Promise<void>;
   models: (id: string) => Promise<void>;
   parseFlags: (args: string[]) => ProviderFlags;
+  parsePoolFlags: (args: string[]) => ProviderPoolFlags;
+  poolCreate: (flags: ProviderPoolFlags) => Promise<void>;
+  poolDelete: (id: string) => Promise<void>;
+  poolList: () => Promise<void>;
+  poolUpdate: (id: string, flags: ProviderPoolFlags) => Promise<void>;
   update: (
     id: string,
     name?: string,
@@ -315,5 +337,112 @@ export function createCliProviderCommands(
     return { name, key, token, isDefault, oauth };
   };
 
-  return { add, available, delete: remove, discover, list, models, parseFlags, update };
+  const parsePoolFlags = (args: string[]): ProviderPoolFlags => {
+    let name: string | undefined;
+    let provider: string | undefined;
+    let enabled: boolean | undefined;
+    const accounts: ProviderPoolFlags["accounts"] = [];
+    for (let index = 0; index < args.length; index += 1) {
+      const flag = args[index];
+      if (flag === "--name" || flag === "-n") name = args[++index];
+      else if (flag === "--provider" || flag === "-p") provider = args[++index];
+      else if (flag === "--enabled") enabled = true;
+      else if (flag === "--disabled") enabled = false;
+      else if (flag === "--account" || flag === "-a") {
+        const value = args[++index] || "";
+        const separator = value.lastIndexOf(":");
+        const providerId = (separator > 0 ? value.slice(0, separator) : value).trim();
+        const parsedPriority = separator > 0 ? Number(value.slice(separator + 1)) : undefined;
+        if (providerId) {
+          accounts.push(
+            parsedPriority !== undefined && Number.isFinite(parsedPriority)
+              ? {
+                  provider_id: providerId,
+                  priority: Math.max(0, Math.min(10_000, Math.round(parsedPriority))),
+                }
+              : {
+                  provider_id: providerId,
+                }
+          );
+        }
+      }
+    }
+    return { name, provider, enabled, accounts };
+  };
+
+  const poolList = async (): Promise<void> => {
+    const pools = await fetchAPI<ProviderAccountPoolInfo[]>("/api/provider-account-pools");
+    if (!pools) exitWithError(["ERROR: Failed to fetch account pools from", apiBase]);
+    console.log("PROVIDER ACCOUNT POOLS");
+    console.log("======================");
+    if (pools.length === 0) {
+      console.log("No account pools configured");
+      return;
+    }
+    for (const pool of pools) {
+      console.log(
+        `\n${pool.name}  ${pool.provider}  ${pool.enabled ? "active" : "paused"}  ${pool.routing_mode === "usage" ? "usage-balanced" : "priority override"}`
+      );
+      for (const [index, account] of pool.accounts.entries()) {
+        console.log(
+          `  ${index + 1}. ${account.provider_name || account.provider_id}  ${account.priority === null ? "automatic" : `priority ${account.priority}`}`
+        );
+      }
+    }
+  };
+
+  const savePool = async (
+    method: "POST" | "PUT",
+    endpoint: string,
+    flags: ProviderPoolFlags
+  ): Promise<void> => {
+    const response = await fetch(`${apiBase}${endpoint}`, {
+      method,
+      headers: withAuthHeaders({ "Content-Type": "application/json" }),
+      body: JSON.stringify(flags),
+    });
+    const result = (await response.json()) as ProviderAccountPoolInfo & { error?: string };
+    if (!response.ok || !result.id) {
+      exitWithError([`Failed to save account pool: ${result.error || "Unknown error"}`]);
+    }
+    console.log(`Saved account pool: ${result.name} (${result.id})`);
+  };
+
+  const poolCreate = async (flags: ProviderPoolFlags): Promise<void> => {
+    await savePool("POST", "/api/provider-account-pools", flags);
+  };
+
+  const poolUpdate = async (id: string, flags: ProviderPoolFlags): Promise<void> => {
+    if (!id) exitWithError(["Usage: cybara provider pool update <pool-id> [options]"]);
+    await savePool("PUT", `/api/provider-account-pools/${encodeURIComponent(id)}`, flags);
+  };
+
+  const poolDelete = async (id: string): Promise<void> => {
+    if (!id) exitWithError(["Usage: cybara provider pool delete <pool-id>"]);
+    const response = await fetch(
+      `${apiBase}/api/provider-account-pools/${encodeURIComponent(id)}`,
+      { method: "DELETE", headers: withAuthHeaders() }
+    );
+    const result = (await response.json()) as { success?: boolean; error?: string };
+    if (!response.ok || !result.success) {
+      exitWithError([`Failed to delete account pool: ${result.error || "Unknown error"}`]);
+    }
+    console.log(`Deleted account pool: ${id}`);
+  };
+
+  return {
+    add,
+    available,
+    delete: remove,
+    discover,
+    list,
+    models,
+    parseFlags,
+    parsePoolFlags,
+    poolCreate,
+    poolDelete,
+    poolList,
+    poolUpdate,
+    update,
+  };
 }

--- a/src/cli/index.tsx
+++ b/src/cli/index.tsx
@@ -171,6 +171,11 @@ const {
   list: rawProviders,
   models: rawProviderModels,
   parseFlags: parseProviderFlags,
+  parsePoolFlags: parseProviderPoolFlags,
+  poolCreate: rawProviderPoolCreate,
+  poolDelete: rawProviderPoolDelete,
+  poolList: rawProviderPoolList,
+  poolUpdate: rawProviderPoolUpdate,
   update: rawProviderUpdate,
 } = createCliProviderCommands(fetchAPI, API_BASE, withCliAuthHeaders);
 
@@ -1332,6 +1337,29 @@ async function main() {
           );
           break;
         }
+        case "pool": {
+          const poolCommand = args[2] || "list";
+          if (poolCommand === "list") await rawProviderPoolList();
+          else if (poolCommand === "create") {
+            await rawProviderPoolCreate(parseProviderPoolFlags(args.slice(3)));
+          } else if (poolCommand === "update") {
+            await rawProviderPoolUpdate(args[3], parseProviderPoolFlags(args.slice(4)));
+          } else if (poolCommand === "delete" || poolCommand === "remove") {
+            await rawProviderPoolDelete(args[3]);
+          } else {
+            console.log("Provider Pool Commands:");
+            console.log("  cybara provider pool list");
+            console.log(
+              "  cybara provider pool create --name <name> --provider <type> --account <provider-id[:priority]>"
+            );
+            console.log(
+              "  cybara provider pool update <pool-id> --name <name> --provider <type> --account <provider-id[:priority]>"
+            );
+            console.log("  Omit :priority to balance accounts by tracked plan usage");
+            console.log("  cybara provider pool delete <pool-id>");
+          }
+          break;
+        }
         case "delete":
         case "remove":
           await rawProviderDelete(provArg);
@@ -1357,6 +1385,7 @@ async function main() {
           console.log("    --oauth       Connect via OAuth device code flow");
           console.log("    --default     Set as default");
           console.log("  cybara provider update <id>   - Update provider");
+          console.log("  cybara provider pool          - Manage named account pools");
           console.log("  cybara provider delete <id>   - Delete provider");
           console.log("  cybara provider models <id>   - List provider models");
           console.log(

--- a/src/cli/tui/components/app.tsx
+++ b/src/cli/tui/components/app.tsx
@@ -8,6 +8,7 @@ import {
 } from "../../../core/update-check";
 import {
   type AvailableProviderInfo,
+  type ProviderAccountPoolInfo,
   type ProviderInfo,
 } from "../../commands/provider-commands";
 import { connectCliProviderOAuth } from "../../commands/provider-oauth";
@@ -373,6 +374,7 @@ function planWindow(
 const TUIProvidersCommand = () => {
   const exit = useTUIBack();
   const [providers, setProviders] = React.useState<ProviderInfo[]>([]);
+  const [pools, setPools] = React.useState<ProviderAccountPoolInfo[]>([]);
   const [plans, setPlans] = React.useState<TUIProviderPlanStatus | null>(null);
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState<string | null>(null);
@@ -385,12 +387,14 @@ const TUIProvidersCommand = () => {
     Promise.all([
       fetchAPI<ProviderInfo[]>("/api/providers"),
       fetchAPI<TUIProviderPlanStatus>("/api/provider-plans/status"),
+      fetchAPI<ProviderAccountPoolInfo[]>("/api/provider-account-pools"),
     ])
-      .then(([providerData, planData]) => {
+      .then(([providerData, planData, poolData]) => {
         if (providerData)
           setProviders(Array.isArray(providerData) ? providerData : []);
         else setError("Failed to fetch providers");
         if (planData) setPlans(planData);
+        if (poolData) setPools(Array.isArray(poolData) ? poolData : []);
       })
       .finally(() => setLoading(false));
   }, []);
@@ -471,6 +475,31 @@ const TUIProvidersCommand = () => {
           })}
         </Box>
       )}
+      <Box marginTop={1} flexDirection="column">
+        <Text bold color="cyan">
+          Account pools ({pools.length})
+        </Text>
+        {pools.length === 0 ? (
+          <Text color="gray">No named pools configured</Text>
+        ) : (
+          pools.map((pool) => (
+            <Box key={pool.id} flexDirection="column" marginTop={1}>
+              <Text bold>{pool.name} </Text>
+              <Text color={pool.enabled ? "green" : "yellow"}>
+                {pool.enabled ? "active" : "paused"}
+              </Text>
+              <Text color="gray">
+                {` ${pool.provider}  ${pool.routing_mode === "usage" ? "usage-balanced" : "priority override"}`}
+              </Text>
+              {pool.accounts.map((account, index) => (
+                <Text key={account.provider_id} color="gray">
+                  {`  ${index + 1}. ${account.provider_name || account.provider_id}  ${account.priority === null ? "automatic" : `priority ${account.priority}`}`}
+                </Text>
+              ))}
+            </Box>
+          ))
+        )}
+      </Box>
       <Box marginTop={1}>
         <Text color="gray">Press q to exit</Text>
       </Box>

--- a/src/core/agent-provider-runtime.ts
+++ b/src/core/agent-provider-runtime.ts
@@ -142,6 +142,12 @@ import {
 } from "./openai-codex-models";
 import { type AnthropicCacheRequest, applyAnthropicCacheControl } from "./prompt-cache";
 import {
+  boundedPoolRetryDelayMs,
+  parseProviderRetryAfterMs,
+  providerExceptionRetryDelayMs,
+  providerRetryDelayMs,
+} from "./provider-retry";
+import {
   getDefaultModel,
   getProviderBaseUrl,
   type ProviderType,
@@ -327,17 +333,7 @@ export abstract class AgentProviderRuntime {
   }
 
   private parseRetryAfterMs(headers: Headers, defaultRetryAfterMs = 60_000): number {
-    const raw = headers.get("retry-after") || headers.get("Retry-After");
-    if (!raw) return defaultRetryAfterMs;
-    const seconds = Number(raw);
-    if (Number.isFinite(seconds) && seconds >= 0) {
-      return Math.max(0, Math.floor(seconds * 1000));
-    }
-    const dateMs = Date.parse(raw);
-    if (Number.isFinite(dateMs)) {
-      return Math.max(0, dateMs - Date.now());
-    }
-    return defaultRetryAfterMs;
+    return parseProviderRetryAfterMs(headers, defaultRetryAfterMs);
   }
 
   private async waitForRetryDelay(delayMs: number, signal?: AbortSignal): Promise<void> {
@@ -379,8 +375,7 @@ export abstract class AgentProviderRuntime {
   }
 
   private providerRetryDelayMs(status: number, headers: Headers, attempt: number): number {
-    const fallback = Math.min(1000 * Math.pow(2, attempt), 8000);
-    return status === 429 ? this.parseRetryAfterMs(headers, fallback) : fallback;
+    return providerRetryDelayMs(status, headers, attempt);
   }
 
   private broadcastProviderRetryStatus(
@@ -401,9 +396,11 @@ export abstract class AgentProviderRuntime {
   private recordHttpRateLimit(
     status: number,
     headers: Headers,
-    context?: ProviderRateLimitContext
+    context?: ProviderRateLimitContext,
+    body = ""
   ): void {
     if (status !== 429) return;
+    if (classifyApiError({ status, body }).category === "overloaded") return;
     const retryAfterMs = this.parseRetryAfterMs(headers, context?.defaultRetryAfterMs);
     const keys = [context?.providerId?.trim(), context?.providerType?.trim()].filter(
       (key): key is string => Boolean(key)
@@ -1103,6 +1100,7 @@ export abstract class AgentProviderRuntime {
           }
         : undefined;
     let streamingDisabled = false;
+    let transientRetryCount = 0;
     const post = async (body: Record<string, unknown>): Promise<Response | OpenAIResponse> => {
       if (streamingDisabled) {
         try {
@@ -1113,7 +1111,20 @@ export abstract class AgentProviderRuntime {
             signal: withLlmRequestTimeout(signal),
           });
         } catch (error) {
-          throw normalizeLlmTimeoutError(error, signal);
+          const normalized = normalizeLlmTimeoutError(error, signal);
+          const retryDelayMs = providerExceptionRetryDelayMs(
+            normalized,
+            transientRetryCount,
+            signal
+          );
+          if (retryDelayMs === undefined) throw normalized;
+          transientRetryCount += 1;
+          this.broadcastProviderRetryStatus(
+            streamContext,
+            `Provider connection interrupted; retrying (${transientRetryCount}/3)...`
+          );
+          await this.waitForRetryDelay(retryDelayMs, signal);
+          return post(body);
         }
       }
 
@@ -1122,9 +1133,10 @@ export abstract class AgentProviderRuntime {
         callerSignal: signal,
         label: "chat.completions",
       });
+      const requestStartedAt = performance.now();
+      let response: Response;
       try {
-        const requestStartedAt = performance.now();
-        const response = await fetch(`${baseUrl}/chat/completions`, {
+        response = await fetch(`${baseUrl}/chat/completions`, {
           method: "POST",
           headers,
           body: JSON.stringify({
@@ -1134,6 +1146,20 @@ export abstract class AgentProviderRuntime {
           }),
           signal: watchdog.signal,
         });
+      } catch (error) {
+        watchdog.dispose();
+        const normalized = watchdog.wrapError(error);
+        const retryDelayMs = providerExceptionRetryDelayMs(normalized, transientRetryCount, signal);
+        if (retryDelayMs === undefined) throw normalized;
+        transientRetryCount += 1;
+        this.broadcastProviderRetryStatus(
+          streamContext,
+          `Provider connection interrupted; retrying (${transientRetryCount}/3)...`
+        );
+        await this.waitForRetryDelay(retryDelayMs, signal);
+        return post(body);
+      }
+      try {
         if (!response.ok) {
           watchdog.dispose();
           return response;
@@ -1168,7 +1194,6 @@ export abstract class AgentProviderRuntime {
     let attemptedToolChoiceCompatibilityRetry = false;
     let contextRetryCount = 0;
     let attemptedOAuthRefresh = false;
-    let transientRetryCount = 0;
     const maxTransientRetries = 3;
     const maxRetryDelayMs = 120_000;
 
@@ -1184,7 +1209,7 @@ export abstract class AgentProviderRuntime {
       }
 
       const errorText = await response.text();
-      this.recordHttpRateLimit(response.status, response.headers, rateLimitContext);
+      this.recordHttpRateLimit(response.status, response.headers, rateLimitContext, errorText);
       if (
         response.status === 401 &&
         !attemptedOAuthRefresh &&
@@ -2156,13 +2181,26 @@ export abstract class AgentProviderRuntime {
           });
         } catch (error) {
           watchdog.dispose();
-          throw watchdog.wrapError(error);
+          const normalized = watchdog.wrapError(error);
+          const retryDelayMs = providerExceptionRetryDelayMs(
+            normalized,
+            transientRetryCount,
+            signal
+          );
+          if (retryDelayMs === undefined) throw normalized;
+          transientRetryCount += 1;
+          this.broadcastProviderRetryStatus(
+            { sessionId, agentId },
+            `Provider connection interrupted; retrying (${transientRetryCount}/3)...`
+          );
+          await this.waitForRetryDelay(retryDelayMs, signal);
+          continue;
         }
 
         if (!response.ok) {
           watchdog.dispose();
           const errorText = await response.text();
-          this.recordHttpRateLimit(response.status, response.headers, rateLimitContext);
+          this.recordHttpRateLimit(response.status, response.headers, rateLimitContext, errorText);
           finalError = `API error: ${response.status} - ${errorText}`;
           if (
             response.status === 401 &&
@@ -2186,7 +2224,7 @@ export abstract class AgentProviderRuntime {
             transientRetryCount += 1;
             this.broadcastProviderRetryStatus(
               { sessionId, agentId },
-              response.status === 429
+              classifiedError.category === "rate_limit"
                 ? `Provider rate limited; retrying (${transientRetryCount}/3)...`
                 : `Provider temporarily unavailable; retrying (${transientRetryCount}/3)...`
             );
@@ -2691,18 +2729,35 @@ export abstract class AgentProviderRuntime {
       let transientRetryCount = 0;
       let attemptedOAuthRefresh = false;
       while (true) {
-        response = await fetch(endpoint, {
-          method: "POST",
-          headers,
-          body: JSON.stringify(requestBody),
-          signal: withLlmRequestTimeout(toolContext?.abortSignal),
-        });
+        try {
+          response = await fetch(endpoint, {
+            method: "POST",
+            headers,
+            body: JSON.stringify(requestBody),
+            signal: withLlmRequestTimeout(toolContext?.abortSignal),
+          });
+        } catch (error) {
+          const retryDelayMs = providerExceptionRetryDelayMs(
+            error,
+            transientRetryCount,
+            toolContext?.abortSignal
+          );
+          if (retryDelayMs === undefined) throw error;
+          transientRetryCount += 1;
+          this.broadcastAgentStatus(
+            "thinking",
+            toolContext,
+            `Provider connection interrupted; retrying (${transientRetryCount}/3)...`
+          );
+          await this.waitForRetryDelay(retryDelayMs, toolContext?.abortSignal);
+          continue;
+        }
 
         if (response.ok) break;
 
         const errorText = await response.text();
         const rateLimitContext = { providerId, providerType: providerConfig };
-        this.recordHttpRateLimit(response.status, response.headers, rateLimitContext);
+        this.recordHttpRateLimit(response.status, response.headers, rateLimitContext, errorText);
         if (
           response.status === 401 &&
           !attemptedOAuthRefresh &&
@@ -2727,7 +2782,7 @@ export abstract class AgentProviderRuntime {
           this.broadcastAgentStatus(
             "thinking",
             toolContext,
-            response.status === 429
+            classifiedError.category === "rate_limit"
               ? `Provider rate limited; retrying (${transientRetryCount}/3)...`
               : `Provider temporarily unavailable; retrying (${transientRetryCount}/3)...`
           );
@@ -3246,12 +3301,29 @@ export abstract class AgentProviderRuntime {
       } else {
         headers["x-api-key"] = currentApiKey;
       }
-      response = await fetch(`${baseUrl}${anthropicEndpoint}`, {
-        method: "POST",
-        headers,
-        body: JSON.stringify(requestBody),
-        signal: withLlmRequestTimeout(toolContext?.abortSignal),
-      });
+      try {
+        response = await fetch(`${baseUrl}${anthropicEndpoint}`, {
+          method: "POST",
+          headers,
+          body: JSON.stringify(requestBody),
+          signal: withLlmRequestTimeout(toolContext?.abortSignal),
+        });
+      } catch (error) {
+        const retryDelayMs = providerExceptionRetryDelayMs(
+          error,
+          initialRetryCount,
+          toolContext?.abortSignal
+        );
+        if (retryDelayMs === undefined) throw error;
+        initialRetryCount += 1;
+        this.broadcastAgentStatus(
+          "thinking",
+          toolContext,
+          `Provider connection interrupted; retrying (${initialRetryCount}/${INITIAL_MAX_RETRIES})...`
+        );
+        await this.waitForRetryDelay(retryDelayMs, toolContext?.abortSignal);
+        continue;
+      }
 
       if (response.ok) {
         if (activeCredential) markCredentialHealthy(poolName, activeCredential);
@@ -3260,11 +3332,19 @@ export abstract class AgentProviderRuntime {
 
       lastInitialError = await response.text();
 
-      if (activeCredential) recordRateLimit(activeCredential.label, response.headers);
-      this.recordHttpRateLimit(response.status, response.headers, {
-        providerId,
-        providerType: providerConfig,
-      });
+      const classifiedError = classifyApiError({ status: response.status, body: lastInitialError });
+      if (activeCredential && classifiedError.category === "rate_limit") {
+        recordRateLimit(activeCredential.label, response.headers);
+      }
+      this.recordHttpRateLimit(
+        response.status,
+        response.headers,
+        {
+          providerId,
+          providerType: providerConfig,
+        },
+        lastInitialError
+      );
 
       if (response.status === 401 && oauth && !attemptedInitialOAuthRefresh) {
         const refreshedToken = await this.refreshProviderAuthorization(headers, {
@@ -3283,7 +3363,6 @@ export abstract class AgentProviderRuntime {
         }
       }
 
-      const classifiedError = classifyApiError({ status: response.status, body: lastInitialError });
       const retryDelayMs = this.providerRetryDelayMs(
         response.status,
         response.headers,
@@ -3294,19 +3373,21 @@ export abstract class AgentProviderRuntime {
         initialRetryCount < INITIAL_MAX_RETRIES &&
         retryDelayMs <= 120_000
       ) {
-        if (response.status === 429 && activeCredential) {
+        if (classifiedError.category === "rate_limit" && activeCredential) {
           markCredentialCooldown(poolName, activeCredential, "rate_limit");
         }
         const rotated =
-          !vertex && !oauth && poolSize(poolName) > 0 ? acquireCredential(poolName) : null;
+          classifiedError.rotateCredential && !vertex && !oauth && poolSize(poolName) > 0
+            ? acquireCredential(poolName)
+            : null;
         if (rotated) {
           activeCredential = rotated;
           currentApiKey = rotated.value;
         }
         initialRetryCount += 1;
         const backoffMs =
-          response.status === 429
-            ? Math.max(msUntilAnyAvailable(poolName), retryDelayMs)
+          classifiedError.category === "rate_limit"
+            ? boundedPoolRetryDelayMs(msUntilAnyAvailable(poolName), retryDelayMs)
             : retryDelayMs;
         console.warn(
           `[Agent] Anthropic transient error ${response.status} on initial call, ` +
@@ -3315,7 +3396,7 @@ export abstract class AgentProviderRuntime {
         this.broadcastAgentStatus(
           "thinking",
           toolContext,
-          response.status === 429
+          classifiedError.category === "rate_limit"
             ? `Provider rate limited; retrying (${initialRetryCount}/${INITIAL_MAX_RETRIES})...`
             : `Provider temporarily unavailable; retrying (${initialRetryCount}/${INITIAL_MAX_RETRIES})...`
         );
@@ -3644,20 +3725,42 @@ export abstract class AgentProviderRuntime {
 
       try {
         while (loopRetryCount <= MAX_RETRIES) {
-          loopResponse = await fetch(`${baseUrl}${anthropicEndpoint}`, {
-            method: "POST",
-            headers,
-            body: JSON.stringify(loopRequestBody),
-            signal: withLlmRequestTimeout(toolContext?.abortSignal),
-          });
+          try {
+            loopResponse = await fetch(`${baseUrl}${anthropicEndpoint}`, {
+              method: "POST",
+              headers,
+              body: JSON.stringify(loopRequestBody),
+              signal: withLlmRequestTimeout(toolContext?.abortSignal),
+            });
+          } catch (error) {
+            const retryDelayMs = providerExceptionRetryDelayMs(
+              error,
+              loopRetryCount,
+              toolContext?.abortSignal
+            );
+            if (retryDelayMs === undefined) throw error;
+            loopRetryCount += 1;
+            this.broadcastAgentStatus(
+              "thinking",
+              toolContext,
+              `Provider connection interrupted; retrying (${loopRetryCount}/${MAX_RETRIES})...`
+            );
+            await this.waitForRetryDelay(retryDelayMs, toolContext?.abortSignal);
+            continue;
+          }
 
           if (loopResponse.ok) break;
 
           lastLoopError = await loopResponse.text();
-          this.recordHttpRateLimit(loopResponse.status, loopResponse.headers, {
-            providerId,
-            providerType: providerConfig,
-          });
+          this.recordHttpRateLimit(
+            loopResponse.status,
+            loopResponse.headers,
+            {
+              providerId,
+              providerType: providerConfig,
+            },
+            lastLoopError
+          );
 
           if (loopResponse.status === 400 && isContextOverflowError(lastLoopError)) {
             compactAnthropicLoopMessagesForContext(
@@ -3679,10 +3782,15 @@ export abstract class AgentProviderRuntime {
             if (!retryResponse.ok) {
               loopFatalError = true;
               lastLoopError = await retryResponse.text();
-              this.recordHttpRateLimit(retryResponse.status, retryResponse.headers, {
-                providerId,
-                providerType: providerConfig,
-              });
+              this.recordHttpRateLimit(
+                retryResponse.status,
+                retryResponse.headers,
+                {
+                  providerId,
+                  providerType: providerConfig,
+                },
+                lastLoopError
+              );
               break;
             }
             loopResponse = retryResponse;
@@ -3728,7 +3836,7 @@ export abstract class AgentProviderRuntime {
             this.broadcastAgentStatus(
               "thinking",
               toolContext,
-              loopResponse.status === 429
+              classifiedError.category === "rate_limit"
                 ? `Provider rate limited; retrying (${loopRetryCount}/${MAX_RETRIES})...`
                 : `Provider temporarily unavailable; retrying (${loopRetryCount}/${MAX_RETRIES})...`
             );
@@ -3807,19 +3915,32 @@ export abstract class AgentProviderRuntime {
         let closingRetryCount = 0;
         let attemptedClosingOAuthRefresh = false;
         while (true) {
-          closingResponse = await fetch(`${baseUrl}${anthropicEndpoint}`, {
-            method: "POST",
-            headers,
-            body: JSON.stringify(closingBody),
-            signal: withLlmRequestTimeout(toolContext?.abortSignal),
-          });
+          try {
+            closingResponse = await fetch(`${baseUrl}${anthropicEndpoint}`, {
+              method: "POST",
+              headers,
+              body: JSON.stringify(closingBody),
+              signal: withLlmRequestTimeout(toolContext?.abortSignal),
+            });
+          } catch (error) {
+            const retryDelayMs = providerExceptionRetryDelayMs(
+              error,
+              closingRetryCount,
+              toolContext?.abortSignal
+            );
+            if (retryDelayMs === undefined) throw error;
+            closingRetryCount += 1;
+            await this.waitForRetryDelay(retryDelayMs, toolContext?.abortSignal);
+            continue;
+          }
           if (closingResponse.ok) break;
           const errorText = await closingResponse.text();
           const rateLimitContext = { providerId, providerType: providerConfig };
           this.recordHttpRateLimit(
             closingResponse.status,
             closingResponse.headers,
-            rateLimitContext
+            rateLimitContext,
+            errorText
           );
           if (
             closingResponse.status === 401 &&

--- a/src/core/agent-provider-runtime.ts
+++ b/src/core/agent-provider-runtime.ts
@@ -1465,6 +1465,7 @@ export abstract class AgentProviderRuntime {
       providerUrl: baseUrl,
       durationMs,
       sessionId: sessionIdForVisibleTokenUsage(toolContext),
+      routerRouteId: toolContext?.routerRouteId,
     });
 
     if (!message) {
@@ -1743,6 +1744,7 @@ export abstract class AgentProviderRuntime {
         providerUrl: baseUrl,
         durationMs: Math.round(performance.now() - loopRequestStartedAt),
         sessionId: sessionIdForVisibleTokenUsage(toolContext),
+        routerRouteId: toolContext?.routerRouteId,
       });
       const loopChoice = loopData.choices?.[0];
       message = loopChoice?.message as OpenAIMessage;
@@ -1793,6 +1795,7 @@ export abstract class AgentProviderRuntime {
           providerUrl: baseUrl,
           durationMs: Math.round(performance.now() - nudgeStartedAt),
           sessionId: sessionIdForVisibleTokenUsage(toolContext),
+          routerRouteId: toolContext?.routerRouteId,
         });
         const nudgeContent = nudgeData.choices?.[0]?.message?.content;
         if (typeof nudgeContent === "string" && nudgeContent.trim()) finalContent = nudgeContent;
@@ -2447,6 +2450,7 @@ export abstract class AgentProviderRuntime {
             cachedInputTokens: turn.usage.cachedInputTokens,
             cacheWriteTokens: turn.usage.cacheWriteTokens,
             firstTokenMs: turn.firstTokenMs ?? durationMs,
+            routerRouteId: toolContext?.routerRouteId,
           }
         );
       }
@@ -2802,6 +2806,7 @@ export abstract class AgentProviderRuntime {
           sessionId: sessionIdForVisibleTokenUsage(toolContext),
           cachedInputTokens: usage.cachedContentTokenCount || 0,
           firstTokenMs: durationMs,
+          routerRouteId: toolContext?.routerRouteId,
         });
       }
 
@@ -3055,6 +3060,7 @@ export abstract class AgentProviderRuntime {
           {
             sessionId: sessionIdForVisibleTokenUsage(toolContext),
             firstTokenMs: durationMs,
+            routerRouteId: toolContext?.routerRouteId,
           }
         );
       }
@@ -3423,6 +3429,7 @@ export abstract class AgentProviderRuntime {
         cachedInputTokens: data.usage.cache_read_input_tokens || 0,
         cacheWriteTokens: data.usage.cache_creation_input_tokens || 0,
         firstTokenMs: durationMs,
+        routerRouteId: toolContext?.routerRouteId,
       });
     }
 
@@ -3885,6 +3892,7 @@ export abstract class AgentProviderRuntime {
             cachedInputTokens: responseData.usage.cache_read_input_tokens || 0,
             cacheWriteTokens: responseData.usage.cache_creation_input_tokens || 0,
             firstTokenMs: Math.round(performance.now() - loopRequestStartedAt),
+            routerRouteId: toolContext?.routerRouteId,
           }
         );
       }
@@ -3987,6 +3995,7 @@ export abstract class AgentProviderRuntime {
                 cachedInputTokens: closingData.usage.cache_read_input_tokens || 0,
                 cacheWriteTokens: closingData.usage.cache_creation_input_tokens || 0,
                 firstTokenMs: Math.round(performance.now() - closingStartedAt),
+                routerRouteId: toolContext?.routerRouteId,
               }
             );
           }
@@ -4094,6 +4103,7 @@ export abstract class AgentProviderRuntime {
       providerUrl: baseUrl,
       durationMs,
       sessionId: sessionIdForVisibleTokenUsage(toolContext),
+      routerRouteId: toolContext?.routerRouteId,
     });
 
     if (!message) {
@@ -4346,6 +4356,7 @@ export abstract class AgentProviderRuntime {
         providerUrl: baseUrl,
         durationMs: Math.round(performance.now() - loopRequestStartedAt),
         sessionId: sessionIdForVisibleTokenUsage(toolContext),
+        routerRouteId: toolContext?.routerRouteId,
       });
       const loopChoice = loopData.choices?.[0];
       message = loopChoice?.message as OpenAIMessage;
@@ -4386,6 +4397,7 @@ export abstract class AgentProviderRuntime {
           providerUrl: baseUrl,
           durationMs: Math.round(performance.now() - closingStartedAt),
           sessionId: sessionIdForVisibleTokenUsage(toolContext),
+          routerRouteId: toolContext?.routerRouteId,
         });
         const closingContent = closingData.choices?.[0]?.message?.content;
         if (typeof closingContent === "string" && closingContent.trim()) {

--- a/src/core/agent-provider-runtime.ts
+++ b/src/core/agent-provider-runtime.ts
@@ -485,6 +485,7 @@ export abstract class AgentProviderRuntime {
     const toolCallId = this.createToolCallStatusId(toolName);
     try {
       const startedAt = Date.now();
+      if (toolContext?.executionState) toolContext.executionState.toolCallsStarted += 1;
       this.broadcastAgentStatus(
         "tool_executing",
         toolContext,

--- a/src/core/agent-provider-runtime.ts
+++ b/src/core/agent-provider-runtime.ts
@@ -78,6 +78,7 @@ import {
   poolSize,
 } from "./credential-pool";
 import type { Agent, Provider, ToolDefinition } from "./database";
+import { classifyApiError } from "./error-classifier";
 import {
   anthropicEndpointPath,
   anthropicRequestBase,
@@ -353,6 +354,47 @@ export abstract class AgentProviderRuntime {
       const timeout = setTimeout(finish, delayMs);
       if (signal?.aborted) abort();
       else signal?.addEventListener("abort", abort, { once: true });
+    });
+  }
+
+  private async refreshOpenAICompatibleAuthorization(
+    headers: Record<string, string>,
+    context?: ProviderRateLimitContext
+  ): Promise<boolean> {
+    const providerId = context?.providerId?.trim();
+    if (!providerId) return false;
+    const authorizationKey = Object.keys(headers).find(
+      (key) => key.toLowerCase() === "authorization"
+    );
+    if (!authorizationKey || !headers[authorizationKey]?.startsWith("Bearer ")) return false;
+    const provider = providerManager.getWithCredentials(providerId);
+    if (!provider?.refresh_token) return false;
+    const refreshed = await providerManager.refreshOAuthCredentialsIfNeeded(provider, {
+      force: true,
+    });
+    const accessToken = refreshed?.access_token?.trim();
+    if (!accessToken) return false;
+    headers[authorizationKey] = `Bearer ${accessToken}`;
+    return true;
+  }
+
+  private openAICompatibleRetryDelayMs(status: number, headers: Headers, attempt: number): number {
+    const fallback = Math.min(1000 * Math.pow(2, attempt), 8000);
+    return status === 429 ? this.parseRetryAfterMs(headers, fallback) : fallback;
+  }
+
+  private broadcastProviderRetryStatus(
+    streamContext: { sessionId?: string | null; agentId?: string | null } | undefined,
+    detail: string
+  ): void {
+    const sessionId = streamContext?.sessionId?.trim();
+    if (!sessionId) return;
+    broadcastStatus({
+      status: "thinking",
+      timestamp: Date.now(),
+      detail,
+      sessionId,
+      agentId: streamContext?.agentId || undefined,
     });
   }
 
@@ -1125,6 +1167,10 @@ export abstract class AgentProviderRuntime {
     let attemptedMaxCompletionRetry = false;
     let attemptedToolChoiceCompatibilityRetry = false;
     let contextRetryCount = 0;
+    let attemptedOAuthRefresh = false;
+    let transientRetryCount = 0;
+    const maxTransientRetries = 3;
+    const maxRetryDelayMs = 120_000;
 
     let attemptedNonStreamingRetry = false;
     while (true) {
@@ -1139,6 +1185,39 @@ export abstract class AgentProviderRuntime {
 
       const errorText = await response.text();
       this.recordHttpRateLimit(response.status, response.headers, rateLimitContext);
+      if (
+        response.status === 401 &&
+        !attemptedOAuthRefresh &&
+        (await this.refreshOpenAICompatibleAuthorization(headers, rateLimitContext))
+      ) {
+        attemptedOAuthRefresh = true;
+        this.broadcastProviderRetryStatus(
+          streamContext,
+          "Provider session refreshed; continuing..."
+        );
+        continue;
+      }
+      const classifiedError = classifyApiError({ status: response.status, body: errorText });
+      const retryDelayMs = this.openAICompatibleRetryDelayMs(
+        response.status,
+        response.headers,
+        transientRetryCount
+      );
+      if (
+        classifiedError.retryable &&
+        transientRetryCount < maxTransientRetries &&
+        retryDelayMs <= maxRetryDelayMs
+      ) {
+        transientRetryCount += 1;
+        this.broadcastProviderRetryStatus(
+          streamContext,
+          response.status === 429
+            ? `Provider rate limited; retrying (${transientRetryCount}/${maxTransientRetries})...`
+            : `Provider temporarily unavailable; retrying (${transientRetryCount}/${maxTransientRetries})...`
+        );
+        await this.waitForRetryDelay(retryDelayMs, signal);
+        continue;
+      }
       if (
         !attemptedNonStreamingRetry &&
         !streamingDisabled &&

--- a/src/core/agent-provider-runtime.ts
+++ b/src/core/agent-provider-runtime.ts
@@ -357,28 +357,28 @@ export abstract class AgentProviderRuntime {
     });
   }
 
-  private async refreshOpenAICompatibleAuthorization(
+  private async refreshProviderAuthorization(
     headers: Record<string, string>,
     context?: ProviderRateLimitContext
-  ): Promise<boolean> {
+  ): Promise<string | undefined> {
     const providerId = context?.providerId?.trim();
-    if (!providerId) return false;
+    if (!providerId) return undefined;
     const authorizationKey = Object.keys(headers).find(
       (key) => key.toLowerCase() === "authorization"
     );
-    if (!authorizationKey || !headers[authorizationKey]?.startsWith("Bearer ")) return false;
+    if (!authorizationKey || !headers[authorizationKey]?.startsWith("Bearer ")) return undefined;
     const provider = providerManager.getWithCredentials(providerId);
-    if (!provider?.refresh_token) return false;
+    if (!provider?.refresh_token) return undefined;
     const refreshed = await providerManager.refreshOAuthCredentialsIfNeeded(provider, {
       force: true,
     });
     const accessToken = refreshed?.access_token?.trim();
-    if (!accessToken) return false;
+    if (!accessToken) return undefined;
     headers[authorizationKey] = `Bearer ${accessToken}`;
-    return true;
+    return accessToken;
   }
 
-  private openAICompatibleRetryDelayMs(status: number, headers: Headers, attempt: number): number {
+  private providerRetryDelayMs(status: number, headers: Headers, attempt: number): number {
     const fallback = Math.min(1000 * Math.pow(2, attempt), 8000);
     return status === 429 ? this.parseRetryAfterMs(headers, fallback) : fallback;
   }
@@ -1188,7 +1188,7 @@ export abstract class AgentProviderRuntime {
       if (
         response.status === 401 &&
         !attemptedOAuthRefresh &&
-        (await this.refreshOpenAICompatibleAuthorization(headers, rateLimitContext))
+        (await this.refreshProviderAuthorization(headers, rateLimitContext))
       ) {
         attemptedOAuthRefresh = true;
         this.broadcastProviderRetryStatus(
@@ -1198,7 +1198,7 @@ export abstract class AgentProviderRuntime {
         continue;
       }
       const classifiedError = classifyApiError({ status: response.status, body: errorText });
-      const retryDelayMs = this.openAICompatibleRetryDelayMs(
+      const retryDelayMs = this.providerRetryDelayMs(
         response.status,
         response.headers,
         transientRetryCount
@@ -2136,99 +2136,91 @@ export abstract class AgentProviderRuntime {
     for (let index = 0; index < candidates.length; index++) {
       const candidate = candidates[index];
       const body = { ...requestBody, model: candidate };
-      const watchdog = createStreamWatchdog({
-        ...resolveLlmWatchdogDefaults(url),
-        callerSignal: signal,
-        label: transport === "grok" ? "Grok Build" : "Codex",
-      });
-      let response: Response;
-      const requestStartedAt = performance.now();
-      try {
-        response = await fetch(url, {
-          method: "POST",
-          headers,
-          body: JSON.stringify(body),
-          signal: watchdog.signal,
+      let attemptedOAuthRefresh = false;
+      let transientRetryCount = 0;
+
+      while (true) {
+        const watchdog = createStreamWatchdog({
+          ...resolveLlmWatchdogDefaults(url),
+          callerSignal: signal,
+          label: transport === "grok" ? "Grok Build" : "Codex",
         });
-      } catch (error) {
-        watchdog.dispose();
-        throw watchdog.wrapError(error);
-      }
-
-      if (!response.ok) {
-        watchdog.dispose();
-        const errorText = await response.text();
-        this.recordHttpRateLimit(response.status, response.headers, rateLimitContext);
-        finalError = `API error: ${response.status} - ${errorText}`;
-        if (transport === "grok" && response.status === 429 && index === 0) {
-          const retryAfterMs = this.parseRetryAfterMs(response.headers, 2_000);
-          await this.waitForRetryDelay(retryAfterMs, signal);
-          const retryWatchdog = createStreamWatchdog({
-            ...resolveLlmWatchdogDefaults(url),
-            callerSignal: signal,
-            label: "Grok Build",
+        let response: Response;
+        const requestStartedAt = performance.now();
+        try {
+          response = await fetch(url, {
+            method: "POST",
+            headers,
+            body: JSON.stringify(body),
+            signal: watchdog.signal,
           });
-          const retryStartedAt = performance.now();
-          let retryResponse: Response;
-          try {
-            retryResponse = await fetch(url, {
-              method: "POST",
-              headers,
-              body: JSON.stringify(body),
-              signal: retryWatchdog.signal,
-            });
-          } catch (error) {
-            retryWatchdog.dispose();
-            throw retryWatchdog.wrapError(error);
-          }
-          if (!retryResponse.ok) {
-            retryWatchdog.dispose();
-            const retryErrorText = await retryResponse.text();
-            this.recordHttpRateLimit(retryResponse.status, retryResponse.headers, rateLimitContext);
-            throw new Error(`API error: ${retryResponse.status} - ${retryErrorText}`);
-          }
-          try {
-            const parsed = await this.parseOpenAICodexTurnResponse(
-              retryResponse,
-              sessionId,
-              agentId,
-              retryWatchdog,
-              retryStartedAt
-            );
-            retryWatchdog.dispose();
-            return { ...parsed, resolvedModel: candidate };
-          } catch (error) {
-            retryWatchdog.dispose();
-            throw retryWatchdog.wrapError(error);
-          }
+        } catch (error) {
+          watchdog.dispose();
+          throw watchdog.wrapError(error);
         }
-        if (
-          transport === "codex" &&
-          index < candidates.length - 1 &&
-          shouldRetryOpenAICodexModel(response.status, errorText)
-        ) {
-          console.warn(
-            `[Agent] OpenAI Codex model ${candidate} unavailable, retrying with ${candidates[index + 1]}`
-          );
-          continue;
-        }
-        throw new Error(finalError);
-      }
 
-      try {
-        watchdog.touch();
-        const parsed = await this.parseOpenAICodexTurnResponse(
-          response,
-          sessionId,
-          agentId,
-          watchdog,
-          requestStartedAt
-        );
-        watchdog.dispose();
-        return { ...parsed, resolvedModel: candidate };
-      } catch (error) {
-        watchdog.dispose();
-        throw watchdog.wrapError(error);
+        if (!response.ok) {
+          watchdog.dispose();
+          const errorText = await response.text();
+          this.recordHttpRateLimit(response.status, response.headers, rateLimitContext);
+          finalError = `API error: ${response.status} - ${errorText}`;
+          if (
+            response.status === 401 &&
+            !attemptedOAuthRefresh &&
+            (await this.refreshProviderAuthorization(headers, rateLimitContext))
+          ) {
+            attemptedOAuthRefresh = true;
+            this.broadcastProviderRetryStatus(
+              { sessionId, agentId },
+              "Provider session refreshed; continuing..."
+            );
+            continue;
+          }
+          const classifiedError = classifyApiError({ status: response.status, body: errorText });
+          const retryDelayMs = this.providerRetryDelayMs(
+            response.status,
+            response.headers,
+            transientRetryCount
+          );
+          if (classifiedError.retryable && transientRetryCount < 3 && retryDelayMs <= 120_000) {
+            transientRetryCount += 1;
+            this.broadcastProviderRetryStatus(
+              { sessionId, agentId },
+              response.status === 429
+                ? `Provider rate limited; retrying (${transientRetryCount}/3)...`
+                : `Provider temporarily unavailable; retrying (${transientRetryCount}/3)...`
+            );
+            await this.waitForRetryDelay(retryDelayMs, signal);
+            continue;
+          }
+          if (
+            transport === "codex" &&
+            index < candidates.length - 1 &&
+            shouldRetryOpenAICodexModel(response.status, errorText)
+          ) {
+            console.warn(
+              `[Agent] OpenAI Codex model ${candidate} unavailable, retrying with ${candidates[index + 1]}`
+            );
+            break;
+          }
+          throw new Error(finalError);
+        }
+
+        try {
+          watchdog.touch();
+          const parsed = await this.parseOpenAICodexTurnResponse(
+            response,
+            sessionId,
+            agentId,
+            watchdog,
+            requestStartedAt
+          );
+          watchdog.dispose();
+          return { ...parsed, resolvedModel: candidate };
+        } catch (error) {
+          watchdog.dispose();
+          throw watchdog.wrapError(error);
+        }
       }
     }
 
@@ -2625,7 +2617,7 @@ export abstract class AgentProviderRuntime {
       return { role, parts: [{ text: message.content }] };
     });
 
-    const headers = vertex
+    const headers: Record<string, string> = vertex
       ? {
           "Content-Type": "application/json",
           Authorization: `Bearer ${auth.trim()}`,
@@ -2695,19 +2687,53 @@ export abstract class AgentProviderRuntime {
       }
 
       const startTime = performance.now();
-      const response = await fetch(endpoint, {
-        method: "POST",
-        headers,
-        body: JSON.stringify(requestBody),
-        signal: withLlmRequestTimeout(toolContext?.abortSignal),
-      });
-
-      if (!response.ok) {
-        const errorText = await response.text();
-        this.recordHttpRateLimit(response.status, response.headers, {
-          providerId,
-          providerType: providerConfig,
+      let response: Response | null = null;
+      let transientRetryCount = 0;
+      let attemptedOAuthRefresh = false;
+      while (true) {
+        response = await fetch(endpoint, {
+          method: "POST",
+          headers,
+          body: JSON.stringify(requestBody),
+          signal: withLlmRequestTimeout(toolContext?.abortSignal),
         });
+
+        if (response.ok) break;
+
+        const errorText = await response.text();
+        const rateLimitContext = { providerId, providerType: providerConfig };
+        this.recordHttpRateLimit(response.status, response.headers, rateLimitContext);
+        if (
+          response.status === 401 &&
+          !attemptedOAuthRefresh &&
+          (await this.refreshProviderAuthorization(headers, rateLimitContext))
+        ) {
+          attemptedOAuthRefresh = true;
+          this.broadcastAgentStatus(
+            "thinking",
+            toolContext,
+            "Provider session refreshed; continuing..."
+          );
+          continue;
+        }
+        const classifiedError = classifyApiError({ status: response.status, body: errorText });
+        const retryDelayMs = this.providerRetryDelayMs(
+          response.status,
+          response.headers,
+          transientRetryCount
+        );
+        if (classifiedError.retryable && transientRetryCount < 3 && retryDelayMs <= 120_000) {
+          transientRetryCount += 1;
+          this.broadcastAgentStatus(
+            "thinking",
+            toolContext,
+            response.status === 429
+              ? `Provider rate limited; retrying (${transientRetryCount}/3)...`
+              : `Provider temporarily unavailable; retrying (${transientRetryCount}/3)...`
+          );
+          await this.waitForRetryDelay(retryDelayMs, toolContext?.abortSignal);
+          continue;
+        }
         throw new Error(`API error: ${response.status} - ${errorText}`);
       }
 
@@ -3179,7 +3205,7 @@ export abstract class AgentProviderRuntime {
       requestBody.tool_choice = { type: "auto" };
     }
 
-    const oauth = providerConfig === "anthropic-oauth";
+    const oauth = providerCatalog[providerConfig as ProviderType]?.authType === "oauth";
     const headers: Record<string, string> = anthropicRequestHeaders(auth, vertex, oauth);
 
     if (!vertex && modelParams?.context1m === true) {
@@ -3202,16 +3228,17 @@ export abstract class AgentProviderRuntime {
     requestBody.messages = cached.messages;
 
     const startTime = performance.now();
-    const INITIAL_TRANSIENT_CODES = new Set([429, 500, 502, 503, 520, 529]);
     const INITIAL_MAX_RETRIES = 3;
     let response: Response | null = null;
     let lastInitialError = "";
+    let initialRetryCount = 0;
+    let attemptedInitialOAuthRefresh = false;
     const poolName = "anthropic";
     let activeCredential: PooledCredential | null =
       !vertex && !oauth && poolSize(poolName) > 0 ? acquireCredential(poolName) : null;
     let currentApiKey = activeCredential?.value ?? auth;
 
-    for (let attempt = 0; attempt <= INITIAL_MAX_RETRIES; attempt++) {
+    while (initialRetryCount <= INITIAL_MAX_RETRIES) {
       if (vertex) {
         headers.Authorization = `Bearer ${currentApiKey}`;
       } else if (oauth) {
@@ -3239,7 +3266,34 @@ export abstract class AgentProviderRuntime {
         providerType: providerConfig,
       });
 
-      if (INITIAL_TRANSIENT_CODES.has(response.status) && attempt < INITIAL_MAX_RETRIES) {
+      if (response.status === 401 && oauth && !attemptedInitialOAuthRefresh) {
+        const refreshedToken = await this.refreshProviderAuthorization(headers, {
+          providerId,
+          providerType: providerConfig,
+        });
+        if (refreshedToken) {
+          attemptedInitialOAuthRefresh = true;
+          currentApiKey = refreshedToken;
+          this.broadcastAgentStatus(
+            "thinking",
+            toolContext,
+            "Provider session refreshed; continuing..."
+          );
+          continue;
+        }
+      }
+
+      const classifiedError = classifyApiError({ status: response.status, body: lastInitialError });
+      const retryDelayMs = this.providerRetryDelayMs(
+        response.status,
+        response.headers,
+        initialRetryCount
+      );
+      if (
+        classifiedError.retryable &&
+        initialRetryCount < INITIAL_MAX_RETRIES &&
+        retryDelayMs <= 120_000
+      ) {
         if (response.status === 429 && activeCredential) {
           markCredentialCooldown(poolName, activeCredential, "rate_limit");
         }
@@ -3249,15 +3303,23 @@ export abstract class AgentProviderRuntime {
           activeCredential = rotated;
           currentApiKey = rotated.value;
         }
+        initialRetryCount += 1;
         const backoffMs =
           response.status === 429
-            ? Math.max(msUntilAnyAvailable(poolName), Math.min(1000 * Math.pow(2, attempt), 8000))
-            : Math.min(1000 * Math.pow(2, attempt), 8000);
+            ? Math.max(msUntilAnyAvailable(poolName), retryDelayMs)
+            : retryDelayMs;
         console.warn(
           `[Agent] Anthropic transient error ${response.status} on initial call, ` +
-            `retrying in ${backoffMs}ms (attempt ${attempt + 1}/${INITIAL_MAX_RETRIES})...`
+            `retrying in ${backoffMs}ms (attempt ${initialRetryCount}/${INITIAL_MAX_RETRIES})...`
         );
-        await new Promise((resolve) => setTimeout(resolve, backoffMs));
+        this.broadcastAgentStatus(
+          "thinking",
+          toolContext,
+          response.status === 429
+            ? `Provider rate limited; retrying (${initialRetryCount}/${INITIAL_MAX_RETRIES})...`
+            : `Provider temporarily unavailable; retrying (${initialRetryCount}/${INITIAL_MAX_RETRIES})...`
+        );
+        await this.waitForRetryDelay(backoffMs, toolContext?.abortSignal);
         continue;
       }
 
@@ -3572,15 +3634,16 @@ export abstract class AgentProviderRuntime {
       if (loopCached.system !== undefined) loopRequestBody.system = loopCached.system;
       loopRequestBody.messages = loopCached.messages;
 
-      const TRANSIENT_STATUS_CODES = new Set([429, 500, 502, 503, 520, 529]);
       const MAX_RETRIES = 3;
       let loopResponse: Response | null = null;
       let lastLoopError = "";
       let loopFatalError = false;
+      let loopRetryCount = 0;
+      let attemptedLoopOAuthRefresh = false;
       const loopRequestStartedAt = performance.now();
 
       try {
-        for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+        while (loopRetryCount <= MAX_RETRIES) {
           loopResponse = await fetch(`${baseUrl}${anthropicEndpoint}`, {
             method: "POST",
             headers,
@@ -3626,16 +3689,50 @@ export abstract class AgentProviderRuntime {
             break;
           }
 
-          if (TRANSIENT_STATUS_CODES.has(loopResponse.status) && attempt < MAX_RETRIES) {
-            const backoffMs =
-              loopResponse.status === 429
-                ? Math.min(this.parseRetryAfterMs(loopResponse.headers), 120_000)
-                : Math.min(1000 * Math.pow(2, attempt), 8000);
+          if (loopResponse.status === 401 && oauth && !attemptedLoopOAuthRefresh) {
+            const refreshedToken = await this.refreshProviderAuthorization(headers, {
+              providerId,
+              providerType: providerConfig,
+            });
+            if (refreshedToken) {
+              attemptedLoopOAuthRefresh = true;
+              currentApiKey = refreshedToken;
+              this.broadcastAgentStatus(
+                "thinking",
+                toolContext,
+                "Provider session refreshed; continuing..."
+              );
+              continue;
+            }
+          }
+
+          const classifiedError = classifyApiError({
+            status: loopResponse.status,
+            body: lastLoopError,
+          });
+          const retryDelayMs = this.providerRetryDelayMs(
+            loopResponse.status,
+            loopResponse.headers,
+            loopRetryCount
+          );
+          if (
+            classifiedError.retryable &&
+            loopRetryCount < MAX_RETRIES &&
+            retryDelayMs <= 120_000
+          ) {
+            loopRetryCount += 1;
             console.warn(
               `[Agent] Anthropic transient error ${loopResponse.status} on iteration ${iterations}, ` +
-                `retrying in ${backoffMs}ms (attempt ${attempt + 1}/${MAX_RETRIES})...`
+                `retrying in ${retryDelayMs}ms (attempt ${loopRetryCount}/${MAX_RETRIES})...`
             );
-            await new Promise((resolve) => setTimeout(resolve, backoffMs));
+            this.broadcastAgentStatus(
+              "thinking",
+              toolContext,
+              loopResponse.status === 429
+                ? `Provider rate limited; retrying (${loopRetryCount}/${MAX_RETRIES})...`
+                : `Provider temporarily unavailable; retrying (${loopRetryCount}/${MAX_RETRIES})...`
+            );
+            await this.waitForRetryDelay(retryDelayMs, toolContext?.abortSignal);
             continue;
           }
 
@@ -3706,12 +3803,54 @@ export abstract class AgentProviderRuntime {
           closingBody.system = systemMessage.content;
         }
         const closingStartedAt = performance.now();
-        const closingResponse = await fetch(`${baseUrl}${anthropicEndpoint}`, {
-          method: "POST",
-          headers,
-          body: JSON.stringify(closingBody),
-          signal: withLlmRequestTimeout(toolContext?.abortSignal),
-        });
+        let closingResponse: Response | null = null;
+        let closingRetryCount = 0;
+        let attemptedClosingOAuthRefresh = false;
+        while (true) {
+          closingResponse = await fetch(`${baseUrl}${anthropicEndpoint}`, {
+            method: "POST",
+            headers,
+            body: JSON.stringify(closingBody),
+            signal: withLlmRequestTimeout(toolContext?.abortSignal),
+          });
+          if (closingResponse.ok) break;
+          const errorText = await closingResponse.text();
+          const rateLimitContext = { providerId, providerType: providerConfig };
+          this.recordHttpRateLimit(
+            closingResponse.status,
+            closingResponse.headers,
+            rateLimitContext
+          );
+          if (
+            closingResponse.status === 401 &&
+            oauth &&
+            !attemptedClosingOAuthRefresh &&
+            (await this.refreshProviderAuthorization(headers, rateLimitContext))
+          ) {
+            attemptedClosingOAuthRefresh = true;
+            this.broadcastAgentStatus(
+              "thinking",
+              toolContext,
+              "Provider session refreshed; continuing..."
+            );
+            continue;
+          }
+          const classifiedError = classifyApiError({
+            status: closingResponse.status,
+            body: errorText,
+          });
+          const retryDelayMs = this.providerRetryDelayMs(
+            closingResponse.status,
+            closingResponse.headers,
+            closingRetryCount
+          );
+          if (classifiedError.retryable && closingRetryCount < 3 && retryDelayMs <= 120_000) {
+            closingRetryCount += 1;
+            await this.waitForRetryDelay(retryDelayMs, toolContext?.abortSignal);
+            continue;
+          }
+          throw new Error(`API error: ${closingResponse.status} - ${errorText}`);
+        }
         if (closingResponse.ok) {
           const closingData = (await closingResponse.json()) as AnthropicResponse;
           if (closingData.usage) {

--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -376,7 +376,7 @@ class AgentManager extends AgentProviderRuntime {
     persistIfResolved = false
   ): ReturnType<typeof providerManager.getWithCredentials> {
     return this.resolveProviderExecutionTarget(agent, {
-      useRouter: false,
+      useRouter: true,
       persistIfResolved,
     })?.provider;
   }
@@ -845,7 +845,7 @@ class AgentManager extends AgentProviderRuntime {
     const { agent, messages } = state;
 
     const target = this.resolveProviderExecutionTarget(agent, {
-      useRouter: false,
+      useRouter: true,
       persistIfResolved: true,
     });
     if (!target) {
@@ -862,6 +862,7 @@ class AgentManager extends AgentProviderRuntime {
       tools = this.getAgentTools(agent);
     }
     const toolContext = this.buildToolExecutionContext(agent);
+    toolContext.routerRouteId = target.routeId;
 
     const routedModel = target.routeId ? getRouterRouteModel(target.routeId) : undefined;
     const selectedModel =
@@ -897,7 +898,7 @@ class AgentManager extends AgentProviderRuntime {
               activeModel,
               fullMessages,
               tools,
-              toolContext
+              { ...toolContext, routerRouteId: undefined }
             );
             return {
               response: fallbackResult.content,
@@ -1052,6 +1053,7 @@ class AgentManager extends AgentProviderRuntime {
     }
 
     const toolContext = this.buildToolExecutionContext(agent, options);
+    toolContext.routerRouteId = target.routeId;
 
     const routerActive = options?.useModelRouter === true && !!provider;
     const routedToDifferentProvider = routerActive && provider!.id !== agent.provider_id;
@@ -1098,7 +1100,7 @@ class AgentManager extends AgentProviderRuntime {
               activeModel,
               workspaceAwareMessages,
               tools,
-              toolContext
+              { ...toolContext, routerRouteId: undefined }
             );
             if (options?.abortSignal?.aborted) throw options.abortSignal.reason;
             return fallbackResult;

--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -325,16 +325,16 @@ class AgentManager extends AgentProviderRuntime {
     agent: Pick<Agent, "id" | "provider_id" | "config">,
     options: { useRouter: boolean; persistIfResolved: boolean }
   ): ProviderExecutionTarget | undefined {
-    if (options.useRouter && isModelRouterEnabled()) {
-      const routeId = selectProvider();
-      const routed = routeId ? providerManager.resolveExecutionTarget(routeId) : undefined;
-      if (routed && routeId) return { ...routed, routeId };
-    }
-
     const poolId = this.agentProviderPoolId(agent);
     if (poolId) {
       const provider = providerManager.getAccountPoolPrimary(poolId);
-      return provider ? { provider, poolId } : undefined;
+      if (provider) return { provider, poolId };
+    }
+
+    if (options.useRouter && isModelRouterEnabled()) {
+      const routeId = selectProvider(agent.provider_id);
+      const routed = routeId ? providerManager.resolveExecutionTarget(routeId) : undefined;
+      if (routed && routeId) return { ...routed, routeId };
     }
 
     let resolvedProvider =
@@ -376,7 +376,7 @@ class AgentManager extends AgentProviderRuntime {
     persistIfResolved = false
   ): ReturnType<typeof providerManager.getWithCredentials> {
     return this.resolveProviderExecutionTarget(agent, {
-      useRouter: true,
+      useRouter: false,
       persistIfResolved,
     })?.provider;
   }
@@ -578,6 +578,9 @@ class AgentManager extends AgentProviderRuntime {
     const poolProviderId = requestedPool?.accounts[0]?.providerId;
     const providerSelectionChanged =
       updates.provider_id !== undefined || updates.provider !== undefined;
+    if (providerSelectionChanged && !poolSelectionChanged) {
+      delete updatedConfig.provider_account_pool_id;
+    }
     const resolvedProviderId =
       poolProviderId ||
       (providerSelectionChanged
@@ -842,7 +845,7 @@ class AgentManager extends AgentProviderRuntime {
     const { agent, messages } = state;
 
     const target = this.resolveProviderExecutionTarget(agent, {
-      useRouter: isModelRouterEnabled(),
+      useRouter: false,
       persistIfResolved: true,
     });
     if (!target) {

--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -25,6 +25,7 @@ import {
 import {
   getRouterRouteModel,
   selectProvider,
+  isModelRouterEnabled,
   isMixtureOfAgentsRoutingActive,
   getMixtureOfAgentsRoutingConfig,
 } from "./router";
@@ -50,6 +51,14 @@ import { loadAllSkills, createEligibilityContext, filterEligibleSkills } from ".
 import { resolveAgentToolPolicy } from "./toolsets";
 import { formatLlmFailure } from "./agent-error-format";
 import { resolveModelContextWindowTokens } from "./agent-model-limits";
+import { classifyApiError, type ClassifiedApiError } from "./error-classifier";
+import {
+  getProviderAccountPool,
+  markProviderAccountHealthy,
+  markProviderAccountUnavailable,
+  parseProviderAccountPoolRouteId,
+  type ProviderAccountFailure,
+} from "./provider-account-pool";
 
 export { resolveAgentToolSelection } from "./agent-tool-selection";
 
@@ -68,6 +77,7 @@ export interface AgentDefinition {
   model?: string;
   provider_id?: string;
   provider?: string;
+  provider_pool_id?: string;
   fallback_provider_id?: string;
   fallback_provider?: string;
   system_prompt?: string;
@@ -162,6 +172,20 @@ interface RunningAgentState {
   lastActive: Date;
 }
 
+type ResolvedProvider = NonNullable<ReturnType<typeof providerManager.getWithCredentials>>;
+
+interface ProviderExecutionTarget {
+  provider: ResolvedProvider;
+  poolId?: string;
+  routeId?: string;
+}
+
+interface AgentProviderResult {
+  content: string;
+  thinking?: string;
+  tool_calls?: AgentToolCallResult[];
+}
+
 class AgentManager extends AgentProviderRuntime {
   private runningAgents: Map<string, RunningAgentState> = new Map();
 
@@ -227,25 +251,90 @@ class AgentManager extends AgentProviderRuntime {
     return supported ? agentModel : getDefaultModel(provider.provider);
   }
 
-  private resolveProviderForAgent(
-    agent: Pick<Agent, "id" | "provider_id" | "config">,
-    persistIfResolved = false
-  ): ReturnType<typeof providerManager.getWithCredentials> {
-    const routerSelected = selectProvider(agent.provider_id);
-    if (routerSelected) {
-      const routedProviderId = providerManager.resolveProviderId(routerSelected);
-      const routedProvider = routedProviderId
-        ? providerManager.getWithCredentials(routedProviderId)
-        : undefined;
-      if (routedProvider) {
-        if (persistIfResolved && agent.provider_id !== routedProvider.id) {
-          this.update(agent.id, { provider_id: routedProvider.id });
-          if ("provider_id" in agent) {
-            agent.provider_id = routedProvider.id;
+  private providerAccountFailure(error: ClassifiedApiError): ProviderAccountFailure | undefined {
+    if (error.category === "auth") return "auth";
+    if (error.category === "billing") return "billing";
+    if (error.category === "rate_limit") return "rate_limit";
+    return undefined;
+  }
+
+  private async callLLMWithAccountPool(
+    primary: ResolvedProvider,
+    poolId: string | undefined,
+    model: string | undefined,
+    messages: AgentMessage[],
+    tools: ToolDefinition[],
+    toolContext?: ToolContext
+  ): Promise<AgentProviderResult> {
+    const candidates = await providerManager.getAccountPoolCandidates(primary.id, poolId);
+    if (candidates.length === 0) {
+      throw new Error(`All ${primary.provider} accounts are cooling down or unavailable.`);
+    }
+
+    let lastError: unknown;
+    for (const candidate of candidates) {
+      const toolCallsBefore = toolContext?.executionState?.toolCallsStarted ?? 0;
+      try {
+        const result = await this.callLLM(candidate, model, messages, tools, toolContext);
+        markProviderAccountHealthy(candidate.id);
+        return result;
+      } catch (error) {
+        lastError = error;
+        let classified = classifyApiError({ error });
+        let failure = this.providerAccountFailure(classified);
+        if (!failure || (toolContext?.executionState?.toolCallsStarted ?? 0) > toolCallsBefore) {
+          throw error;
+        }
+
+        if (failure === "auth" && candidate.refresh_token) {
+          const refreshed = await providerManager.refreshOAuthCredentialsIfNeeded(candidate, {
+            force: true,
+          });
+          if (refreshed) {
+            try {
+              const result = await this.callLLM(refreshed, model, messages, tools, toolContext);
+              markProviderAccountHealthy(candidate.id);
+              return result;
+            } catch (refreshError) {
+              lastError = refreshError;
+              classified = classifyApiError({ error: refreshError });
+              failure = this.providerAccountFailure(classified);
+              if (
+                !failure ||
+                (toolContext?.executionState?.toolCallsStarted ?? 0) > toolCallsBefore
+              ) {
+                throw refreshError;
+              }
+            }
           }
         }
-        return routedProvider;
+
+        markProviderAccountUnavailable(candidate.id, failure);
       }
+    }
+
+    throw lastError ?? new Error(`All ${primary.provider} accounts are unavailable.`);
+  }
+
+  private agentProviderPoolId(agent: Pick<Agent, "config">): string | undefined {
+    const value = parseAgentConfig(agent.config).provider_account_pool_id;
+    return typeof value === "string" && value.trim() ? value.trim() : undefined;
+  }
+
+  private resolveProviderExecutionTarget(
+    agent: Pick<Agent, "id" | "provider_id" | "config">,
+    options: { useRouter: boolean; persistIfResolved: boolean }
+  ): ProviderExecutionTarget | undefined {
+    if (options.useRouter && isModelRouterEnabled()) {
+      const routeId = selectProvider();
+      const routed = routeId ? providerManager.resolveExecutionTarget(routeId) : undefined;
+      if (routed && routeId) return { ...routed, routeId };
+    }
+
+    const poolId = this.agentProviderPoolId(agent);
+    if (poolId) {
+      const provider = providerManager.getAccountPoolPrimary(poolId);
+      return provider ? { provider, poolId } : undefined;
     }
 
     let resolvedProvider =
@@ -253,7 +342,7 @@ class AgentManager extends AgentProviderRuntime {
         ? providerManager.getWithCredentials(agent.provider_id)
         : undefined;
 
-    if (resolvedProvider) return resolvedProvider;
+    if (resolvedProvider) return { provider: resolvedProvider };
 
     const config = parseAgentConfig(agent.config, agent.id);
     const configProviderInput =
@@ -272,25 +361,40 @@ class AgentManager extends AgentProviderRuntime {
     resolvedProvider = providerManager.getWithCredentials(resolvedProviderId);
     if (!resolvedProvider) return undefined;
 
-    if (persistIfResolved && agent.provider_id !== resolvedProviderId) {
+    if (options.persistIfResolved && agent.provider_id !== resolvedProviderId) {
       this.update(agent.id, { provider_id: resolvedProviderId });
       if ("provider_id" in agent) {
         agent.provider_id = resolvedProviderId;
       }
     }
 
-    return resolvedProvider;
+    return { provider: resolvedProvider };
+  }
+
+  private resolveProviderForAgent(
+    agent: Pick<Agent, "id" | "provider_id" | "config">,
+    persistIfResolved = false
+  ): ReturnType<typeof providerManager.getWithCredentials> {
+    return this.resolveProviderExecutionTarget(agent, {
+      useRouter: true,
+      persistIfResolved,
+    })?.provider;
   }
 
   resolveProvider(id: string): ReturnType<typeof providerManager.getWithCredentials> {
     const agent = this.get(id);
     if (!agent) return undefined;
-    return this.resolveProviderForAgent(agent, true);
+    return this.resolveProviderExecutionTarget(agent, {
+      useRouter: false,
+      persistIfResolved: true,
+    })?.provider;
   }
 
   list(): (Agent & {
     provider?: string;
     provider_type?: string;
+    provider_pool_id?: string;
+    provider_pool_name?: string;
     providerInfo?: { name: string };
     typeConfig?: typeof AGENT_TYPES.main;
   })[] {
@@ -300,6 +404,8 @@ class AgentManager extends AgentProviderRuntime {
     );
     return all.map((a) => {
       const provider = a.provider_id ? providersById.get(a.provider_id) : undefined;
+      const providerPoolId = this.agentProviderPoolId(a);
+      const providerPool = providerPoolId ? getProviderAccountPool(providerPoolId) : undefined;
       const typeConfig = a.type ? AGENT_TYPES[a.type as keyof typeof AGENT_TYPES] : undefined;
       const status = this.runningAgents.has(a.id) ? "running" : "stopped";
       return {
@@ -307,6 +413,8 @@ class AgentManager extends AgentProviderRuntime {
         status,
         provider: a.provider_id,
         provider_type: provider?.provider,
+        provider_pool_id: providerPoolId,
+        provider_pool_name: providerPool?.name,
         providerInfo: provider ? { name: provider.name } : undefined,
         typeConfig,
       };
@@ -317,6 +425,8 @@ class AgentManager extends AgentProviderRuntime {
     | (Agent & {
         provider?: string;
         provider_type?: string;
+        provider_pool_id?: string;
+        provider_pool_name?: string;
         typeConfig?: typeof AGENT_TYPES.main;
       })
     | undefined {
@@ -324,6 +434,8 @@ class AgentManager extends AgentProviderRuntime {
     if (!agent) return undefined;
     const typeConfig = agent.type ? AGENT_TYPES[agent.type as keyof typeof AGENT_TYPES] : undefined;
     const status = this.runningAgents.has(agent.id) ? "running" : "stopped";
+    const providerPoolId = this.agentProviderPoolId(agent);
+    const providerPool = providerPoolId ? getProviderAccountPool(providerPoolId) : undefined;
     return {
       ...agent,
       status,
@@ -331,6 +443,8 @@ class AgentManager extends AgentProviderRuntime {
       provider_type: agent.provider_id
         ? providerManager.get(agent.provider_id)?.provider
         : undefined,
+      provider_pool_id: providerPoolId,
+      provider_pool_name: providerPool?.name,
       typeConfig,
     };
   }
@@ -350,8 +464,19 @@ class AgentManager extends AgentProviderRuntime {
     const systemPrompt =
       definition.system_prompt || typeConfig?.systemPrompt || AGENT_TYPE_PROMPTS.main;
 
+    const agentConfig = { ...(definition.config || {}) };
+    const requestedPoolId =
+      typeof definition.provider_pool_id === "string" ? definition.provider_pool_id.trim() : "";
+    const requestedPool = requestedPoolId ? getProviderAccountPool(requestedPoolId) : undefined;
+    if (requestedPoolId && (!requestedPool?.enabled || requestedPool.accounts.length === 0)) {
+      throw new Error("Validation error: Provider account pool is unavailable");
+    }
+    if (requestedPool) agentConfig.provider_account_pool_id = requestedPool.id;
+    const poolProviderId = requestedPool?.accounts[0]?.providerId;
     const resolvedProviderId =
+      providerManager.resolveProviderId(poolProviderId) ||
       providerManager.resolveProviderId(definition.provider_id || definition.provider) ||
+      poolProviderId ||
       definition.provider_id;
     const resolvedFallbackProviderId =
       providerManager.resolveProviderId(
@@ -367,7 +492,7 @@ class AgentManager extends AgentProviderRuntime {
       fallback_provider_id: resolvedFallbackProviderId,
       system_prompt: systemPrompt,
       tools: definition.tools ?? getBuiltinTools(),
-      config: definition.config || {},
+      config: agentConfig,
       status: "stopped",
       memory_enabled: definition.memory_enabled || false,
     };
@@ -433,12 +558,33 @@ class AgentManager extends AgentProviderRuntime {
       resolvedModel = resolveModelAlias(resolvedModel, undefined);
     }
 
+    const existingConfig = parseAgentConfig(existing.config, id);
+    const updatedConfig = updates.config ? { ...updates.config } : { ...existingConfig };
+    const poolSelectionChanged = updates.provider_pool_id !== undefined;
+    const requestedPoolId =
+      typeof updates.provider_pool_id === "string" ? updates.provider_pool_id.trim() : "";
+    const requestedPool = requestedPoolId ? getProviderAccountPool(requestedPoolId) : undefined;
+    if (
+      poolSelectionChanged &&
+      requestedPoolId &&
+      (!requestedPool?.enabled || requestedPool.accounts.length === 0)
+    ) {
+      throw new Error("Validation error: Provider account pool is unavailable");
+    }
+    if (poolSelectionChanged) {
+      if (requestedPool) updatedConfig.provider_account_pool_id = requestedPool.id;
+      else delete updatedConfig.provider_account_pool_id;
+    }
+    const poolProviderId = requestedPool?.accounts[0]?.providerId;
+    const providerSelectionChanged =
+      updates.provider_id !== undefined || updates.provider !== undefined;
     const resolvedProviderId =
-      updates.provider_id !== undefined || updates.provider !== undefined
+      poolProviderId ||
+      (providerSelectionChanged
         ? providerManager.resolveProviderId(
             (updates.provider_id as string | undefined) || (updates.provider as string | undefined)
           )
-        : undefined;
+        : undefined);
     const resolvedFallbackProviderId =
       updates.fallback_provider_id !== undefined || updates.fallback_provider !== undefined
         ? providerManager.resolveProviderId(
@@ -452,7 +598,7 @@ class AgentManager extends AgentProviderRuntime {
       type: updates.type || existing.type,
       model: resolvedModel || existing.model,
       provider_id:
-        updates.provider_id !== undefined || updates.provider !== undefined
+        providerSelectionChanged || poolSelectionChanged
           ? (resolvedProviderId ?? existing.provider_id)
           : existing.provider_id,
       fallback_provider_id:
@@ -464,7 +610,7 @@ class AgentManager extends AgentProviderRuntime {
       tools: updates.tools || existing.tools,
       memory_enabled:
         updates.memory_enabled !== undefined ? updates.memory_enabled : existing.memory_enabled,
-      config: updates.config || parseAgentConfig(existing.config, id),
+      config: updatedConfig,
     };
 
     tables.agents.update(id, updated);
@@ -695,10 +841,14 @@ class AgentManager extends AgentProviderRuntime {
   ): Promise<{ response: string; thinking?: string }> {
     const { agent, messages } = state;
 
-    const provider = this.resolveProviderForAgent(agent, true);
-    if (!provider) {
+    const target = this.resolveProviderExecutionTarget(agent, {
+      useRouter: isModelRouterEnabled(),
+      persistIfResolved: true,
+    });
+    if (!target) {
       return { response: this.generateFallbackResponse(messages) };
     }
+    const provider = target.provider;
 
     const fullMessages = await this.injectMemoryRecall(messages, agent);
 
@@ -708,13 +858,28 @@ class AgentManager extends AgentProviderRuntime {
     if (supportsTools) {
       tools = this.getAgentTools(agent);
     }
+    const toolContext = this.buildToolExecutionContext(agent);
 
-    const resolvedExecution = this.resolveProviderModelForExecution(provider, agent.model);
+    const routedModel = target.routeId ? getRouterRouteModel(target.routeId) : undefined;
+    const selectedModel =
+      routedModel ||
+      (target.routeId && provider.id !== agent.provider_id
+        ? this.resolveModelForRoutedProvider(provider, agent.model)
+        : agent.model);
+    const resolvedExecution = this.resolveProviderModelForExecution(provider, selectedModel);
     const activeProvider = resolvedExecution.provider;
     const activeModel = resolvedExecution.model;
+    const activePoolId = activeProvider.provider === provider.provider ? target.poolId : undefined;
 
     try {
-      const result = await this.callLLM(activeProvider, activeModel, fullMessages, tools);
+      const result = await this.callLLMWithAccountPool(
+        activeProvider,
+        activePoolId,
+        activeModel,
+        fullMessages,
+        tools,
+        toolContext
+      );
       return { response: result.content, thinking: result.thinking };
     } catch (error) {
       console.error("[Agent] LLM call failed:", error);
@@ -723,11 +888,13 @@ class AgentManager extends AgentProviderRuntime {
         const fallbackProvider = providerManager.getWithCredentials(agent.fallback_provider_id);
         if (fallbackProvider) {
           try {
-            const fallbackResult = await this.callLLM(
+            const fallbackResult = await this.callLLMWithAccountPool(
               fallbackProvider,
+              undefined,
               activeModel,
               fullMessages,
-              tools
+              tools,
+              toolContext
             );
             return {
               response: fallbackResult.content,
@@ -835,12 +1002,14 @@ class AgentManager extends AgentProviderRuntime {
       throw new Error("Agent not found");
     }
 
-    let provider = options?.useModelRouter
-      ? this.resolveProviderForAgent({ ...agent, provider_id: undefined }, false)
-      : this.resolveProviderForAgent(agent, true);
-    if (!provider) {
+    const target = this.resolveProviderExecutionTarget(agent, {
+      useRouter: options?.useModelRouter === true,
+      persistIfResolved: options?.useModelRouter !== true,
+    });
+    if (!target) {
       return { content: this.generateFallbackResponse(messages) };
     }
+    let provider = target.provider;
 
     const hasSystemMessage = messages.some((message) => message.role === "system");
     const fallbackSystemPrompt =
@@ -883,9 +1052,8 @@ class AgentManager extends AgentProviderRuntime {
 
     const routerActive = options?.useModelRouter === true && !!provider;
     const routedToDifferentProvider = routerActive && provider!.id !== agent.provider_id;
-    const routedModel = routerActive
-      ? (getRouterRouteModel(provider!.id) ?? getRouterRouteModel(provider!.provider))
-      : undefined;
+    const routedModel =
+      routerActive && target.routeId ? getRouterRouteModel(target.routeId) : undefined;
     const overrideModel =
       typeof options?.modelOverride === "string" && options.modelOverride.trim().length > 0
         ? options.modelOverride.trim()
@@ -900,10 +1068,12 @@ class AgentManager extends AgentProviderRuntime {
     const resolvedExecution = this.resolveProviderModelForExecution(provider, selectedModel);
     const activeProvider = resolvedExecution.provider;
     const activeModel = resolvedExecution.model;
+    const activePoolId = activeProvider.provider === provider.provider ? target.poolId : undefined;
 
     try {
-      const result = await this.callLLM(
+      const result = await this.callLLMWithAccountPool(
         activeProvider,
+        activePoolId,
         activeModel,
         workspaceAwareMessages,
         tools,
@@ -919,8 +1089,9 @@ class AgentManager extends AgentProviderRuntime {
         const fallbackProvider = providerManager.getWithCredentials(agent.fallback_provider_id);
         if (fallbackProvider) {
           try {
-            const fallbackResult = await this.callLLM(
+            const fallbackResult = await this.callLLMWithAccountPool(
               fallbackProvider,
+              undefined,
               activeModel,
               workspaceAwareMessages,
               tools,
@@ -993,6 +1164,7 @@ class AgentManager extends AgentProviderRuntime {
       confineToWorkspace:
         typeof options?.workspaceDir === "string" && options.workspaceDir.trim().length > 0,
       consumeSteeringMessages: options?.consumeSteeringMessages,
+      executionState: { toolCallsStarted: 0 },
     };
   }
 

--- a/src/core/error-classifier.ts
+++ b/src/core/error-classifier.ts
@@ -76,6 +76,21 @@ export function classifyApiError(input: {
       message,
     };
   }
+  if (
+    (status === 429 || status === 529) &&
+    /temporarily overloaded|service (?:is )?overloaded|overloaded.{0,80}(?:retry|try again)|["']?code["']?\s*[:=]\s*1305/.test(
+      text
+    )
+  ) {
+    return {
+      category: "overloaded",
+      retryable: true,
+      rotateCredential: false,
+      reduceContext: false,
+      status,
+      message,
+    };
+  }
   // Rate limit
   if (status === 429 || /rate.?limit|too many requests|429/.test(text)) {
     return {

--- a/src/core/llm/openai-response-usage.ts
+++ b/src/core/llm/openai-response-usage.ts
@@ -7,6 +7,7 @@ export interface OpenAIResponseUsageContext {
   providerUrl: string;
   durationMs: number;
   sessionId?: string;
+  routerRouteId?: string;
 }
 
 export function trackOpenAIResponseUsage(
@@ -30,6 +31,7 @@ export function trackOpenAIResponseUsage(
         0,
       cacheWriteTokens: response.usage.cache_creation_input_tokens || 0,
       firstTokenMs: response.first_token_ms ?? context.durationMs,
+      routerRouteId: context.routerRouteId,
     }
   );
   return true;

--- a/src/core/llm/reasoning.ts
+++ b/src/core/llm/reasoning.ts
@@ -40,7 +40,13 @@ const ADAPTIVE_THINKING_PROVIDERS = new Set([
   "minimax-portal",
   "minimax-portal-cn",
 ]);
-const KIMI_CODE_PROVIDERS = new Set(["kimi-code", "kimi-code-oauth", "kimi-coding", "kimi-oauth"]);
+const KIMI_CODE_PROVIDERS = new Set([
+  "kimi-code",
+  "kimi-code-oauth",
+  "kimi-coding",
+  "kimi-oauth",
+  "kimi-code-subscription",
+]);
 
 const GPT_5_EFFORTS: ReasoningEffort[] = ["minimal", "low", "medium", "high"];
 const GPT_51_EFFORTS: ReasoningEffort[] = ["low", "medium", "high"];

--- a/src/core/llm/session-token-usage.ts
+++ b/src/core/llm/session-token-usage.ts
@@ -93,6 +93,7 @@ export function trackEstimatedSessionTokenUsage(input: LlmUsageFallbackInput): b
   trackTokenUsage(model, provider, providerUrl, inputTokens, outputTokens, input.durationMs, {
     sessionId,
     firstTokenMs: input.durationMs,
+    routerRouteId: input.toolContext?.routerRouteId,
   });
   if (getSessionTokenUsageSnapshot(sessionId).totalTokens <= input.before.totalTokens) {
     addSessionTokenUsageRow({

--- a/src/core/llm/token-usage-tracking.ts
+++ b/src/core/llm/token-usage-tracking.ts
@@ -19,11 +19,18 @@ export function trackTokenUsage(
     cachedInputTokens?: number;
     cacheWriteTokens?: number;
     firstTokenMs?: number;
+    routerRouteId?: string;
   }
 ): void {
   try {
-    // ── Feed the model router's usage tracking + circuit breaker ──
-    recordUsage(provider, inputTokens, outputTokens, true, model);
+    recordUsage(
+      options?.routerRouteId ?? provider,
+      inputTokens,
+      outputTokens,
+      true,
+      model,
+      provider
+    );
   } catch {
     /* router tracking is best-effort */
   }
@@ -49,6 +56,7 @@ export function trackTokenUsage(
       cachedInputTokens,
       cacheWriteTokens,
       firstTokenMs,
+      routerRouteId: options?.routerRouteId,
       sessionId:
         typeof options?.sessionId === "string" && options.sessionId.trim()
           ? options.sessionId.trim()
@@ -71,6 +79,16 @@ export function trackTokenUsage(
       value: totalTokens,
       metadata: serializeMetricMetadata({ ...tokenMetadata, url: providerUrl }),
     });
+
+    if (options?.routerRouteId && options.routerRouteId !== provider) {
+      tables.metrics.add({
+        id: crypto.randomUUID(),
+        type: "token_usage_by_provider",
+        key: options.routerRouteId,
+        value: totalTokens,
+        metadata: serializeMetricMetadata({ ...tokenMetadata, url: providerUrl }),
+      });
+    }
 
     if (typeof tokenMetadata.sessionId === "string") {
       tables.metrics.add({

--- a/src/core/mcp-registry.ts
+++ b/src/core/mcp-registry.ts
@@ -11,11 +11,12 @@ export interface MCPRegistryServer {
   args?: string;
   url?: string;
   envVars?: string[];
+  envDefaults?: Record<string, string>;
   author?: string;
   stars?: number;
   categories?: string[];
   homepage?: string;
-  installType: "bunx" | "bun" | "smithery" | "remote";
+  installType: "bunx" | "bun" | "smithery" | "remote" | "uvx";
 }
 
 interface RegistryConfig {
@@ -110,6 +111,23 @@ const POPULAR_SERVERS: MCPRegistryServer[] = [
     args: "--bun @modelcontextprotocol/server-puppeteer",
     categories: ["browser", "automation"],
     installType: "bunx",
+  },
+  {
+    id: "mcp-blender",
+    name: "Blender",
+    description:
+      "Create and inspect Blender scenes through a community MCP server. Requires uvx and the Blender add-on.",
+    registry: "mcp.so",
+    package: "blender-mcp",
+    command: "uvx",
+    args: "--python 3.11 blender-mcp",
+    envDefaults: {
+      DISABLE_TELEMETRY: "true",
+      UV_PYTHON_PREFERENCE: "only-managed",
+    },
+    categories: ["3d", "creative", "blender"],
+    homepage: "https://github.com/ahujasid/blender-mcp",
+    installType: "uvx",
   },
   {
     id: "mcp-brave-search",
@@ -375,7 +393,10 @@ class MCPRegistryManager {
       url.searchParams.set("q", query);
       url.searchParams.set("pageSize", "20");
       const res = await fetch(url, {
-        headers: { Authorization: `Bearer ${apiKey}`, Accept: "application/json" },
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          Accept: "application/json",
+        },
         signal: AbortSignal.timeout(5000),
       });
       if (!res.ok) return [];
@@ -491,12 +512,19 @@ class MCPRegistryManager {
     try {
       const fullCommand = server.command;
       const fullArgs = server.args || "";
+      const defaultEnvironment = Object.entries(server.envDefaults ?? {});
+      const environmentVariables = (server.envVars ?? [])
+        .filter((key) => !Object.hasOwn(server.envDefaults ?? {}, key))
+        .map((key): [string, string] => [key, ""]);
+      const environment = [...defaultEnvironment, ...environmentVariables]
+        .map(([key, value]) => `${key}=${value}`)
+        .join(",");
 
       const created = mcpManager.create({
         name: server.name,
         command: fullCommand,
         args: fullArgs,
-        env: server.envVars?.map((v) => `${v}=`).join(",") || undefined,
+        env: environment || undefined,
         url: server.url,
         enabled: true,
       });

--- a/src/core/plugins/index.ts
+++ b/src/core/plugins/index.ts
@@ -46,10 +46,14 @@ function getBundledPluginsRoot(): string {
   const isCompiledBinary = !process.execPath.endsWith("bun") && !process.execPath.includes("/bun");
   if (isCompiledBinary) {
     const execDir = dirname(process.execPath);
-    const repoPlugins = resolve(execDir, "..", "plugins");
-    const sidePlugins = join(execDir, "plugins");
-    if (existsSync(repoPlugins)) return repoPlugins;
-    if (existsSync(sidePlugins)) return sidePlugins;
+    const candidates = [
+      join(execDir, "plugins"),
+      resolve(execDir, "..", "plugins"),
+      resolve(execDir, "..", "..", "Resources", "sidecar", "plugins"),
+    ];
+    for (const candidate of candidates) {
+      if (existsSync(candidate)) return candidate;
+    }
     return join(getCybaraHomeDir(), "bundled-plugins");
   }
   return resolve(__dirname, "../../../plugins");

--- a/src/core/provider-account-pool.ts
+++ b/src/core/provider-account-pool.ts
@@ -1,5 +1,6 @@
 import { config } from "./config";
-import type { Provider } from "./database";
+import { tables, type Agent, type Provider } from "./database";
+import { parseAgentConfig } from "./agent-internals";
 import type { LiveProviderUsage } from "./provider-usage-source";
 
 export type ProviderAccountFailure = "auth" | "billing" | "rate_limit";
@@ -101,6 +102,17 @@ function saveProviderAccountPools(pools: ProviderAccountPool[]): void {
   config.set(STORAGE_KEY, pools);
 }
 
+function detachPoolsFromAgents(poolIds: ReadonlySet<string>): void {
+  if (poolIds.size === 0) return;
+  for (const agent of tables.agents.all() as Agent[]) {
+    const agentConfig = parseAgentConfig(agent.config, agent.id);
+    const poolId = agentConfig.provider_account_pool_id;
+    if (typeof poolId !== "string" || !poolIds.has(poolId)) continue;
+    delete agentConfig.provider_account_pool_id;
+    tables.agents.update(agent.id, { ...agent, config: agentConfig });
+  }
+}
+
 function normalizedPoolInput(
   input: ProviderAccountPoolInput,
   providers: readonly Provider[],
@@ -180,6 +192,7 @@ export function deleteProviderAccountPool(id: string): boolean {
   const next = pools.filter((pool) => pool.id !== id);
   if (next.length === pools.length) return false;
   saveProviderAccountPools(next);
+  detachPoolsFromAgents(new Set([id]));
   return true;
 }
 
@@ -189,7 +202,13 @@ export function removeProviderFromAccountPools(providerId: string): void {
     const accounts = pool.accounts.filter((account) => account.providerId !== providerId);
     return accounts.length > 0 ? [{ ...pool, accounts }] : [];
   });
-  if (JSON.stringify(next) !== JSON.stringify(pools)) saveProviderAccountPools(next);
+  if (JSON.stringify(next) !== JSON.stringify(pools)) {
+    saveProviderAccountPools(next);
+    const retainedIds = new Set(next.map((pool) => pool.id));
+    detachPoolsFromAgents(
+      new Set(pools.filter((pool) => !retainedIds.has(pool.id)).map((pool) => pool.id))
+    );
+  }
   cooldownUntil.delete(providerId);
 }
 

--- a/src/core/provider-account-pool.ts
+++ b/src/core/provider-account-pool.ts
@@ -1,0 +1,281 @@
+import { config } from "./config";
+import type { Provider } from "./database";
+import type { LiveProviderUsage } from "./provider-usage-source";
+
+export type ProviderAccountFailure = "auth" | "billing" | "rate_limit";
+
+export interface ProviderAccountPoolMember {
+  providerId: string;
+  priority?: number;
+}
+
+export interface ProviderAccountPool {
+  id: string;
+  name: string;
+  provider: string;
+  enabled: boolean;
+  accounts: ProviderAccountPoolMember[];
+}
+
+export interface ProviderAccountPoolInput {
+  name: string;
+  provider: string;
+  enabled?: boolean;
+  accounts: Array<{ providerId: string; priority?: number }>;
+}
+
+const STORAGE_KEY = "provider_account_pools";
+const ROUTE_PREFIX = "pool:";
+const cooldownUntil = new Map<string, number>();
+
+const COOLDOWN_MS: Record<ProviderAccountFailure, number> = {
+  auth: 5 * 60 * 1000,
+  billing: 24 * 60 * 60 * 1000,
+  rate_limit: 60 * 60 * 1000,
+};
+
+function boundedPriority(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  return Math.max(0, Math.min(10_000, Math.round(value)));
+}
+
+function normalizeStoredPool(value: unknown): ProviderAccountPool | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const record = value as Record<string, unknown>;
+  const id = typeof record.id === "string" ? record.id.trim() : "";
+  const name = typeof record.name === "string" ? record.name.trim().slice(0, 80) : "";
+  const provider = typeof record.provider === "string" ? record.provider.trim() : "";
+  if (!id || !name || !provider || !Array.isArray(record.accounts)) return undefined;
+  let accounts: ProviderAccountPoolMember[] = record.accounts.flatMap((entry) => {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) return [];
+    const account = entry as Record<string, unknown>;
+    const providerId =
+      typeof account.providerId === "string"
+        ? account.providerId.trim()
+        : typeof account.provider_id === "string"
+          ? account.provider_id.trim()
+          : "";
+    return providerId ? [{ providerId, priority: boundedPriority(account.priority) }] : [];
+  });
+  if (accounts.length > 0 && accounts.every((account) => account.priority === 100)) {
+    accounts = accounts.map((account) => ({ providerId: account.providerId }));
+  }
+  return {
+    id,
+    name,
+    provider,
+    enabled: record.enabled !== false,
+    accounts,
+  };
+}
+
+export function listProviderAccountPools(): ProviderAccountPool[] {
+  const stored = config.get<unknown>(STORAGE_KEY);
+  if (!Array.isArray(stored)) return [];
+  return stored.flatMap((entry) => {
+    const pool = normalizeStoredPool(entry);
+    return pool ? [pool] : [];
+  });
+}
+
+export function getProviderAccountPool(id: string): ProviderAccountPool | undefined {
+  return listProviderAccountPools().find((pool) => pool.id === id);
+}
+
+export function providerAccountPoolRouteId(id: string): string {
+  return `${ROUTE_PREFIX}${id}`;
+}
+
+export function parseProviderAccountPoolRouteId(value: string | undefined): string | undefined {
+  if (typeof value !== "string" || !value.startsWith(ROUTE_PREFIX)) return undefined;
+  const id = value.slice(ROUTE_PREFIX.length).trim();
+  return id || undefined;
+}
+
+export function providerAccountPoolRouteProvider(value: string | undefined): string | undefined {
+  const id = parseProviderAccountPoolRouteId(value);
+  return id ? getProviderAccountPool(id)?.provider : undefined;
+}
+
+function saveProviderAccountPools(pools: ProviderAccountPool[]): void {
+  config.set(STORAGE_KEY, pools);
+}
+
+function normalizedPoolInput(
+  input: ProviderAccountPoolInput,
+  providers: readonly Provider[],
+  existingId?: string
+): Omit<ProviderAccountPool, "id"> {
+  const name = typeof input.name === "string" ? input.name.trim().slice(0, 80) : "";
+  const provider = typeof input.provider === "string" ? input.provider.trim() : "";
+  if (!name) throw new Error("Validation error: Pool name is required");
+  if (!provider) throw new Error("Validation error: Pool provider is required");
+  if (!Array.isArray(input.accounts) || input.accounts.length === 0) {
+    throw new Error("Validation error: Select at least one provider account");
+  }
+  const providersById = new Map(providers.map((entry) => [entry.id, entry]));
+  const seen = new Set<string>();
+  const accounts = input.accounts.map((entry) => {
+    const providerId = typeof entry.providerId === "string" ? entry.providerId.trim() : "";
+    const account = providersById.get(providerId);
+    if (!account || account.provider !== provider) {
+      throw new Error("Validation error: Pool accounts must use the selected provider type");
+    }
+    if (seen.has(providerId)) throw new Error("Validation error: Pool accounts must be unique");
+    seen.add(providerId);
+    const priority = boundedPriority(entry.priority);
+    return priority === undefined ? { providerId } : { providerId, priority };
+  });
+  const occupied = new Set(
+    listProviderAccountPools()
+      .filter((pool) => pool.id !== existingId)
+      .flatMap((pool) => pool.accounts.map((account) => account.providerId))
+  );
+  if (accounts.some((account) => occupied.has(account.providerId))) {
+    throw new Error("Validation error: A provider account can belong to only one pool");
+  }
+  if (accounts.some((account) => account.priority !== undefined)) {
+    accounts.sort((left, right) => {
+      if (left.priority === undefined) return 1;
+      if (right.priority === undefined) return -1;
+      return left.priority - right.priority || left.providerId.localeCompare(right.providerId);
+    });
+  }
+  return {
+    name,
+    provider,
+    enabled: input.enabled !== false,
+    accounts,
+  };
+}
+
+export function createProviderAccountPool(
+  input: ProviderAccountPoolInput,
+  providers: readonly Provider[]
+): ProviderAccountPool {
+  const pool = {
+    id: crypto.randomUUID(),
+    ...normalizedPoolInput(input, providers),
+  };
+  saveProviderAccountPools([...listProviderAccountPools(), pool]);
+  return pool;
+}
+
+export function updateProviderAccountPool(
+  id: string,
+  input: ProviderAccountPoolInput,
+  providers: readonly Provider[]
+): ProviderAccountPool | undefined {
+  const pools = listProviderAccountPools();
+  const index = pools.findIndex((pool) => pool.id === id);
+  if (index < 0) return undefined;
+  const pool = { id, ...normalizedPoolInput(input, providers, id) };
+  pools[index] = pool;
+  saveProviderAccountPools(pools);
+  return pool;
+}
+
+export function deleteProviderAccountPool(id: string): boolean {
+  const pools = listProviderAccountPools();
+  const next = pools.filter((pool) => pool.id !== id);
+  if (next.length === pools.length) return false;
+  saveProviderAccountPools(next);
+  return true;
+}
+
+export function removeProviderFromAccountPools(providerId: string): void {
+  const pools = listProviderAccountPools();
+  const next = pools.flatMap((pool) => {
+    const accounts = pool.accounts.filter((account) => account.providerId !== providerId);
+    return accounts.length > 0 ? [{ ...pool, accounts }] : [];
+  });
+  if (JSON.stringify(next) !== JSON.stringify(pools)) saveProviderAccountPools(next);
+  cooldownUntil.delete(providerId);
+}
+
+function isAvailable(providerId: string, now: number): boolean {
+  const until = cooldownUntil.get(providerId) ?? 0;
+  if (until <= now) {
+    cooldownUntil.delete(providerId);
+    return true;
+  }
+  return false;
+}
+
+export function providerAccountPoolCandidates(
+  poolId: string | undefined,
+  primary: Provider,
+  providers: readonly Provider[],
+  now = Date.now(),
+  remainingByProviderId: ReadonlyMap<string, number> = new Map()
+): Provider[] {
+  if (!poolId) return [primary];
+  const pool = getProviderAccountPool(poolId);
+  if (!pool?.enabled || pool.provider !== primary.provider) return [];
+  const providersById = new Map(providers.map((provider) => [provider.id, provider]));
+  return pool.accounts
+    .flatMap((member, index) => {
+      const provider = providersById.get(member.providerId);
+      return provider && provider.provider === pool.provider && isAvailable(provider.id, now)
+        ? [{ provider, member, index }]
+        : [];
+    })
+    .sort((left, right) => {
+      const leftPriority = left.member.priority;
+      const rightPriority = right.member.priority;
+      if (leftPriority !== undefined || rightPriority !== undefined) {
+        if (leftPriority === undefined) return 1;
+        if (rightPriority === undefined) return -1;
+        if (leftPriority !== rightPriority) return leftPriority - rightPriority;
+      }
+      const leftRemaining = remainingByProviderId.get(left.provider.id);
+      const rightRemaining = remainingByProviderId.get(right.provider.id);
+      if (leftRemaining !== undefined || rightRemaining !== undefined) {
+        if (leftRemaining === undefined) return 1;
+        if (rightRemaining === undefined) return -1;
+        if (leftRemaining !== rightRemaining) return rightRemaining - leftRemaining;
+      }
+      return left.index - right.index;
+    })
+    .map((entry) => entry.provider);
+}
+
+export function providerAccountRemainingPercent(
+  usage: LiveProviderUsage | null
+): number | undefined {
+  if (!usage) return undefined;
+  const windows = [usage.fiveHour, usage.weekly, usage.monthly].filter(
+    (window): window is NonNullable<typeof window> => Boolean(window)
+  );
+  if (windows.length === 0) return undefined;
+  const limited = windows.filter((window) => window.unlimited !== true);
+  if (limited.length === 0) return 100;
+  return Math.min(...limited.map((window) => Math.max(0, Math.min(100, 100 - window.usedPercent))));
+}
+
+export function markProviderAccountUnavailable(
+  providerId: string,
+  failure: ProviderAccountFailure,
+  now = Date.now()
+): void {
+  cooldownUntil.set(providerId, now + COOLDOWN_MS[failure]);
+}
+
+export function markProviderAccountHealthy(providerId: string): void {
+  cooldownUntil.delete(providerId);
+}
+
+export function providerAccountCooldownUntil(providerId: string): number | undefined {
+  const until = cooldownUntil.get(providerId);
+  if (until === undefined) return undefined;
+  if (until <= Date.now()) {
+    cooldownUntil.delete(providerId);
+    return undefined;
+  }
+  return until;
+}
+
+export function resetProviderAccountPoolsForTests(): void {
+  cooldownUntil.clear();
+  config.set(STORAGE_KEY, []);
+}

--- a/src/core/provider-plans.ts
+++ b/src/core/provider-plans.ts
@@ -982,7 +982,10 @@ function resolveStatus(
   const warning = providerConfig.warningThresholdPct ?? globalWarning;
   const worst = windows.reduce((max, window) => Math.max(max, window.usedPercent ?? 0), 0);
   if (worst >= hardStop) {
-    return { status: "exhausted", reason: `Plan usage reached ${Math.round(worst)}%` };
+    return {
+      status: "exhausted",
+      reason: `Plan usage reached ${Math.round(worst)}%`,
+    };
   }
   if (worst >= warning) {
     return { status: "warning", reason: `Plan usage is ${Math.round(worst)}%` };
@@ -1156,12 +1159,20 @@ export function getProviderPlanSnapshot(
   const windows =
     configuredWindows.length > 0 || !managedAutomatically
       ? configuredWindows
-      : [buildAutomaticUsageWindow({ usedTokens: localTokens30d, usedSpend: localSpend30d })];
+      : [
+          buildAutomaticUsageWindow({
+            usedTokens: localTokens30d,
+            usedSpend: localSpend30d,
+          }),
+        ];
 
   const resolved = !monitored
     ? { status: "disabled" as const, reason: "Provider is not monitored" }
     : managedAutomatically && !providerConfig
-      ? { status: "ok" as const, reason: "Automatic provider-plan tracking active" }
+      ? {
+          status: "ok" as const,
+          reason: "Automatic provider-plan tracking active",
+        }
       : resolveStatus(windows, providerConfig, cfg.warningThresholdPct);
 
   return {
@@ -1316,14 +1327,21 @@ function liveUsageWindow(
   id: string,
   title: string,
   kind: ProviderPlanWindowKind,
-  live: { usedPercent: number; resetsAt?: string; unlimited?: boolean } | undefined,
+  live:
+    | {
+        usedPercent: number;
+        resetsAt?: string;
+        unlimited?: boolean;
+        title?: string;
+      }
+    | undefined,
   resetDescription: string
 ): ProviderPlanUsageWindow | null {
   if (!live) return base ?? null;
   const resetsAt = live.resetsAt ?? base?.resetsAt;
   return {
     id,
-    title,
+    title: live.title ?? title,
     kind,
     usedTokens: base?.usedTokens ?? 0,
     tokenLimit: base?.tokenLimit,

--- a/src/core/provider-plans.ts
+++ b/src/core/provider-plans.ts
@@ -1,5 +1,6 @@
 import { config } from "./config";
 import { tables, type Provider } from "./database";
+import { providerAccountPoolRouteProvider } from "./provider-account-pool";
 import { providerManager, providers, resolveProviderType, type ProviderType } from "./providers";
 import { fetchLiveProviderUsage, type LiveProviderUsage } from "./provider-usage-source";
 
@@ -703,7 +704,8 @@ function configuredProviderForRoute(
     context?.providerById.get(routeKey) ??
     (!context ? (tables.providers.get(routeKey) as Provider | undefined) : undefined);
   if (direct) return direct;
-  const resolvedType = resolveProviderType(routeKey) ?? routeKey;
+  const resolvedType =
+    providerAccountPoolRouteProvider(routeKey) ?? resolveProviderType(routeKey) ?? routeKey;
   if (context) return context.firstProviderByType.get(resolvedType);
   return (tables.providers.all() as Provider[]).find(
     (provider) => provider.provider === resolvedType || providerTypeOf(provider) === resolvedType
@@ -713,20 +715,24 @@ function configuredProviderForRoute(
 function planConfigFor(
   cfg: ProviderPlanMonitoringConfig,
   providerId: string,
-  providerType: string
+  providerType: string,
+  routeKey?: string
 ): ProviderPlanProviderConfig | undefined {
-  const byId = cfg.providers[providerId];
-  const byType = cfg.providers[providerType];
-  if (byId && byType && byId !== byType) {
-    return {
-      ...byType,
-      ...byId,
-      fiveHour: byId.fiveHour ?? byType.fiveHour,
-      weekly: byId.weekly ?? byType.weekly,
-      monthly: byId.monthly ?? byType.monthly,
-    };
+  let merged: ProviderPlanProviderConfig | undefined;
+  for (const key of new Set([providerType, providerId, routeKey].filter(Boolean) as string[])) {
+    const current = cfg.providers[key];
+    if (!current) continue;
+    merged = merged
+      ? {
+          ...merged,
+          ...current,
+          fiveHour: current.fiveHour ?? merged.fiveHour,
+          weekly: current.weekly ?? merged.weekly,
+          monthly: current.monthly ?? merged.monthly,
+        }
+      : current;
   }
-  return byId ?? byType;
+  return merged;
 }
 
 function hasWindowLimit(windowConfig?: ProviderPlanWindowConfig): boolean {
@@ -1016,6 +1022,10 @@ function buildProviderPlanEvaluationContext(
     const month = monthWindow(now, providerConfig?.billingCycleAnchorDay ?? 1);
     metricStarts.add(month.startMs);
   }
+  for (const providerConfig of Object.values(cfg.providers)) {
+    const month = monthWindow(now, providerConfig.billingCycleAnchorDay ?? 1);
+    metricStarts.add(month.startMs);
+  }
   return {
     cfg,
     providerById,
@@ -1045,18 +1055,23 @@ function providerMetricKeys(params: {
   providerName: string;
   configuredProviderType?: string;
 }): Set<string> {
+  const explicitRouteConfig = Boolean(params.cfg.providers[params.routeKey]);
   const explicitProviderIdConfig = Boolean(params.cfg.providers[params.providerId]);
   const explicitProviderTypeConfig = Boolean(params.cfg.providers[params.providerType]);
   const keyCandidates =
-    explicitProviderIdConfig && !explicitProviderTypeConfig
-      ? [params.routeKey, params.providerId, params.providerName]
-      : [
-          params.routeKey,
-          params.providerId,
-          params.providerType,
-          params.configuredProviderType,
-          params.providerName,
-        ];
+    explicitRouteConfig &&
+    params.routeKey !== params.providerId &&
+    params.routeKey !== params.providerType
+      ? [params.routeKey]
+      : explicitProviderIdConfig && !explicitProviderTypeConfig
+        ? [params.routeKey, params.providerId, params.providerName]
+        : [
+            params.routeKey,
+            params.providerId,
+            params.providerType,
+            params.configuredProviderType,
+            params.providerName,
+          ];
   return new Set(keyCandidates.filter(Boolean) as string[]);
 }
 
@@ -1067,12 +1082,12 @@ export function hasProviderPlanRouteConstraints(routeKeys: string[]): boolean {
     const configured = configuredProviderForRoute(routeKey);
     const providerType = configured
       ? providerTypeOf(configured)
-      : (resolveProviderType(routeKey) ?? routeKey);
+      : (providerAccountPoolRouteProvider(routeKey) ?? resolveProviderType(routeKey) ?? routeKey);
     const staticInfo = providers[providerType as ProviderType];
     const authType = staticInfo?.authType ?? "unknown";
     if (!isPlanCapableProvider(providerType, authType)) continue;
     const providerId = configured?.id ?? routeKey;
-    if (hasProviderPlanLimits(planConfigFor(cfg, providerId, providerType))) return true;
+    if (hasProviderPlanLimits(planConfigFor(cfg, providerId, providerType, routeKey))) return true;
   }
   return false;
 }
@@ -1216,12 +1231,12 @@ export function getProviderPlanRouteConstraint(
   const configuredProvider = configuredProviderForRoute(routeKey, context);
   const providerType = configuredProvider
     ? providerTypeOf(configuredProvider)
-    : (resolveProviderType(routeKey) ?? routeKey);
+    : (providerAccountPoolRouteProvider(routeKey) ?? resolveProviderType(routeKey) ?? routeKey);
   const staticInfo = providers[providerType as ProviderType];
   const authType = staticInfo?.authType ?? "unknown";
   const providerId = configuredProvider?.id ?? routeKey;
   const providerName = configuredProvider?.name || staticInfo?.name || routeKey;
-  const providerConfig = planConfigFor(cfg, providerId, providerType);
+  const providerConfig = planConfigFor(cfg, providerId, providerType, routeKey);
   const monitored = cfg.enabled && isPlanCapableProvider(providerType, authType);
 
   if (!monitored) {

--- a/src/core/provider-retry.ts
+++ b/src/core/provider-retry.ts
@@ -1,0 +1,56 @@
+import { classifyApiError } from "./error-classifier";
+
+const MAX_RETRY_DELAY_MS = 120_000;
+
+function finiteNonNegative(value: string | null): number | undefined {
+  if (value === null || !/^\d+(?:\.\d+)?$/.test(value.trim())) return undefined;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined;
+}
+
+export function parseProviderRetryAfterMs(
+  headers: Headers,
+  fallbackMs: number,
+  nowMs = Date.now()
+): number {
+  const milliseconds = finiteNonNegative(headers.get("retry-after-ms"));
+  if (milliseconds !== undefined) return Math.floor(milliseconds);
+
+  const raw = headers.get("retry-after")?.trim();
+  const seconds = finiteNonNegative(raw ?? null);
+  if (seconds !== undefined) return Math.floor(seconds * 1000);
+  if (raw) {
+    const dateMs = Date.parse(raw);
+    if (Number.isFinite(dateMs)) return Math.max(0, dateMs - nowMs);
+  }
+  return Math.max(0, Math.floor(fallbackMs));
+}
+
+export function providerRetryDelayMs(
+  status: number,
+  headers: Headers,
+  attempt: number,
+  random: () => number = Math.random
+): number {
+  const fallbackMs = Math.min(1000 * 2 ** Math.max(0, attempt), 8000);
+  const baseMs = status === 429 ? parseProviderRetryAfterMs(headers, fallbackMs) : fallbackMs;
+  if (baseMs <= 0 || baseMs >= MAX_RETRY_DELAY_MS) return baseMs;
+  const jitterRangeMs = Math.min(250, Math.ceil(baseMs * 0.2));
+  return Math.ceil(baseMs + Math.max(0, Math.min(1, random())) * jitterRangeMs);
+}
+
+export function providerExceptionRetryDelayMs(
+  error: unknown,
+  attempt: number,
+  signal?: AbortSignal,
+  random: () => number = Math.random
+): number | undefined {
+  if (signal?.aborted) return undefined;
+  const classified = classifyApiError({ error });
+  if (!classified.retryable || attempt >= 3) return undefined;
+  return providerRetryDelayMs(0, new Headers(), attempt, random);
+}
+
+export function boundedPoolRetryDelayMs(poolDelayMs: number, retryDelayMs: number): number {
+  return Math.max(Number.isFinite(poolDelayMs) ? poolDelayMs : 0, retryDelayMs);
+}

--- a/src/core/provider-usage-source.ts
+++ b/src/core/provider-usage-source.ts
@@ -548,58 +548,105 @@ async function fetchMiniMaxUsage(
   return parseMiniMaxUsageResponse(await res.json(), Date.now());
 }
 
+const ZAI_FIVE_HOUR_UNIT = 3;
+const ZAI_MONTHLY_UNIT = 5;
+const ZAI_WEEKLY_UNIT = 6;
+
+function zaiLimitDescriptor(record: Record<string, unknown>): string {
+  return [record.type, record.name, record.label, record.description]
+    .map((value) => String(value ?? "").toLowerCase())
+    .join(" ");
+}
+
+function zaiLimitWindow(record: Record<string, unknown> | undefined): LiveUsageWindow | undefined {
+  if (!record) return undefined;
+  if (record.unlimited === true || record.isUnlimited === true || record.is_unlimited === true) {
+    return { usedPercent: 0, unlimited: true };
+  }
+  const usedPercent = clampPercent(
+    record.percentage ?? record.percent ?? record.used_percent ?? record.usedPercent
+  );
+  if (usedPercent === undefined) return undefined;
+  return {
+    usedPercent,
+    resetsAt: resetToIso(
+      record.nextResetTime,
+      record.next_reset_time,
+      record.resetsAt,
+      record.resets_at,
+      record.resetTime,
+      record.reset_time
+    ),
+  };
+}
+
+function zaiResetTimestamp(record: Record<string, unknown>): number {
+  const reset = toNumber(
+    record.nextResetTime ??
+      record.next_reset_time ??
+      record.resetsAt ??
+      record.resets_at ??
+      record.resetTime ??
+      record.reset_time
+  );
+  return reset !== undefined && reset > 0 ? reset : Number.POSITIVE_INFINITY;
+}
+
+function sortZaiTokenLimits(records: Record<string, unknown>[]): Record<string, unknown>[] {
+  return records.slice().sort((left, right) => {
+    const resetDifference = zaiResetTimestamp(left) - zaiResetTimestamp(right);
+    if (Number.isFinite(resetDifference) && resetDifference !== 0) return resetDifference;
+    return (
+      (clampPercent(left.percentage ?? left.percent) ?? 0) -
+      (clampPercent(right.percentage ?? right.percent) ?? 0)
+    );
+  });
+}
+
 export function parseZaiUsageResponse(body: unknown, now: number): LiveProviderUsage | null {
   const root = asRecord(body);
   const data = asRecord(root?.data) ?? root;
   const limits = Array.isArray(data?.limits) ? data.limits : [];
-  const tokenLimit = limits.find((entry) => {
-    const type = String(asRecord(entry)?.type ?? "").toLowerCase();
-    return type.includes("token");
+  const records = limits.flatMap((entry) => {
+    const record = asRecord(entry);
+    return record ? [record] : [];
   });
-  const timeLimit = limits.find((entry) => {
-    const type = String(asRecord(entry)?.type ?? "").toLowerCase();
-    return type.includes("time");
+  const weeklyByUnit = records.find((record) => toNumber(record.unit) === ZAI_WEEKLY_UNIT);
+  const weeklyByName = records.find((record) => zaiLimitDescriptor(record).includes("week"));
+  let weeklyRecord = weeklyByUnit ?? weeklyByName;
+  const tokenRecords = records.filter((record) => zaiLimitDescriptor(record).includes("token"));
+  let fiveHourRecord = records.find((record) => toNumber(record.unit) === ZAI_FIVE_HOUR_UNIT);
+  fiveHourRecord ??= records.find((record) => {
+    const descriptor = zaiLimitDescriptor(record);
+    return (
+      descriptor.includes("5 hour") || descriptor.includes("5h") || descriptor.includes("five hour")
+    );
   });
-  const record = asRecord(tokenLimit);
-  if (!record) return null;
-  const usedPercent = clampPercent(
-    record.percentage ?? record.percent ?? record.used_percent ?? record.usedPercent
+  const hasUnitMetadata = tokenRecords.some((record) => toNumber(record.unit) !== undefined);
+  const unclassifiedTokens = sortZaiTokenLimits(
+    tokenRecords.filter((record) => record !== weeklyRecord && record !== fiveHourRecord)
   );
-  if (usedPercent === undefined) return null;
-  const weeklyRecord = asRecord(timeLimit);
-  const weeklyPercent = clampPercent(
-    weeklyRecord?.percentage ??
-      weeklyRecord?.percent ??
-      weeklyRecord?.used_percent ??
-      weeklyRecord?.usedPercent
-  );
+  fiveHourRecord ??= unclassifiedTokens.shift();
+  if (!weeklyRecord && !hasUnitMetadata) weeklyRecord = unclassifiedTokens.shift();
+  const monthlyRecord = records.find((record) => {
+    if (record === weeklyRecord || record === fiveHourRecord) return false;
+    const value = zaiLimitDescriptor(record);
+    return (
+      toNumber(record.unit) === ZAI_MONTHLY_UNIT ||
+      value.includes("time_limit") ||
+      value.includes("month") ||
+      value.includes("mcp")
+    );
+  });
+  const fiveHour = zaiLimitWindow(fiveHourRecord);
+  const weekly = zaiLimitWindow(weeklyRecord);
+  const monthly = zaiLimitWindow(monthlyRecord);
+  if (!fiveHour && !weekly && !monthly) return null;
   return {
     planLabel: "GLM Coding Plan",
-    fiveHour: {
-      usedPercent,
-      resetsAt: resetToIso(
-        record.nextResetTime,
-        record.next_reset_time,
-        record.resetsAt,
-        record.resets_at,
-        record.resetTime,
-        record.reset_time
-      ),
-    },
-    weekly:
-      weeklyPercent === undefined
-        ? undefined
-        : {
-            usedPercent: weeklyPercent,
-            resetsAt: resetToIso(
-              weeklyRecord?.nextResetTime,
-              weeklyRecord?.next_reset_time,
-              weeklyRecord?.resetsAt,
-              weeklyRecord?.resets_at,
-              weeklyRecord?.resetTime,
-              weeklyRecord?.reset_time
-            ),
-          },
+    fiveHour,
+    weekly,
+    monthly,
     source: "provider_api",
     fetchedAt: now,
   };

--- a/src/core/provider-usage-source.ts
+++ b/src/core/provider-usage-source.ts
@@ -11,6 +11,7 @@ export interface LiveUsageWindow {
   resetsAt?: string;
   windowSeconds?: number;
   unlimited?: boolean;
+  title?: string;
 }
 
 export interface LiveProviderUsage {
@@ -549,6 +550,7 @@ async function fetchMiniMaxUsage(
 }
 
 const ZAI_FIVE_HOUR_UNIT = 3;
+const ZAI_DAILY_UNIT = 4;
 const ZAI_MONTHLY_UNIT = 5;
 const ZAI_WEEKLY_UNIT = 6;
 
@@ -563,9 +565,23 @@ function zaiLimitWindow(record: Record<string, unknown> | undefined): LiveUsageW
   if (record.unlimited === true || record.isUnlimited === true || record.is_unlimited === true) {
     return { usedPercent: 0, unlimited: true };
   }
-  const usedPercent = clampPercent(
+  const directPercent = clampPercent(
     record.percentage ?? record.percent ?? record.used_percent ?? record.usedPercent
   );
+  const limit = toNumber(record.usage ?? record.total ?? record.limit);
+  const current = toNumber(record.currentValue ?? record.current_value ?? record.used);
+  const remaining = toNumber(record.remaining ?? record.remainingValue ?? record.remaining_value);
+  const usedFromRemaining =
+    limit !== undefined && remaining !== undefined ? limit - remaining : undefined;
+  const used =
+    current !== undefined && usedFromRemaining !== undefined
+      ? Math.max(current, usedFromRemaining)
+      : (current ?? usedFromRemaining);
+  const computedPercent =
+    limit !== undefined && limit > 0 && used !== undefined
+      ? clampPercent((used / limit) * 100)
+      : undefined;
+  const usedPercent = computedPercent ?? directPercent;
   if (usedPercent === undefined) return undefined;
   return {
     usedPercent,
@@ -596,15 +612,28 @@ function sortZaiTokenLimits(records: Record<string, unknown>[]): Record<string, 
   return records.slice().sort((left, right) => {
     const resetDifference = zaiResetTimestamp(left) - zaiResetTimestamp(right);
     if (Number.isFinite(resetDifference) && resetDifference !== 0) return resetDifference;
-    return (
-      (clampPercent(left.percentage ?? left.percent) ?? 0) -
-      (clampPercent(right.percentage ?? right.percent) ?? 0)
-    );
+    return 0;
   });
+}
+
+function zaiPlanLabel(data: Record<string, unknown>): string {
+  for (const value of [data.planName, data.plan, data.plan_type, data.packageName]) {
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return "GLM Coding Plan";
+}
+
+function zaiApiErrorCode(body: unknown): number | undefined {
+  const root = asRecord(body);
+  if (!root) return undefined;
+  const code = toNumber(root.code);
+  if (root.success === false || (code !== undefined && code >= 400)) return code ?? 500;
+  return undefined;
 }
 
 export function parseZaiUsageResponse(body: unknown, now: number): LiveProviderUsage | null {
   const root = asRecord(body);
+  if (!root || zaiApiErrorCode(root) !== undefined) return null;
   const data = asRecord(root?.data) ?? root;
   const limits = Array.isArray(data?.limits) ? data.limits : [];
   const records = limits.flatMap((entry) => {
@@ -622,12 +651,21 @@ export function parseZaiUsageResponse(body: unknown, now: number): LiveProviderU
       descriptor.includes("5 hour") || descriptor.includes("5h") || descriptor.includes("five hour")
     );
   });
-  const hasUnitMetadata = tokenRecords.some((record) => toNumber(record.unit) !== undefined);
   const unclassifiedTokens = sortZaiTokenLimits(
-    tokenRecords.filter((record) => record !== weeklyRecord && record !== fiveHourRecord)
+    tokenRecords.filter(
+      (record) =>
+        record !== weeklyRecord &&
+        record !== fiveHourRecord &&
+        toNumber(record.unit) !== ZAI_DAILY_UNIT
+    )
   );
-  fiveHourRecord ??= unclassifiedTokens.shift();
-  if (!weeklyRecord && !hasUnitMetadata) weeklyRecord = unclassifiedTokens.shift();
+  if (!fiveHourRecord && !weeklyRecord && unclassifiedTokens.length > 1) {
+    fiveHourRecord = unclassifiedTokens.shift();
+    weeklyRecord = unclassifiedTokens.pop();
+  } else {
+    fiveHourRecord ??= unclassifiedTokens.shift();
+    weeklyRecord ??= unclassifiedTokens.pop();
+  }
   const monthlyRecord = records.find((record) => {
     if (record === weeklyRecord || record === fiveHourRecord) return false;
     const value = zaiLimitDescriptor(record);
@@ -640,10 +678,11 @@ export function parseZaiUsageResponse(body: unknown, now: number): LiveProviderU
   });
   const fiveHour = zaiLimitWindow(fiveHourRecord);
   const weekly = zaiLimitWindow(weeklyRecord);
-  const monthly = zaiLimitWindow(monthlyRecord);
+  const monthlyWindow = zaiLimitWindow(monthlyRecord);
+  const monthly = monthlyWindow ? { ...monthlyWindow, title: "Monthly MCP" } : undefined;
   if (!fiveHour && !weekly && !monthly) return null;
   return {
-    planLabel: "GLM Coding Plan",
+    planLabel: zaiPlanLabel(data),
     fiveHour,
     weekly,
     monthly,
@@ -676,7 +715,14 @@ async function fetchZaiUsage(token: string, baseUrl?: string): Promise<LiveProvi
       },
       signal: AbortSignal.timeout(10_000),
     });
-    if (res.ok) return parseZaiUsageResponse(await res.json(), Date.now());
+    if (res.ok) {
+      const body: unknown = await res.json();
+      const parsed = parseZaiUsageResponse(body, Date.now());
+      if (parsed) return parsed;
+      const errorCode = zaiApiErrorCode(body);
+      if (errorCode !== 401 && errorCode !== 403) return null;
+      continue;
+    }
     if (res.status !== 401 && res.status !== 403) return null;
   }
   return null;
@@ -1068,7 +1114,11 @@ function scanGrokProtobuf(
       const value = readVarint(data, index);
       if (!value) break;
       index = value.next;
-      scan.varintFields.push({ path: nextPath, value: value.value, order: scan.order++ });
+      scan.varintFields.push({
+        path: nextPath,
+        value: value.value,
+        order: scan.order++,
+      });
       continue;
     }
 
@@ -1122,7 +1172,11 @@ export function parseGrokWebBillingResponse(
   if (payloads.length === 0 && looksLikeProtobufPayload(data)) payloads = [data];
   if (payloads.length === 0) return null;
 
-  const scan: GrokProtobufScan = { fixed32Fields: [], varintFields: [], order: 0 };
+  const scan: GrokProtobufScan = {
+    fixed32Fields: [],
+    varintFields: [],
+    order: 0,
+  };
   for (const payload of payloads) scanGrokProtobuf(payload, 0, [], scan);
 
   const percent = scan.fixed32Fields

--- a/src/core/providers.ts
+++ b/src/core/providers.ts
@@ -6,6 +6,13 @@ import { integrationProviderCatalog } from "./providers/catalog-integrations";
 import { accountOAuthProviders } from "./providers/account-oauth";
 import { parseOAuthTokenPayload, type ProviderOAuthConfig } from "./provider-oauth";
 import { isKimiCodeProvider, kimiCodeIdentityHeaders } from "./providers/kimi-code";
+import {
+  getProviderAccountPool,
+  parseProviderAccountPoolRouteId,
+  providerAccountPoolCandidates,
+  providerAccountRemainingPercent,
+} from "./provider-account-pool";
+import { fetchLiveProviderUsage } from "./provider-usage-source";
 
 export const providers = {
   ...foundationProviderCatalog,
@@ -159,12 +166,76 @@ class ProviderManager {
     return this.mergeWithStaticConfig(dbProvider);
   }
 
+  getAccountPoolPrimary(poolId: string): Provider | undefined {
+    const pool = getProviderAccountPool(poolId);
+    if (!pool?.enabled) return undefined;
+    for (const account of pool.accounts) {
+      const provider = this.getWithCredentials(account.providerId);
+      if (provider?.provider === pool.provider) return provider;
+    }
+    return undefined;
+  }
+
+  resolveExecutionTarget(target: string): { provider: Provider; poolId?: string } | undefined {
+    const poolId = parseProviderAccountPoolRouteId(target);
+    if (poolId) {
+      const provider = this.getAccountPoolPrimary(poolId);
+      return provider ? { provider, poolId } : undefined;
+    }
+    const providerId = this.resolveProviderId(target);
+    const provider = providerId ? this.getWithCredentials(providerId) : undefined;
+    return provider ? { provider } : undefined;
+  }
+
+  async getAccountPoolCandidates(id: string, poolId?: string): Promise<Provider[]> {
+    const primary = this.getWithCredentials(id);
+    if (!primary) return [];
+    const storedProviders = tables.providers.all() as Provider[];
+    const candidates = providerAccountPoolCandidates(poolId, primary, storedProviders);
+    const resolvedCandidates = candidates.flatMap((candidate) => {
+      const resolved = this.getWithCredentials(candidate.id);
+      return resolved ? [resolved] : [];
+    });
+    if (resolvedCandidates.length < 2) return resolvedCandidates;
+
+    const usagePromise = Promise.all(
+      resolvedCandidates.map(async (candidate) => {
+        const usage = await fetchLiveProviderUsage({
+          id: candidate.id,
+          providerType: candidate.provider,
+          apiKey: candidate.api_key,
+          accessToken: candidate.access_token,
+          baseUrl: candidate.base_url,
+        });
+        return [candidate.id, providerAccountRemainingPercent(usage)] as const;
+      })
+    );
+    const usage = await Promise.race([usagePromise, Bun.sleep(750).then(() => undefined)]);
+    if (!usage) return resolvedCandidates;
+    const remainingByProviderId = new Map(
+      usage.filter((entry): entry is readonly [string, number] => entry[1] !== undefined)
+    );
+    const ranked = providerAccountPoolCandidates(
+      poolId,
+      primary,
+      storedProviders,
+      Date.now(),
+      remainingByProviderId
+    );
+    const resolvedById = new Map(resolvedCandidates.map((candidate) => [candidate.id, candidate]));
+    return ranked.flatMap((candidate) => {
+      const resolved = resolvedById.get(candidate.id);
+      return resolved ? [resolved] : [];
+    });
+  }
+
   private oauthRefreshInFlight = new Map<string, Promise<Provider | undefined>>();
   private oauthRefreshCooldownUntil = new Map<string, number>();
   private static readonly OAUTH_REFRESH_COOLDOWN_MS = 60_000;
 
   async refreshOAuthCredentialsIfNeeded(
-    provider: Provider | undefined
+    provider: Provider | undefined,
+    options?: { force?: boolean }
   ): Promise<Provider | undefined> {
     if (!provider?.id) return undefined;
     const staticConfig = providers[provider.provider as ProviderType] as
@@ -178,8 +249,8 @@ class ProviderManager {
     const now = Date.now();
     const skewMs = 120_000;
     const expiresAt = typeof provider.expires_at === "number" ? provider.expires_at : 0;
-    if (expiresAt > 0 && expiresAt - skewMs > now) return undefined;
-    if (expiresAt === 0) {
+    if (options?.force !== true && expiresAt > 0 && expiresAt - skewMs > now) return undefined;
+    if (options?.force !== true && expiresAt === 0) {
       const cooldownUntil = this.oauthRefreshCooldownUntil.get(provider.id) || 0;
       if (cooldownUntil > now) return undefined;
       this.oauthRefreshCooldownUntil.set(

--- a/src/core/providers.ts
+++ b/src/core/providers.ts
@@ -5,6 +5,8 @@ import { foundationProviderCatalog } from "./providers/catalog-foundation";
 import { integrationProviderCatalog } from "./providers/catalog-integrations";
 import { accountOAuthProviders } from "./providers/account-oauth";
 import { parseOAuthTokenPayload, type ProviderOAuthConfig } from "./provider-oauth";
+import { classifyApiError } from "./error-classifier";
+import { providerExceptionRetryDelayMs, providerRetryDelayMs } from "./provider-retry";
 import { isKimiCodeProvider, kimiCodeIdentityHeaders } from "./providers/kimi-code";
 import {
   getProviderAccountPool,
@@ -274,40 +276,63 @@ class ProviderManager {
     oauth: ProviderOAuthConfig
   ): Promise<Provider | undefined> {
     try {
-      const fields: Record<string, string> = {
-        grant_type: "refresh_token",
-        refresh_token: provider.refresh_token || "",
-      };
-      if (oauth.clientId) fields.client_id = oauth.clientId;
-      if (oauth.clientSecret) fields.client_secret = oauth.clientSecret;
-      if (oauth.scope && provider.provider !== "xai-oauth") fields.scope = oauth.scope;
       const cursor = oauth.refreshMode === "cursor";
       const json = oauth.tokenRequestFormat === "json" || cursor;
-      const request = () =>
-        fetch(oauth.tokenUrl || "", {
-          method: "POST",
-          headers: {
-            Accept: "application/json",
-            "Content-Type": json ? "application/json" : "application/x-www-form-urlencoded",
-            ...(cursor ? { Authorization: `Bearer ${provider.refresh_token}` } : {}),
-            ...oauth.refreshHeaders,
-            ...(oauth.identityHeaders === "kimi-code" ? kimiCodeIdentityHeaders() : {}),
-          },
-          body: json ? JSON.stringify(cursor ? {} : fields) : new URLSearchParams(fields),
-          signal: AbortSignal.timeout(30_000),
-        });
-      let response = await request();
+      let credentialSource = this.getWithCredentials(provider.id) ?? provider;
       if (
-        (provider.provider === "xai-oauth" || provider.provider === "kimi-code-oauth") &&
-        (response.status === 429 || response.status >= 500)
+        credentialSource.access_token &&
+        credentialSource.access_token !== provider.access_token &&
+        (!(credentialSource.expires_at ?? 0) || (credentialSource.expires_at ?? 0) > Date.now())
       ) {
-        const retryAfter = Number(response.headers.get("retry-after"));
-        const delayMs = Number.isFinite(retryAfter) && retryAfter >= 0 ? retryAfter * 1000 : 200;
-        await response.body?.cancel();
-        await new Promise((resolve) => setTimeout(resolve, delayMs));
-        response = await request();
+        return credentialSource;
       }
-      if (!response.ok) return undefined;
+
+      let response: Response | undefined;
+      for (let attempt = 0; attempt <= 2; attempt++) {
+        const fields: Record<string, string> = {
+          grant_type: "refresh_token",
+          refresh_token: credentialSource.refresh_token || "",
+        };
+        if (oauth.clientId) fields.client_id = oauth.clientId;
+        if (oauth.clientSecret) fields.client_secret = oauth.clientSecret;
+        if (oauth.scope && provider.provider !== "xai-oauth") fields.scope = oauth.scope;
+        try {
+          response = await fetch(oauth.tokenUrl || "", {
+            method: "POST",
+            headers: {
+              Accept: "application/json",
+              "Content-Type": json ? "application/json" : "application/x-www-form-urlencoded",
+              ...(cursor ? { Authorization: `Bearer ${credentialSource.refresh_token}` } : {}),
+              ...oauth.refreshHeaders,
+              ...(oauth.identityHeaders === "kimi-code" ? kimiCodeIdentityHeaders() : {}),
+            },
+            body: json ? JSON.stringify(cursor ? {} : fields) : new URLSearchParams(fields),
+            signal: AbortSignal.timeout(30_000),
+          });
+        } catch (error) {
+          const delayMs = providerExceptionRetryDelayMs(error, attempt);
+          if (delayMs === undefined || delayMs > 30_000) return undefined;
+          await Bun.sleep(delayMs);
+          continue;
+        }
+        if (response.ok) break;
+        const errorBody = await response.text();
+        const classified = classifyApiError({ status: response.status, body: errorBody });
+        if (!classified.retryable || attempt >= 2) return undefined;
+        const delayMs = providerRetryDelayMs(response.status, response.headers, attempt);
+        if (delayMs > 30_000) return undefined;
+        await Bun.sleep(delayMs);
+        const latest = this.getWithCredentials(provider.id);
+        if (
+          latest?.access_token &&
+          latest.access_token !== credentialSource.access_token &&
+          (!(latest.expires_at ?? 0) || (latest.expires_at ?? 0) > Date.now())
+        ) {
+          return latest;
+        }
+        credentialSource = latest ?? credentialSource;
+      }
+      if (!response?.ok) return undefined;
       const token = parseOAuthTokenPayload(await response.json(), oauth);
       if (!token) return undefined;
 
@@ -316,7 +341,7 @@ class ProviderManager {
       tables.providers.update(provider.id, {
         ...current,
         access_token: token.accessToken,
-        refresh_token: token.refreshToken || provider.refresh_token,
+        refresh_token: token.refreshToken || credentialSource.refresh_token,
         expires_at: token.expiresAt,
       });
       return this.getWithCredentials(provider.id);

--- a/src/core/router.ts
+++ b/src/core/router.ts
@@ -26,6 +26,11 @@ import {
   type ProviderPlanEvaluationContext,
   type ProviderPlanRouteConstraint,
 } from "./provider-plans";
+import {
+  getProviderAccountPool,
+  parseProviderAccountPoolRouteId,
+  providerAccountPoolRouteProvider,
+} from "./provider-account-pool";
 
 // ─── Built-in pricing data ($USD per 1M tokens) ─────────────────────────────
 // Stamped pricing data + estimates.
@@ -232,6 +237,9 @@ export interface RouterUsageRecord {
 
 export interface ProviderAvailability {
   providerId: string;
+  providerType?: string;
+  targetName?: string;
+  targetType?: "provider" | "pool";
   weight: number;
   priority: number;
   enabled: boolean;
@@ -272,7 +280,13 @@ const WINDOW_WEEK_MS = 7 * 24 * 60 * 60 * 1000;
 
 function getRouterConfig(): RouterConfig {
   const cfg = config.get<RouterConfig>("router");
-  if (!cfg) return { enabled: false, strategy: "weighted", fallbackToAny: true, routes: {} };
+  if (!cfg)
+    return {
+      enabled: false,
+      strategy: "weighted",
+      fallbackToAny: true,
+      routes: {},
+    };
   return {
     enabled: cfg.enabled === true,
     strategy: normalizeRouterStrategy(cfg.strategy),
@@ -306,7 +320,10 @@ export function getMixtureOfAgentsRoutingConfig(): {
   aggregatorAgentId?: string;
 } {
   const cfg = getRouterConfig();
-  return { maxAgents: cfg.moaMaxAgents, aggregatorAgentId: cfg.moaAggregatorAgentId };
+  return {
+    maxAgents: cfg.moaMaxAgents,
+    aggregatorAgentId: cfg.moaAggregatorAgentId,
+  };
 }
 
 function normalizeRoute(route: ProviderRouteConfig): ProviderRouteConfig {
@@ -363,7 +380,10 @@ function isCircuitOpen(providerId: string): boolean {
 
 /** Record a provider failure. Opens the circuit after CIRCUIT_FAILURE_THRESHOLD. */
 export function recordProviderFailure(providerId: string, reason?: string): void {
-  const state = circuitState.get(providerId) ?? { consecutiveFailures: 0, openUntil: 0 };
+  const state = circuitState.get(providerId) ?? {
+    consecutiveFailures: 0,
+    openUntil: 0,
+  };
   state.consecutiveFailures += 1;
   if (state.consecutiveFailures >= CIRCUIT_FAILURE_THRESHOLD) {
     state.openUntil = Date.now() + CIRCUIT_RECOVERY_MS;
@@ -401,7 +421,10 @@ function resolvePrice(
   providerId: string
 ): { inputPerM: number; outputPerM: number } {
   if (route.priceInputPerM !== undefined && route.priceOutputPerM !== undefined) {
-    return { inputPerM: route.priceInputPerM, outputPerM: route.priceOutputPerM };
+    return {
+      inputPerM: route.priceInputPerM,
+      outputPerM: route.priceOutputPerM,
+    };
   }
   const builtIn = getPricing(providerId, route.model);
   return {
@@ -414,19 +437,27 @@ export function getProviderAvailability(
   providerId: string,
   planContext?: ProviderPlanEvaluationContext
 ): ProviderAvailability {
+  const poolId = parseProviderAccountPoolRouteId(providerId);
+  const pool = poolId ? getProviderAccountPool(poolId) : undefined;
+  const providerType = pool?.provider ?? providerId;
   const routerCfg = getRouterConfig();
   const route = normalizeRoute(routerCfg.routes[providerId] ?? { weight: 50, enabled: true });
   const requests5h = getWindowedRequests(providerId, WINDOW_5H_MS);
   const requestsWeek = getWindowedRequests(providerId, WINDOW_WEEK_MS);
   const spendToday = getWindowedSpend(providerId, WINDOW_DAY_MS);
   const spendWeek = getWindowedSpend(providerId, WINDOW_WEEK_MS);
-  const price = resolvePrice(route, providerId);
+  const price = resolvePrice(route, providerType);
   const circuitOpen = isCircuitOpen(providerId);
   const inCooldown = isInCooldown(providerId);
-  const plan = getProviderPlanRouteConstraint(providerId, planContext);
+  const plan = getProviderPlanRouteConstraint(providerType, planContext);
 
   let available = route.enabled !== false;
   let reason: string | undefined;
+
+  if (poolId && (!pool?.enabled || pool.accounts.length === 0)) {
+    available = false;
+    reason = pool ? "Provider pool is disabled" : "Provider pool not found";
+  }
 
   if (circuitOpen) {
     available = false;
@@ -470,6 +501,9 @@ export function getProviderAvailability(
 
   return {
     providerId,
+    providerType,
+    targetName: pool?.name,
+    targetType: pool ? "pool" : "provider",
     weight: route.weight,
     priority: route.priority ?? 0,
     enabled: route.enabled !== false,
@@ -503,7 +537,9 @@ export function selectProvider(preferredProviderId?: string): string | null {
     preferredProviderId,
     ...routeIds,
     ...fallbackProviderIds.filter((id) => !routerCfg.routes[id]),
-  ].filter((id): id is string => Boolean(id));
+  ]
+    .filter((id): id is string => Boolean(id))
+    .map((id) => providerAccountPoolRouteProvider(id) ?? id);
   const planContext = hasProviderPlanRouteConstraints(planRouteKeys)
     ? createProviderPlanEvaluationContext()
     : undefined;
@@ -560,15 +596,20 @@ export function selectProvider(preferredProviderId?: string): string | null {
       return pool[0].id;
     }
     case "usage_aware": {
-      const remainingFor = (c: { avail: ProviderAvailability }): number => {
-        if (c.avail.plan?.status === "exhausted") return -1;
-        const remaining = c.avail.plan?.primaryRemainingPercent;
-        if (typeof remaining === "number") return remaining;
-        return 100;
+      const remainingFor = (candidate: { avail: ProviderAvailability }): number | undefined => {
+        if (candidate.avail.plan?.status === "exhausted") return -1;
+        return candidate.avail.plan?.primaryRemainingPercent;
       };
-      candidates.sort(
-        (a, b) => remainingFor(b) - remainingFor(a) || b.avail.weight - a.avail.weight
-      );
+      candidates.sort((left, right) => {
+        const leftRemaining = remainingFor(left);
+        const rightRemaining = remainingFor(right);
+        if (leftRemaining !== undefined || rightRemaining !== undefined) {
+          if (leftRemaining === undefined) return 1;
+          if (rightRemaining === undefined) return -1;
+          if (leftRemaining !== rightRemaining) return rightRemaining - leftRemaining;
+        }
+        return right.avail.weight - left.avail.weight;
+      });
       return candidates[0].id;
     }
     case "weighted":
@@ -671,7 +712,8 @@ export interface RouterStatus {
 export function getRouterStatus(): RouterStatus {
   const cfg = getRouterConfig();
   const routeIds = Object.keys(cfg.routes);
-  const planContext = hasProviderPlanRouteConstraints(routeIds)
+  const planRouteKeys = routeIds.map((id) => providerAccountPoolRouteProvider(id) ?? id);
+  const planContext = hasProviderPlanRouteConstraints(planRouteKeys)
     ? createProviderPlanEvaluationContext()
     : undefined;
   return {

--- a/src/core/router.ts
+++ b/src/core/router.ts
@@ -449,7 +449,7 @@ export function getProviderAvailability(
   const price = resolvePrice(route, providerType);
   const circuitOpen = isCircuitOpen(providerId);
   const inCooldown = isInCooldown(providerId);
-  const plan = getProviderPlanRouteConstraint(providerType, planContext);
+  const plan = getProviderPlanRouteConstraint(providerId, planContext);
 
   let available = route.enabled !== false;
   let reason: string | undefined;
@@ -544,9 +544,7 @@ export function selectProvider(preferredProviderId?: string): string | null {
     preferredRouteId,
     ...routeIds,
     ...fallbackProviderIds.filter((id) => !routerCfg.routes[id]),
-  ]
-    .filter((id): id is string => Boolean(id))
-    .map((id) => providerAccountPoolRouteProvider(id) ?? id);
+  ].filter((id): id is string => Boolean(id));
   const planContext = hasProviderPlanRouteConstraints(planRouteKeys)
     ? createProviderPlanEvaluationContext()
     : undefined;
@@ -654,15 +652,18 @@ export function recordUsage(
   inputTokens: number,
   outputTokens: number,
   success: boolean,
-  model?: string
+  model?: string,
+  providerType?: string
 ): void {
   const routerCfg = getRouterConfig();
   const route = routerCfg.routes[providerId] ? normalizeRoute(routerCfg.routes[providerId]) : null;
+  const pricingProviderId =
+    providerType ?? providerAccountPoolRouteProvider(providerId) ?? providerId;
   const price = route
-    ? resolvePrice(route, providerId)
+    ? resolvePrice(route, pricingProviderId)
     : {
-        inputPerM: getPricing(providerId, model)?.inputPerM ?? 0,
-        outputPerM: getPricing(providerId, model)?.outputPerM ?? 0,
+        inputPerM: getPricing(pricingProviderId, model)?.inputPerM ?? 0,
+        outputPerM: getPricing(pricingProviderId, model)?.outputPerM ?? 0,
       };
 
   const estimatedCost =
@@ -719,8 +720,7 @@ export interface RouterStatus {
 export function getRouterStatus(): RouterStatus {
   const cfg = getRouterConfig();
   const routeIds = Object.keys(cfg.routes);
-  const planRouteKeys = routeIds.map((id) => providerAccountPoolRouteProvider(id) ?? id);
-  const planContext = hasProviderPlanRouteConstraints(planRouteKeys)
+  const planContext = hasProviderPlanRouteConstraints(routeIds)
     ? createProviderPlanEvaluationContext()
     : undefined;
   return {

--- a/src/core/router.ts
+++ b/src/core/router.ts
@@ -527,6 +527,13 @@ export function selectProvider(preferredProviderId?: string): string | null {
   const routerCfg = getRouterConfig();
   if (!routerCfg.enabled) return preferredProviderId ?? null;
   const routeIds = Object.keys(routerCfg.routes);
+  const preferredProvider = preferredProviderId
+    ? providerManager.getWithCredentials(preferredProviderId)
+    : undefined;
+  const preferredRouteId = [preferredProviderId, preferredProvider?.provider].find(
+    (candidate): candidate is string =>
+      typeof candidate === "string" && candidate in routerCfg.routes
+  );
   const fallbackProviderIds = routerCfg.fallbackToAny
     ? providerManager
         .list()
@@ -534,7 +541,7 @@ export function selectProvider(preferredProviderId?: string): string | null {
         .filter((provider): provider is string => Boolean(provider))
     : [];
   const planRouteKeys = [
-    preferredProviderId,
+    preferredRouteId,
     ...routeIds,
     ...fallbackProviderIds.filter((id) => !routerCfg.routes[id]),
   ]
@@ -545,8 +552,8 @@ export function selectProvider(preferredProviderId?: string): string | null {
     : undefined;
 
   // Preferred provider passthrough.
-  if (preferredProviderId && getProviderAvailability(preferredProviderId, planContext).available) {
-    return preferredProviderId;
+  if (preferredRouteId && getProviderAvailability(preferredRouteId, planContext).available) {
+    return preferredRouteId;
   }
 
   // Build candidates from configured routes.

--- a/src/core/subagent-registry.ts
+++ b/src/core/subagent-registry.ts
@@ -82,7 +82,7 @@ const defaultPersistPath =
 
 const DEFAULT_CONFIG: SubagentConfig = {
   archiveAfterMinutes: 60,
-  defaultTimeoutSeconds: 600,
+  defaultTimeoutSeconds: 0,
   persistPath: defaultPersistPath,
 };
 const SUBAGENT_RESULT_MAX_CHARS = 12_000;
@@ -199,7 +199,6 @@ export function configureSubagentRegistry(cfg: Partial<SubagentConfig>): void {
 }
 
 const subagentRuns = new Map<string, SubagentRunRecord>();
-const resumedRuns = new Set<string>();
 let sweeper: ReturnType<typeof setInterval> | null = null;
 let listenerStarted = false;
 let restoreAttempted = false;
@@ -375,28 +374,6 @@ function finalizeSubagentCleanup(runId: string, cleanup: "delete" | "keep"): voi
   persistSubagentRuns();
 }
 
-function resumeSubagentRun(runId: string): void {
-  if (!runId || resumedRuns.has(runId)) return;
-
-  const entry = subagentRuns.get(runId);
-  if (!entry) return;
-  if (entry.cleanupCompletedAt) return;
-
-  if (typeof entry.endedAt === "number" && entry.endedAt > 0) {
-    if (beginSubagentCleanup(runId)) {
-      finalizeSubagentCleanup(runId, entry.cleanup);
-    }
-    resumedRuns.add(runId);
-    return;
-  }
-
-  const timeoutMs = resolveRunTimeoutMs(entry.runTimeoutSeconds);
-  if (timeoutMs) {
-    void waitForSubagentCompletion(runId, timeoutMs);
-  }
-  resumedRuns.add(runId);
-}
-
 function restoreSubagentRunsOnce(): void {
   if (restoreAttempted) return;
   restoreAttempted = true;
@@ -405,8 +382,19 @@ function restoreSubagentRunsOnce(): void {
     const restored = loadSubagentRegistryFromDisk();
     if (restored.size === 0) return;
 
+    const restoredAt = Date.now();
     for (const [runId, entry] of restored.entries()) {
       if (!runId || !entry) continue;
+      if (!entry.endedAt) {
+        entry.endedAt = restoredAt;
+        entry.outcome = {
+          status: "error",
+          error: "Subagent interrupted by gateway restart",
+        };
+        entry.cleanupHandled = true;
+        entry.cleanupCompletedAt = restoredAt;
+      }
+      if (entry.cleanup === "delete") continue;
       if (!subagentRuns.has(runId)) {
         subagentRuns.set(runId, entry);
       }
@@ -416,9 +404,7 @@ function restoreSubagentRunsOnce(): void {
     if ([...subagentRuns.values()].some((e) => e.archiveAtMs)) {
       startSweeper();
     }
-    for (const runId of subagentRuns.keys()) {
-      resumeSubagentRun(runId);
-    }
+    persistSubagentRuns();
 
     console.log(`[Subagent] Restored ${restored.size} runs from disk`);
   } catch (err) {
@@ -492,7 +478,7 @@ export function registerSubagentRun(params: {
     label: params.label,
     model: params.model,
     workspaceDir: params.workspaceDir,
-    runTimeoutSeconds: params.runTimeoutSeconds,
+    runTimeoutSeconds: params.runTimeoutSeconds ?? config.defaultTimeoutSeconds,
     silent: params.silent === true,
     createdAt: now,
     startedAt: now,
@@ -749,7 +735,6 @@ export function initSubagentRegistry(): void {
 
 export function resetSubagentRegistryForTests(): void {
   subagentRuns.clear();
-  resumedRuns.clear();
   stopSweeper();
   restoreAttempted = false;
   listenerStarted = false;

--- a/src/core/tools/handlers/channel.ts
+++ b/src/core/tools/handlers/channel.ts
@@ -519,6 +519,28 @@ function recordSubagentActivity(
   return true;
 }
 
+function recordSubagentToolCall(
+  toolCalls: subagentRegistry.SubagentToolCall[],
+  payload: StatusPayload
+): boolean {
+  const phase = statusPhase(payload);
+  if (!phase || (!payload.toolName && !payload.toolCallId)) return false;
+  const id = payload.toolCallId || `${payload.toolName}-${payload.timestamp}`;
+  const existingIndex = toolCalls.findIndex((toolCall) => toolCall.id === id);
+  const status = phase === "start" ? "executing" : phase === "result" ? "completed" : "failed";
+  const next: subagentRegistry.SubagentToolCall = {
+    id,
+    name: payload.toolName || "tool",
+    result: phase === "start" ? null : payload.detail || null,
+    status,
+    timeline_index:
+      existingIndex >= 0 ? toolCalls[existingIndex]?.timeline_index : toolCalls.length,
+  };
+  if (existingIndex >= 0) toolCalls[existingIndex] = next;
+  else toolCalls.push(next);
+  return true;
+}
+
 async function executeSubagent(sessionId: string, run?: SubagentRunRecord): Promise<void> {
   const session = sessions.get(sessionId);
   if (!session) return;
@@ -529,12 +551,15 @@ async function executeSubagent(sessionId: string, run?: SubagentRunRecord): Prom
   }
 
   const activities: subagentRegistry.SubagentActivity[] = [];
+  const liveToolCalls: subagentRegistry.SubagentToolCall[] = [];
   const abortController = new AbortController();
   subagentAbortControllers.set(sessionId, abortController);
   const stopStatusCapture = onStatus((payload) => {
     if (payload.sessionId !== sessionId) return;
-    if (recordSubagentActivity(activities, payload) && run) {
-      subagentRegistry.updateRunDetails(run.runId, { activities });
+    const activityChanged = recordSubagentActivity(activities, payload);
+    const toolCallChanged = recordSubagentToolCall(liveToolCalls, payload);
+    if ((activityChanged || toolCallChanged) && run) {
+      subagentRegistry.updateRunDetails(run.runId, { activities, toolCalls: liveToolCalls });
     }
   });
 

--- a/src/core/tools/types.ts
+++ b/src/core/tools/types.ts
@@ -20,6 +20,7 @@ export interface ToolContext {
   denyWritePrefixes?: string[];
   confineToWorkspace?: boolean;
   consumeSteeringMessages?: () => Array<{ id: string; content: string; createdAt: number }>;
+  executionState?: { toolCallsStarted: number };
 }
 
 export interface Tool {

--- a/src/core/tools/types.ts
+++ b/src/core/tools/types.ts
@@ -5,6 +5,7 @@ export interface ToolHandler {
 export interface ToolContext {
   agentId: string;
   sessionId?: string;
+  routerRouteId?: string;
   workspaceDir?: string;
   channel?: string;
   userId?: string;

--- a/tests/api/routes.test.ts
+++ b/tests/api/routes.test.ts
@@ -1122,6 +1122,72 @@ describe("Providers API", () => {
     expect(Array.isArray(data)).toBe(true);
   });
 
+  test("provider account pool CRUD keeps named same-provider membership", async () => {
+    const suffix = Date.now();
+    const first = await api("POST", "/api/providers", {
+      provider: "openai",
+      name: `pool-primary-${suffix}`,
+      api_key: `sk-pool-primary-${suffix}`,
+    });
+    const second = await api("POST", "/api/providers", {
+      provider: "openai",
+      name: `pool-backup-${suffix}`,
+      api_key: `sk-pool-backup-${suffix}`,
+    });
+    const pool = await api("POST", "/api/provider-account-pools", {
+      name: "Work plans",
+      provider: "openai",
+      accounts: [
+        { provider_id: first.data.id, priority: 20 },
+        { provider_id: second.data.id, priority: 10 },
+      ],
+    });
+
+    expect(pool.status).toBe(200);
+    expect(pool.data.name).toBe("Work plans");
+    expect(pool.data.routing_mode).toBe("priority_then_usage");
+    expect(
+      pool.data.accounts.map((account: { provider_id: string }) => account.provider_id)
+    ).toEqual([second.data.id, first.data.id]);
+    expect(
+      pool.data.accounts.map((account: { provider_name: string }) => account.provider_name)
+    ).toEqual([`pool-backup-${suffix}`, `pool-primary-${suffix}`]);
+
+    const listed = await api("GET", "/api/provider-account-pools");
+    expect(listed.status).toBe(200);
+    expect(listed.data.some((entry: { id: string }) => entry.id === pool.data.id)).toBe(true);
+
+    const agent = await api("POST", "/api/agents", {
+      name: `pool-agent-${suffix}`,
+      type: "main",
+      model: "gpt-5.2",
+      provider_pool_id: pool.data.id,
+    });
+    expect(agent.status).toBe(200);
+    expect(agent.data.provider_id).toBe(second.data.id);
+    expect(agent.data.config.provider_account_pool_id).toBe(pool.data.id);
+    const summary = await api("GET", "/api/agents/summary");
+    const poolAgent = summary.data.find((entry: { id: string }) => entry.id === agent.data.id);
+    expect(poolAgent?.provider_pool_id).toBe(pool.data.id);
+    expect(poolAgent?.provider_pool_name).toBe("Work plans");
+
+    const updated = await api("PUT", `/api/provider-account-pools/${pool.data.id}`, {
+      name: "Work plans",
+      provider: "openai",
+      enabled: false,
+      accounts: [{ provider_id: first.data.id }],
+    });
+    expect(updated.status).toBe(200);
+    expect(updated.data.enabled).toBe(false);
+    expect(updated.data.routing_mode).toBe("usage");
+    expect(updated.data.accounts[0]?.priority).toBeNull();
+
+    await api("DELETE", `/api/agents/${agent.data.id}`);
+    expect((await api("DELETE", `/api/provider-account-pools/${pool.data.id}`)).status).toBe(200);
+    await api("DELETE", `/api/providers/${first.data.id}`);
+    await api("DELETE", `/api/providers/${second.data.id}`);
+  });
+
   test("POST /api/providers rejects invalid OpenAI key shapes", async () => {
     const bad = await api("POST", "/api/providers", {
       provider: "openai",
@@ -3415,7 +3481,9 @@ describe("Config API", () => {
     expect(getRes.status).toBe(200);
     expect(getRes.data[key]).toBe("***redacted***");
 
-    const echoRes = await api("PUT", "/api/config", { [key]: "***redacted***" });
+    const echoRes = await api("PUT", "/api/config", {
+      [key]: "***redacted***",
+    });
     expect(echoRes.status).toBe(200);
     expect(echoRes.data.success).toBe(true);
     expect(readRawConfig(key)).toBe(JSON.stringify(secret));

--- a/tests/api/routes.test.ts
+++ b/tests/api/routes.test.ts
@@ -1182,6 +1182,17 @@ describe("Providers API", () => {
     expect(updated.data.routing_mode).toBe("usage");
     expect(updated.data.accounts[0]?.priority).toBeNull();
 
+    const renamed = await api("PUT", `/api/provider-account-pools/${pool.data.id}`, {
+      name: "Renamed work plans",
+    });
+    expect(renamed.status).toBe(200);
+    expect(renamed.data.name).toBe("Renamed work plans");
+    expect(renamed.data.provider).toBe("openai");
+    expect(renamed.data.enabled).toBe(false);
+    expect(
+      renamed.data.accounts.map((account: { provider_id: string }) => account.provider_id)
+    ).toEqual([first.data.id]);
+
     await api("DELETE", `/api/agents/${agent.data.id}`);
     expect((await api("DELETE", `/api/provider-account-pools/${pool.data.id}`)).status).toBe(200);
     await api("DELETE", `/api/providers/${first.data.id}`);

--- a/tests/cli/provider-account-pool.test.ts
+++ b/tests/cli/provider-account-pool.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createCliProviderCommands } from "../../src/cli/commands/provider-commands";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function commands() {
+  return createCliProviderCommands(
+    async () => null,
+    "http://127.0.0.1:4269",
+    (headers) => new Headers(headers)
+  );
+}
+
+describe("CLI provider account pools", () => {
+  test("parses named pool flags and bounded account priorities", () => {
+    const parsed = commands().parsePoolFlags([
+      "--name",
+      "Work plans",
+      "--provider",
+      "openai-codex",
+      "--account",
+      "primary:25",
+      "--account",
+      "backup:25000",
+      "--disabled",
+    ]);
+    expect(parsed).toEqual({
+      name: "Work plans",
+      provider: "openai-codex",
+      enabled: false,
+      accounts: [
+        { provider_id: "primary", priority: 25 },
+        { provider_id: "backup", priority: 10_000 },
+      ],
+    });
+  });
+
+  test("leaves account ordering automatic when priority is omitted", () => {
+    expect(
+      commands().parsePoolFlags([
+        "--name",
+        "Work plans",
+        "--provider",
+        "openai-codex",
+        "--account",
+        "primary",
+        "--account",
+        "backup",
+      ]).accounts
+    ).toEqual([{ provider_id: "primary" }, { provider_id: "backup" }]);
+  });
+
+  test("creates a named pool through the pool API", async () => {
+    let requestUrl = "";
+    let requestBody: Record<string, unknown> = {};
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      requestUrl = String(input);
+      requestBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      return Response.json({
+        id: "pool-1",
+        name: "Work plans",
+        provider: "openai-codex",
+        enabled: true,
+        accounts: [],
+      });
+    }) as typeof fetch;
+
+    await commands().poolCreate({
+      name: "Work plans",
+      provider: "openai-codex",
+      accounts: [{ provider_id: "primary", priority: 10 }],
+    });
+
+    expect(requestUrl).toBe("http://127.0.0.1:4269/api/provider-account-pools");
+    expect(requestBody).toEqual({
+      name: "Work plans",
+      provider: "openai-codex",
+      accounts: [{ provider_id: "primary", priority: 10 }],
+    });
+  });
+});

--- a/tests/cli/provider-account-pool.test.ts
+++ b/tests/cli/provider-account-pool.test.ts
@@ -82,4 +82,26 @@ describe("CLI provider account pools", () => {
       accounts: [{ provider_id: "primary", priority: 10 }],
     });
   });
+
+  test("updates only explicitly supplied pool fields", async () => {
+    let requestUrl = "";
+    let requestBody: Record<string, unknown> = {};
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      requestUrl = String(input);
+      requestBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      return Response.json({
+        id: "pool-1",
+        name: "Work plans",
+        provider: "openai-codex",
+        enabled: false,
+        accounts: [{ provider_id: "primary", priority: null }],
+      });
+    }) as typeof fetch;
+
+    const flags = commands().parsePoolFlags(["--disabled"]);
+    await commands().poolUpdate("pool-1", flags);
+
+    expect(requestUrl).toBe("http://127.0.0.1:4269/api/provider-account-pools/pool-1");
+    expect(requestBody).toEqual({ enabled: false });
+  });
 });

--- a/tests/core/agent-provider-compatible-routing.test.ts
+++ b/tests/core/agent-provider-compatible-routing.test.ts
@@ -191,6 +191,198 @@ describe("Agent provider Google and compatible routing", () => {
     expect(requestHeaders.get("X-Msh-Device-Id")).toMatch(/^[0-9a-f-]{36}$/);
   });
 
+  test("retries transient Kimi rate limits before surfacing an error", async () => {
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls += 1;
+      if (calls < 3) {
+        return Response.json(
+          { error: { message: "temporary rate limit" } },
+          { status: 429, headers: { "Retry-After": "0" } }
+        );
+      }
+      return Response.json({
+        id: "kimi-retry-response",
+        object: "chat.completion",
+        model: "k3",
+        choices: [
+          {
+            index: 0,
+            finish_reason: "stop",
+            message: { role: "assistant", content: "kimi-retry-ok" },
+          },
+        ],
+        usage: { prompt_tokens: 4, completion_tokens: 2, total_tokens: 6 },
+      });
+    }) as typeof fetch;
+
+    const provider = providerManager.create({
+      provider: "kimi-code-oauth",
+      name: "Kimi Transient Retry Provider",
+      access_token: "kimi-transient-access-token",
+      expires_at: Date.now() + 3_600_000,
+    });
+    createdProviderIds.push(provider.id);
+    const agent = agentManager.create({
+      name: "Kimi Transient Retry Agent",
+      type: "main",
+      provider_id: provider.id,
+      model: "k3",
+      tools: [],
+    });
+    createdAgentIds.push(agent.id);
+
+    const result = await agentManager.execute(
+      agent.id,
+      [{ role: "user", content: "reply briefly" }],
+      { useTools: false, sessionId: "kimi-transient-retry-session" }
+    );
+
+    expect(result.content).toBe("kimi-retry-ok");
+    expect(calls).toBe(3);
+  });
+
+  test("does not retry Kimi plan exhaustion as a transient rate limit", async () => {
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls += 1;
+      return Response.json(
+        { error: { message: "weekly quota exceeded" } },
+        { status: 429, headers: { "Retry-After": "0" } }
+      );
+    }) as typeof fetch;
+
+    const provider = providerManager.create({
+      provider: "kimi-code-oauth",
+      name: "Kimi Exhausted Provider",
+      access_token: "kimi-exhausted-access-token",
+      expires_at: Date.now() + 3_600_000,
+    });
+    createdProviderIds.push(provider.id);
+    const agent = agentManager.create({
+      name: "Kimi Exhausted Agent",
+      type: "main",
+      provider_id: provider.id,
+      model: "k3",
+      tools: [],
+    });
+    createdAgentIds.push(agent.id);
+
+    const result = await agentManager.execute(
+      agent.id,
+      [{ role: "user", content: "reply briefly" }],
+      { useTools: false, sessionId: "kimi-exhausted-session" }
+    );
+
+    expect(result.content.toLowerCase()).toContain("quota");
+    expect(calls).toBe(1);
+  });
+
+  test("refreshes Kimi OAuth in place when a long tool loop crosses token expiry", async () => {
+    const chatAuthorizations: string[] = [];
+    let chatCalls = 0;
+    let refreshCalls = 0;
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "https://auth.kimi.com/api/oauth/token") {
+        refreshCalls += 1;
+        return Response.json({
+          access_token: "fresh-kimi-loop-token",
+          refresh_token: "fresh-kimi-loop-refresh",
+          expires_in: 900,
+        });
+      }
+
+      chatCalls += 1;
+      chatAuthorizations.push(new Headers(init?.headers).get("Authorization") || "");
+      if (chatCalls === 1) {
+        return Response.json({
+          id: "kimi-loop-tool-response",
+          object: "chat.completion",
+          model: "k3",
+          choices: [
+            {
+              index: 0,
+              finish_reason: "tool_calls",
+              message: {
+                role: "assistant",
+                content: "",
+                tool_calls: [
+                  {
+                    id: "kimi-loop-calc",
+                    type: "function",
+                    function: { name: "calc", arguments: '{"expression":"6 * 7"}' },
+                  },
+                ],
+              },
+            },
+          ],
+          usage: { prompt_tokens: 8, completion_tokens: 3, total_tokens: 11 },
+        });
+      }
+      if (chatCalls === 2) {
+        return Response.json({ error: { message: "access token expired" } }, { status: 401 });
+      }
+      return Response.json({
+        id: "kimi-loop-final-response",
+        object: "chat.completion",
+        model: "k3",
+        choices: [
+          {
+            index: 0,
+            finish_reason: "stop",
+            message: { role: "assistant", content: "The result is 42." },
+          },
+        ],
+        usage: { prompt_tokens: 12, completion_tokens: 4, total_tokens: 16 },
+      });
+    }) as typeof fetch;
+
+    const provider = providerManager.create({
+      provider: "kimi-code-oauth",
+      name: "Kimi Long Loop Provider",
+      access_token: "stale-kimi-loop-token",
+      refresh_token: "stale-kimi-loop-refresh",
+      expires_at: Date.now() + 3_600_000,
+    });
+    createdProviderIds.push(provider.id);
+    const agent = agentManager.create({
+      name: "Kimi Long Loop Agent",
+      type: "main",
+      provider_id: provider.id,
+      model: "k3",
+      tools: [
+        {
+          name: "calc",
+          description: "Evaluate math",
+          input_schema: {
+            type: "object",
+            properties: { expression: { type: "string" } },
+            required: ["expression"],
+          },
+        },
+      ],
+    });
+    createdAgentIds.push(agent.id);
+    config.set("tool_approval_mode", "always_allow");
+
+    const result = await agentManager.execute(
+      agent.id,
+      [{ role: "user", content: "Calculate six times seven" }],
+      { useTools: true, sessionId: "kimi-long-loop-refresh-session" }
+    );
+
+    expect(result.content).toBe("The result is 42.");
+    expect(result.tool_calls).toHaveLength(1);
+    expect(chatCalls).toBe(3);
+    expect(refreshCalls).toBe(1);
+    expect(chatAuthorizations).toEqual([
+      "Bearer stale-kimi-loop-token",
+      "Bearer stale-kimi-loop-token",
+      "Bearer fresh-kimi-loop-token",
+    ]);
+  });
+
   test("routes openai-codex-responses providers to codex responses endpoint", async () => {
     let requestUrl = "";
     let requestBody: Record<string, unknown> = {};

--- a/tests/core/agent-provider-compatible-routing.test.ts
+++ b/tests/core/agent-provider-compatible-routing.test.ts
@@ -137,11 +137,12 @@ describe("Agent provider Google and compatible routing", () => {
     expect(requestHeaders.get("x-goog-api-key")).toBeNull();
   });
 
-  test("retries transient Google rate limits but not quota exhaustion", async () => {
+  test("retries transient Google connection failures and rate limits but not quota exhaustion", async () => {
     let transientCalls = 0;
     globalThis.fetch = (async () => {
       transientCalls += 1;
-      if (transientCalls < 3) {
+      if (transientCalls === 1) throw new Error("fetch failed: ECONNRESET");
+      if (transientCalls === 2) {
         return Response.json(
           { error: { message: "temporary rate limit" } },
           { status: 429, headers: { "Retry-After": "0" } }
@@ -265,11 +266,12 @@ describe("Agent provider Google and compatible routing", () => {
     expect(requestHeaders.get("X-Msh-Device-Id")).toMatch(/^[0-9a-f-]{36}$/);
   });
 
-  test("retries transient Kimi rate limits before surfacing an error", async () => {
+  test("retries transient Kimi connection failures and rate limits", async () => {
     let calls = 0;
     globalThis.fetch = (async () => {
       calls += 1;
-      if (calls < 3) {
+      if (calls === 1) throw new Error("fetch failed: ECONNRESET");
+      if (calls === 2) {
         return Response.json(
           { error: { message: "temporary rate limit" } },
           { status: 429, headers: { "Retry-After": "0" } }

--- a/tests/core/agent-provider-compatible-routing.test.ts
+++ b/tests/core/agent-provider-compatible-routing.test.ts
@@ -137,6 +137,80 @@ describe("Agent provider Google and compatible routing", () => {
     expect(requestHeaders.get("x-goog-api-key")).toBeNull();
   });
 
+  test("retries transient Google rate limits but not quota exhaustion", async () => {
+    let transientCalls = 0;
+    globalThis.fetch = (async () => {
+      transientCalls += 1;
+      if (transientCalls < 3) {
+        return Response.json(
+          { error: { message: "temporary rate limit" } },
+          { status: 429, headers: { "Retry-After": "0" } }
+        );
+      }
+      return Response.json({
+        candidates: [{ content: { parts: [{ text: "google-retry-ok" }] } }],
+        usageMetadata: { promptTokenCount: 7, candidatesTokenCount: 2, totalTokenCount: 9 },
+      });
+    }) as typeof fetch;
+
+    const transientProvider = providerManager.create({
+      provider: "google",
+      name: "Google Transient Retry Provider",
+      api_key: "google-transient-key",
+    });
+    createdProviderIds.push(transientProvider.id);
+    const transientAgent = agentManager.create({
+      name: "Google Transient Retry Agent",
+      type: "main",
+      provider_id: transientProvider.id,
+      model: "gemini-3-pro-preview",
+      tools: [],
+    });
+    createdAgentIds.push(transientAgent.id);
+
+    const transientResult = await agentManager.execute(
+      transientAgent.id,
+      [{ role: "user", content: "reply briefly" }],
+      { useTools: false, sessionId: "google-transient-retry-session" }
+    );
+
+    expect(transientResult.content).toBe("google-retry-ok");
+    expect(transientCalls).toBe(3);
+
+    let exhaustedCalls = 0;
+    globalThis.fetch = (async () => {
+      exhaustedCalls += 1;
+      return Response.json(
+        { error: { message: "weekly quota exceeded" } },
+        { status: 429, headers: { "Retry-After": "0" } }
+      );
+    }) as typeof fetch;
+
+    const exhaustedProvider = providerManager.create({
+      provider: "google",
+      name: "Google Exhausted Provider",
+      api_key: "google-exhausted-key",
+    });
+    createdProviderIds.push(exhaustedProvider.id);
+    const exhaustedAgent = agentManager.create({
+      name: "Google Exhausted Agent",
+      type: "main",
+      provider_id: exhaustedProvider.id,
+      model: "gemini-3-pro-preview",
+      tools: [],
+    });
+    createdAgentIds.push(exhaustedAgent.id);
+
+    const exhaustedResult = await agentManager.execute(
+      exhaustedAgent.id,
+      [{ role: "user", content: "reply briefly" }],
+      { useTools: false, sessionId: "google-exhausted-session" }
+    );
+
+    expect(exhaustedResult.content.toLowerCase()).toContain("quota");
+    expect(exhaustedCalls).toBe(1);
+  });
+
   test("applies static provider headers for openai-compatible requests", async () => {
     let requestHeaders = new Headers();
 
@@ -702,11 +776,14 @@ describe("Agent provider Google and compatible routing", () => {
   });
 
   test("records provider cooldown when openai-codex returns 429", async () => {
-    globalThis.fetch = (async () =>
-      new Response(JSON.stringify({ error: { message: "rate limit reached" } }), {
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls += 1;
+      return new Response(JSON.stringify({ error: { message: "rate limit reached" } }), {
         status: 429,
-        headers: { "Content-Type": "application/json", "Retry-After": "7" },
-      })) as typeof fetch;
+        headers: { "Content-Type": "application/json", "Retry-After": "0" },
+      });
+    }) as typeof fetch;
 
     const provider = providerManager.create({
       provider: "openai-codex",
@@ -731,6 +808,7 @@ describe("Agent provider Google and compatible routing", () => {
     );
 
     expect(result.content.toLowerCase()).toContain("rate limit");
+    expect(calls).toBe(4);
     const availability = getProviderAvailability(provider.id);
     expect(availability.inCooldown).toBe(true);
     expect(availability.available).toBe(false);

--- a/tests/core/agent-provider-routing.test.ts
+++ b/tests/core/agent-provider-routing.test.ts
@@ -291,7 +291,7 @@ describe("Agent provider API-family routing", () => {
     ]);
   });
 
-  test("routes Grok OAuth through the Grok Build proxy and retries transient 429s", async () => {
+  test("routes Grok OAuth through the proxy and retries connection failures and 429s", async () => {
     let requestUrl = "";
     let requestHeaders = new Headers();
     let requestBody: Record<string, unknown> = {};
@@ -302,7 +302,8 @@ describe("Agent provider API-family routing", () => {
       requestUrl = String(input);
       requestHeaders = new Headers(init?.headers);
       requestBody = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
-      if (calls < 3) {
+      if (calls === 1) throw new Error("fetch failed: ECONNRESET");
+      if (calls === 2) {
         return Response.json(
           { error: { message: "temporary rate limit" } },
           { status: 429, headers: { "Retry-After": "0" } }
@@ -842,11 +843,12 @@ describe("Agent provider API-family routing", () => {
     ]);
   });
 
-  test("retries transient MiniMax rate limits before returning a response", async () => {
+  test("retries transient MiniMax connection failures and rate limits", async () => {
     let calls = 0;
     globalThis.fetch = (async () => {
       calls += 1;
-      if (calls < 3) {
+      if (calls === 1) throw new Error("fetch failed: ECONNRESET");
+      if (calls === 2) {
         return Response.json(
           { error: { message: "temporary rate limit" } },
           { status: 429, headers: { "Retry-After": "0" } }

--- a/tests/core/agent-provider-routing.test.ts
+++ b/tests/core/agent-provider-routing.test.ts
@@ -7,6 +7,7 @@ import { summarizeSessionTokenUsage } from "../../src/core/session-context";
 import {
   createProviderAccountPool,
   resetProviderAccountPoolsForTests,
+  updateProviderAccountPool,
 } from "../../src/core/provider-account-pool";
 
 const createdAgentIds: string[] = [];
@@ -289,6 +290,269 @@ describe("Agent provider API-family routing", () => {
       "Bearer primary-side-effect-key",
       "Bearer primary-side-effect-key",
     ]);
+  });
+
+  test("falls back to the agent provider when its account pool is paused", async () => {
+    let authorization = "";
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      authorization = new Headers(init?.headers).get("Authorization") || "";
+      return Response.json({
+        id: "paused-pool-response",
+        object: "chat.completion",
+        model: "gpt-5.2",
+        choices: [
+          {
+            index: 0,
+            finish_reason: "stop",
+            message: { role: "assistant", content: "direct-provider-ok" },
+          },
+        ],
+      });
+    }) as typeof fetch;
+
+    const provider = providerManager.create({
+      provider: "openai",
+      name: "Paused Pool Provider",
+      api_key: "paused-pool-key",
+    });
+    createdProviderIds.push(provider.id);
+    const pool = createProviderAccountPool(
+      {
+        name: "Paused plans",
+        provider: "openai",
+        accounts: [{ providerId: provider.id }],
+      },
+      [provider]
+    );
+    const agent = agentManager.create({
+      name: "Paused Pool Agent",
+      provider_id: provider.id,
+      provider_pool_id: pool.id,
+      model: "gpt-5.2",
+      tools: [],
+    });
+    createdAgentIds.push(agent.id);
+    updateProviderAccountPool(
+      pool.id,
+      {
+        name: pool.name,
+        provider: pool.provider,
+        enabled: false,
+        accounts: pool.accounts,
+      },
+      [provider]
+    );
+
+    const result = await agentManager.execute(
+      agent.id,
+      [{ role: "user", content: "Use the direct provider" }],
+      { useTools: false }
+    );
+
+    expect(result.content).toBe("direct-provider-ok");
+    expect(authorization).toBe("Bearer paused-pool-key");
+  });
+
+  test("changing an agent provider detaches its previous account pool", () => {
+    const primary = providerManager.create({
+      provider: "openai",
+      name: "Pool Provider",
+      api_key: "pool-provider-key",
+    });
+    const replacement = providerManager.create({
+      provider: "openai",
+      name: "Replacement Provider",
+      api_key: "replacement-provider-key",
+    });
+    createdProviderIds.push(primary.id, replacement.id);
+    const pool = createProviderAccountPool(
+      {
+        name: "Replace provider plans",
+        provider: "openai",
+        accounts: [{ providerId: primary.id }],
+      },
+      [primary, replacement]
+    );
+    const agent = agentManager.create({
+      name: "Replace Pool Agent",
+      provider_id: primary.id,
+      provider_pool_id: pool.id,
+      model: "gpt-5.2",
+      tools: [],
+    });
+    createdAgentIds.push(agent.id);
+
+    const updated = agentManager.update(agent.id, { provider_id: replacement.id });
+
+    expect(updated?.provider_id).toBe(replacement.id);
+    expect(agentManager.get(agent.id)?.provider_pool_id).toBeUndefined();
+  });
+
+  test("keeps an explicit agent pool ahead of global router routes", async () => {
+    let requestUrl = "";
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      requestUrl = String(input);
+      return Response.json({
+        id: "explicit-pool-response",
+        object: "chat.completion",
+        model: "gpt-5.2",
+        choices: [
+          {
+            index: 0,
+            finish_reason: "stop",
+            message: { role: "assistant", content: "explicit-pool-ok" },
+          },
+        ],
+      });
+    }) as typeof fetch;
+
+    const poolProvider = providerManager.create({
+      provider: "openai",
+      name: "Explicit Pool Provider",
+      api_key: "explicit-pool-key",
+    });
+    const routerProvider = providerManager.create({
+      provider: "synthetic",
+      name: "Global Router Provider",
+      api_key: "global-router-key",
+    });
+    createdProviderIds.push(poolProvider.id, routerProvider.id);
+    const pool = createProviderAccountPool(
+      {
+        name: "Explicit pool",
+        provider: "openai",
+        accounts: [{ providerId: poolProvider.id }],
+      },
+      [poolProvider, routerProvider]
+    );
+    const agent = agentManager.create({
+      name: "Explicit Pool Routing Agent",
+      provider_id: poolProvider.id,
+      provider_pool_id: pool.id,
+      model: "gpt-5.2",
+      tools: [],
+    });
+    createdAgentIds.push(agent.id);
+    config.set("router", {
+      enabled: true,
+      strategy: "priority",
+      fallbackToAny: false,
+      routes: { synthetic: { weight: 100, priority: 0, enabled: true } },
+    });
+
+    const result = await agentManager.execute(
+      agent.id,
+      [{ role: "user", content: "Keep the selected pool" }],
+      { useTools: false, useModelRouter: true }
+    );
+
+    expect(result.content).toBe("explicit-pool-ok");
+    expect(requestUrl.endsWith("/chat/completions")).toBe(true);
+  });
+
+  test("prefers the agent provider when it is a configured router route", async () => {
+    let authorization = "";
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      authorization = new Headers(init?.headers).get("Authorization") || "";
+      return Response.json({
+        id: "preferred-route-response",
+        object: "chat.completion",
+        model: "gpt-5.2",
+        choices: [
+          {
+            index: 0,
+            finish_reason: "stop",
+            message: { role: "assistant", content: "preferred-route-ok" },
+          },
+        ],
+      });
+    }) as typeof fetch;
+
+    const preferred = providerManager.create({
+      provider: "openai",
+      name: "Preferred Router Provider",
+      api_key: "preferred-router-key",
+    });
+    const alternate = providerManager.create({
+      provider: "synthetic",
+      name: "Alternate Router Provider",
+      api_key: "alternate-router-key",
+    });
+    createdProviderIds.push(preferred.id, alternate.id);
+    const agent = agentManager.create({
+      name: "Preferred Router Agent",
+      provider_id: preferred.id,
+      model: "gpt-5.2",
+      tools: [],
+    });
+    createdAgentIds.push(agent.id);
+    config.set("router", {
+      enabled: true,
+      strategy: "priority",
+      fallbackToAny: false,
+      routes: {
+        openai: { weight: 100, priority: 10, enabled: true },
+        synthetic: { weight: 100, priority: 0, enabled: true },
+      },
+    });
+
+    const result = await agentManager.execute(
+      agent.id,
+      [{ role: "user", content: "Use my configured provider" }],
+      { useTools: false, useModelRouter: true }
+    );
+
+    expect(result.content).toBe("preferred-route-ok");
+    expect(authorization).toBe("Bearer preferred-router-key");
+  });
+
+  test("running-agent messages do not enable the global router implicitly", async () => {
+    let authorization = "";
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      authorization = new Headers(init?.headers).get("Authorization") || "";
+      return Response.json({
+        id: "running-agent-response",
+        object: "chat.completion",
+        model: "gpt-5.2",
+        choices: [
+          {
+            index: 0,
+            finish_reason: "stop",
+            message: { role: "assistant", content: "running-agent-direct-ok" },
+          },
+        ],
+      });
+    }) as typeof fetch;
+
+    const direct = providerManager.create({
+      provider: "openai",
+      name: "Running Agent Provider",
+      api_key: "running-agent-key",
+    });
+    const routed = providerManager.create({
+      provider: "synthetic",
+      name: "Implicit Router Provider",
+      api_key: "implicit-router-key",
+    });
+    createdProviderIds.push(direct.id, routed.id);
+    const agent = agentManager.create({
+      name: "Running Agent Router Opt In",
+      provider_id: direct.id,
+      model: "gpt-5.2",
+      tools: [],
+    });
+    createdAgentIds.push(agent.id);
+    config.set("router", {
+      enabled: true,
+      strategy: "priority",
+      fallbackToAny: false,
+      routes: { synthetic: { weight: 100, priority: 0, enabled: true } },
+    });
+
+    const result = await agentManager.message(agent.id, "Stay on the agent provider");
+
+    expect(result.response).toBe("running-agent-direct-ok");
+    expect(authorization).toBe("Bearer running-agent-key");
   });
 
   test("routes Grok OAuth through the proxy and retries connection failures and 429s", async () => {

--- a/tests/core/agent-provider-routing.test.ts
+++ b/tests/core/agent-provider-routing.test.ts
@@ -506,7 +506,7 @@ describe("Agent provider API-family routing", () => {
     expect(authorization).toBe("Bearer preferred-router-key");
   });
 
-  test("running-agent messages do not enable the global router implicitly", async () => {
+  test("running-agent messages honor the enabled global router", async () => {
     let authorization = "";
     globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
       authorization = new Headers(init?.headers).get("Authorization") || "";
@@ -530,13 +530,13 @@ describe("Agent provider API-family routing", () => {
       api_key: "running-agent-key",
     });
     const routed = providerManager.create({
-      provider: "synthetic",
-      name: "Implicit Router Provider",
-      api_key: "implicit-router-key",
+      provider: "openai",
+      name: "Running Agent Routed Provider",
+      api_key: "running-agent-routed-key",
     });
     createdProviderIds.push(direct.id, routed.id);
     const agent = agentManager.create({
-      name: "Running Agent Router Opt In",
+      name: "Running Agent Router",
       provider_id: direct.id,
       model: "gpt-5.2",
       tools: [],
@@ -546,13 +546,13 @@ describe("Agent provider API-family routing", () => {
       enabled: true,
       strategy: "priority",
       fallbackToAny: false,
-      routes: { synthetic: { weight: 100, priority: 0, enabled: true } },
+      routes: { [routed.id]: { weight: 100, priority: 0, enabled: true } },
     });
 
-    const result = await agentManager.message(agent.id, "Stay on the agent provider");
+    const result = await agentManager.message(agent.id, "Use the configured router");
 
     expect(result.response).toBe("running-agent-direct-ok");
-    expect(authorization).toBe("Bearer running-agent-key");
+    expect(authorization).toBe("Bearer running-agent-routed-key");
   });
 
   test("routes Grok OAuth through the proxy and retries connection failures and 429s", async () => {
@@ -902,6 +902,7 @@ describe("Agent provider API-family routing", () => {
       "Bearer router-pool-primary",
       "Bearer router-pool-backup",
     ]);
+    expect(getProviderAvailability(`pool:${pool.id}`).requestsIn5hWindow).toBe(1);
     expect(agentManager.get(agent.id)?.provider_id).toBe(originalProvider.id);
   });
 

--- a/tests/core/agent-provider-routing.test.ts
+++ b/tests/core/agent-provider-routing.test.ts
@@ -291,7 +291,7 @@ describe("Agent provider API-family routing", () => {
     ]);
   });
 
-  test("routes Grok OAuth through the Grok Build proxy and retries one transient 429", async () => {
+  test("routes Grok OAuth through the Grok Build proxy and retries transient 429s", async () => {
     let requestUrl = "";
     let requestHeaders = new Headers();
     let requestBody: Record<string, unknown> = {};
@@ -302,7 +302,7 @@ describe("Agent provider API-family routing", () => {
       requestUrl = String(input);
       requestHeaders = new Headers(init?.headers);
       requestBody = init?.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : {};
-      if (calls === 1) {
+      if (calls < 3) {
         return Response.json(
           { error: { message: "temporary rate limit" } },
           { status: 429, headers: { "Retry-After": "0" } }
@@ -342,7 +342,7 @@ describe("Agent provider API-family routing", () => {
     );
 
     expect(result.content).toBe("grok-ok");
-    expect(calls).toBe(2);
+    expect(calls).toBe(3);
     expect(requestUrl).toBe("https://cli-chat-proxy.grok.com/v1/responses");
     expect(requestHeaders.get("Authorization")).toBe("Bearer grok-oauth-token");
     expect(requestHeaders.get("X-XAI-Token-Auth")).toBe("xai-grok-cli");
@@ -361,6 +361,138 @@ describe("Agent provider API-family routing", () => {
     expect(requestBody.stream).toBe(true);
     expect(requestBody.store).toBe(false);
     expect(Array.isArray(requestBody.input)).toBe(true);
+  });
+
+  test("does not retry Grok weekly quota exhaustion", async () => {
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls += 1;
+      return Response.json(
+        { error: { message: "weekly quota exceeded" } },
+        { status: 429, headers: { "Retry-After": "0" } }
+      );
+    }) as typeof fetch;
+
+    const provider = providerManager.create({
+      provider: "xai-oauth",
+      name: "Grok Exhausted OAuth Provider",
+      access_token: "grok-exhausted-token",
+      base_url: "https://api.x.ai/v1",
+    });
+    createdProviderIds.push(provider.id);
+    const agent = agentManager.create({
+      name: "Grok Exhausted OAuth Agent",
+      type: "main",
+      provider_id: provider.id,
+      model: "grok-4.5",
+      tools: [],
+    });
+    createdAgentIds.push(agent.id);
+
+    const result = await agentManager.execute(
+      agent.id,
+      [{ role: "user", content: "reply briefly" }],
+      { useTools: false, sessionId: "grok-exhausted-session" }
+    );
+
+    expect(result.content.toLowerCase()).toContain("quota");
+    expect(calls).toBe(1);
+  });
+
+  test("refreshes Grok OAuth in place when a tool loop crosses token expiry", async () => {
+    const chatAuthorizations: string[] = [];
+    let chatCalls = 0;
+    let refreshCalls = 0;
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "https://auth.x.ai/oauth2/token") {
+        refreshCalls += 1;
+        return Response.json({
+          access_token: "fresh-grok-loop-token",
+          refresh_token: "fresh-grok-loop-refresh",
+          expires_in: 3600,
+        });
+      }
+
+      chatCalls += 1;
+      chatAuthorizations.push(new Headers(init?.headers).get("Authorization") || "");
+      if (chatCalls === 1) {
+        return Response.json({
+          choices: [
+            {
+              message: {
+                role: "assistant",
+                content: "",
+                tool_calls: [
+                  {
+                    id: "grok-loop-calc",
+                    type: "function",
+                    function: { name: "calc", arguments: '{"expression":"6 * 7"}' },
+                  },
+                ],
+              },
+            },
+          ],
+          usage: { prompt_tokens: 8, completion_tokens: 3, total_tokens: 11 },
+        });
+      }
+      if (chatCalls === 2) {
+        return Response.json({ error: { message: "access token expired" } }, { status: 401 });
+      }
+      return Response.json({
+        choices: [
+          {
+            message: { role: "assistant", content: "GROK_LOOP_OK 42" },
+          },
+        ],
+        usage: { prompt_tokens: 12, completion_tokens: 4, total_tokens: 16 },
+      });
+    }) as typeof fetch;
+
+    const provider = providerManager.create({
+      provider: "xai-oauth",
+      name: "Grok Long Loop OAuth Provider",
+      access_token: "stale-grok-loop-token",
+      refresh_token: "stale-grok-loop-refresh",
+      expires_at: Date.now() + 3_600_000,
+      base_url: "https://api.x.ai/v1",
+    });
+    createdProviderIds.push(provider.id);
+    const agent = agentManager.create({
+      name: "Grok Long Loop OAuth Agent",
+      type: "main",
+      provider_id: provider.id,
+      model: "grok-4.5",
+      tools: [
+        {
+          name: "calc",
+          description: "Evaluate math",
+          input_schema: {
+            type: "object",
+            properties: { expression: { type: "string" } },
+            required: ["expression"],
+          },
+        },
+      ],
+    });
+    createdAgentIds.push(agent.id);
+    config.set("tool_approval_mode", "always_allow");
+
+    const result = await agentManager.execute(
+      agent.id,
+      [{ role: "user", content: "Calculate six times seven" }],
+      { useTools: true, sessionId: "grok-long-loop-refresh-session" }
+    );
+
+    expect(result.content).toBe("GROK_LOOP_OK 42");
+    expect(result.tool_calls).toHaveLength(1);
+    expect(chatCalls).toBe(3);
+    expect(refreshCalls).toBe(1);
+    expect(chatAuthorizations).toEqual([
+      "Bearer stale-grok-loop-token",
+      "Bearer stale-grok-loop-token",
+      "Bearer fresh-grok-loop-token",
+    ]);
   });
 
   test("model router resolves provider-type routes without changing the selected agent", async () => {
@@ -616,6 +748,178 @@ describe("Agent provider API-family routing", () => {
     expect(requestHeaders.get("authorization")).toBe("Bearer oauth-access-token");
     expect(requestHeaders.get("x-api-key")).toBeNull();
     expect(requestHeaders.get("anthropic-beta")).toBe("oauth-2025-04-20");
+  });
+
+  test("refreshes MiniMax Portal OAuth in place when a tool loop crosses token expiry", async () => {
+    const chatAuthorizations: string[] = [];
+    let chatCalls = 0;
+    let refreshCalls = 0;
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "https://account.minimax.io/oauth2/token") {
+        refreshCalls += 1;
+        return Response.json({
+          access_token: "fresh-minimax-loop-token",
+          refresh_token: "fresh-minimax-loop-refresh",
+          expires_in: 3600,
+        });
+      }
+
+      chatCalls += 1;
+      chatAuthorizations.push(new Headers(init?.headers).get("Authorization") || "");
+      if (chatCalls === 1) {
+        return Response.json({
+          id: "minimax-loop-tool-response",
+          type: "message",
+          role: "assistant",
+          model: "MiniMax-M3",
+          content: [
+            {
+              type: "tool_use",
+              id: "minimax-loop-calc",
+              name: "calc",
+              input: { expression: "6 * 7" },
+            },
+          ],
+          usage: { input_tokens: 8, output_tokens: 3 },
+        });
+      }
+      if (chatCalls === 2) {
+        return Response.json({ error: { message: "access token expired" } }, { status: 401 });
+      }
+      return Response.json({
+        id: "minimax-loop-final-response",
+        type: "message",
+        role: "assistant",
+        model: "MiniMax-M3",
+        content: [{ type: "text", text: "MINIMAX_LOOP_OK 42" }],
+        usage: { input_tokens: 12, output_tokens: 4 },
+      });
+    }) as typeof fetch;
+
+    const provider = providerManager.create({
+      provider: "minimax-portal",
+      name: "MiniMax Portal Long Loop Provider",
+      access_token: "stale-minimax-loop-token",
+      refresh_token: "stale-minimax-loop-refresh",
+      expires_at: Date.now() + 3_600_000,
+    });
+    createdProviderIds.push(provider.id);
+    const agent = agentManager.create({
+      name: "MiniMax Portal Long Loop Agent",
+      type: "main",
+      provider_id: provider.id,
+      model: "MiniMax-M3",
+      tools: [
+        {
+          name: "calc",
+          description: "Evaluate math",
+          input_schema: {
+            type: "object",
+            properties: { expression: { type: "string" } },
+            required: ["expression"],
+          },
+        },
+      ],
+    });
+    createdAgentIds.push(agent.id);
+    config.set("tool_approval_mode", "always_allow");
+
+    const result = await agentManager.execute(
+      agent.id,
+      [{ role: "user", content: "Calculate six times seven" }],
+      { useTools: true, sessionId: "minimax-long-loop-refresh-session" }
+    );
+
+    expect(result.content).toBe("MINIMAX_LOOP_OK 42");
+    expect(result.tool_calls).toHaveLength(1);
+    expect(chatCalls).toBe(3);
+    expect(refreshCalls).toBe(1);
+    expect(chatAuthorizations).toEqual([
+      "Bearer stale-minimax-loop-token",
+      "Bearer stale-minimax-loop-token",
+      "Bearer fresh-minimax-loop-token",
+    ]);
+  });
+
+  test("retries transient MiniMax rate limits before returning a response", async () => {
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls += 1;
+      if (calls < 3) {
+        return Response.json(
+          { error: { message: "temporary rate limit" } },
+          { status: 429, headers: { "Retry-After": "0" } }
+        );
+      }
+      return Response.json({
+        id: "minimax-retry-response",
+        type: "message",
+        role: "assistant",
+        model: "MiniMax-M3",
+        content: [{ type: "text", text: "minimax-retry-ok" }],
+        usage: { input_tokens: 5, output_tokens: 2 },
+      });
+    }) as typeof fetch;
+
+    const provider = providerManager.create({
+      provider: "minimax",
+      name: "MiniMax Transient Retry Provider",
+      api_key: "minimax-transient-key",
+    });
+    createdProviderIds.push(provider.id);
+    const agent = agentManager.create({
+      name: "MiniMax Transient Retry Agent",
+      type: "main",
+      provider_id: provider.id,
+      model: "MiniMax-M3",
+      tools: [],
+    });
+    createdAgentIds.push(agent.id);
+
+    const result = await agentManager.execute(
+      agent.id,
+      [{ role: "user", content: "reply briefly" }],
+      { useTools: false, sessionId: "minimax-transient-retry-session" }
+    );
+
+    expect(result.content).toBe("minimax-retry-ok");
+    expect(calls).toBe(3);
+  });
+
+  test("does not retry MiniMax plan exhaustion as a transient rate limit", async () => {
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls += 1;
+      return Response.json(
+        { error: { message: "weekly quota exceeded" } },
+        { status: 429, headers: { "Retry-After": "0" } }
+      );
+    }) as typeof fetch;
+
+    const provider = providerManager.create({
+      provider: "minimax",
+      name: "MiniMax Exhausted Provider",
+      api_key: "minimax-exhausted-key",
+    });
+    createdProviderIds.push(provider.id);
+    const agent = agentManager.create({
+      name: "MiniMax Exhausted Agent",
+      type: "main",
+      provider_id: provider.id,
+      model: "MiniMax-M3",
+      tools: [],
+    });
+    createdAgentIds.push(agent.id);
+
+    const result = await agentManager.execute(
+      agent.id,
+      [{ role: "user", content: "reply briefly" }],
+      { useTools: false, sessionId: "minimax-exhausted-session" }
+    );
+
+    expect(result.content.toLowerCase()).toContain("quota");
+    expect(calls).toBe(1);
   });
 
   test("routes Devin accounts through the native transport validation", async () => {

--- a/tests/core/agent-provider-routing.test.ts
+++ b/tests/core/agent-provider-routing.test.ts
@@ -4,6 +4,10 @@ import { config } from "../../src/core/config";
 import { providerManager } from "../../src/core/providers";
 import { getProviderAvailability, resetRouterForTests } from "../../src/core/router";
 import { summarizeSessionTokenUsage } from "../../src/core/session-context";
+import {
+  createProviderAccountPool,
+  resetProviderAccountPoolsForTests,
+} from "../../src/core/provider-account-pool";
 
 const createdAgentIds: string[] = [];
 const createdProviderIds: string[] = [];
@@ -20,9 +24,273 @@ afterEach(() => {
     providerManager.delete(providerId);
   }
   resetRouterForTests();
+  resetProviderAccountPoolsForTests();
 });
 
 describe("Agent provider API-family routing", () => {
+  test("orders automatic coding-plan accounts by tracked remaining usage", async () => {
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const authorization = new Headers(init?.headers).get("Authorization") || "";
+      const usedPercent = authorization.includes("primary-usage-key") ? 88 : 24;
+      return Response.json({
+        data: {
+          level: "pro",
+          limits: [
+            { type: "TOKENS_LIMIT", unit: 3, percentage: usedPercent },
+            { type: "TOKENS_LIMIT", unit: 6, percentage: usedPercent },
+          ],
+        },
+      });
+    }) as typeof fetch;
+
+    const primary = providerManager.create({
+      provider: "z.ai-coding",
+      name: "Primary Usage Account",
+      api_key: "primary-usage-key",
+    });
+    const backup = providerManager.create({
+      provider: "z.ai-coding",
+      name: "Backup Usage Account",
+      api_key: "backup-usage-key",
+    });
+    createdProviderIds.push(primary.id, backup.id);
+    const pool = createProviderAccountPool(
+      {
+        name: "Usage-balanced plans",
+        provider: "z.ai-coding",
+        accounts: [{ providerId: primary.id }, { providerId: backup.id }],
+      },
+      [primary, backup]
+    );
+
+    expect(
+      (await providerManager.getAccountPoolCandidates(primary.id, pool.id)).map((item) => item.id)
+    ).toEqual([backup.id, primary.id]);
+  });
+
+  test("fails over to the next enabled account after quota exhaustion", async () => {
+    const authorizationHeaders: string[] = [];
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const authorization = new Headers(init?.headers).get("Authorization") || "";
+      authorizationHeaders.push(authorization);
+      if (authorization === "Bearer primary-pool-key") {
+        return Response.json({ error: { message: "weekly quota exceeded" } }, { status: 429 });
+      }
+      return Response.json({
+        id: "pool-response",
+        object: "chat.completion",
+        model: "gpt-5.2",
+        choices: [
+          {
+            index: 0,
+            finish_reason: "stop",
+            message: { role: "assistant", content: "backup-account-ok" },
+          },
+        ],
+        usage: { prompt_tokens: 5, completion_tokens: 2, total_tokens: 7 },
+      });
+    }) as typeof fetch;
+
+    const primary = providerManager.create({
+      provider: "openai",
+      name: "Primary Pool Account",
+      api_key: "primary-pool-key",
+    });
+    const backup = providerManager.create({
+      provider: "openai",
+      name: "Backup Pool Account",
+      api_key: "backup-pool-key",
+    });
+    createdProviderIds.push(primary.id, backup.id);
+    const pool = createProviderAccountPool(
+      {
+        name: "OpenAI plans",
+        provider: "openai",
+        accounts: [
+          { providerId: primary.id, priority: 10 },
+          { providerId: backup.id, priority: 20 },
+        ],
+      },
+      [primary, backup]
+    );
+    const agent = agentManager.create({
+      name: "Account Pool Agent",
+      type: "main",
+      provider_id: primary.id,
+      provider_pool_id: pool.id,
+      model: "gpt-5.2",
+      tools: [],
+    });
+    createdAgentIds.push(agent.id);
+
+    const result = await agentManager.execute(
+      agent.id,
+      [{ role: "user", content: "Use the available account" }],
+      { useTools: false, sessionId: "provider-account-pool-session" }
+    );
+
+    expect(result.content).toBe("backup-account-ok");
+    expect(authorizationHeaders).toEqual(["Bearer primary-pool-key", "Bearer backup-pool-key"]);
+    expect(agentManager.get(agent.id)?.provider_id).toBe(primary.id);
+    expect(agentManager.get(agent.id)?.provider_pool_id).toBe(pool.id);
+  });
+
+  test("keeps an explicitly selected account pinned even when it belongs to a pool", async () => {
+    const authorizationHeaders: string[] = [];
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const authorization = new Headers(init?.headers).get("Authorization") || "";
+      authorizationHeaders.push(authorization);
+      return Response.json({ error: { message: "weekly quota exceeded" } }, { status: 429 });
+    }) as typeof fetch;
+
+    const primary = providerManager.create({
+      provider: "openai",
+      name: "Pinned Pool Member",
+      api_key: "pinned-pool-key",
+    });
+    const backup = providerManager.create({
+      provider: "openai",
+      name: "Unused Pool Member",
+      api_key: "unused-pool-key",
+    });
+    createdProviderIds.push(primary.id, backup.id);
+    createProviderAccountPool(
+      {
+        name: "Pinned behavior",
+        provider: "openai",
+        accounts: [{ providerId: primary.id }, { providerId: backup.id }],
+      },
+      [primary, backup]
+    );
+    const agent = agentManager.create({
+      name: "Pinned Account Agent",
+      type: "main",
+      provider_id: primary.id,
+      model: "gpt-5.2",
+      tools: [],
+    });
+    createdAgentIds.push(agent.id);
+
+    await agentManager.execute(agent.id, [{ role: "user", content: "Stay pinned" }], {
+      useTools: false,
+    });
+
+    expect(authorizationHeaders).toEqual(["Bearer pinned-pool-key"]);
+    expect(agentManager.get(agent.id)?.provider_pool_id).toBeUndefined();
+  });
+
+  test("does not replay a turn on another account after a tool starts", async () => {
+    config.set("tool_approval_mode", "always_allow");
+    const authorizationHeaders: string[] = [];
+    let primaryCalls = 0;
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const authorization = new Headers(init?.headers).get("Authorization") || "";
+      authorizationHeaders.push(authorization);
+      if (authorization === "Bearer primary-side-effect-key") {
+        primaryCalls += 1;
+        if (primaryCalls === 1) {
+          return Response.json({
+            id: "pool-tool-response",
+            object: "chat.completion",
+            model: "gpt-5.2",
+            choices: [
+              {
+                index: 0,
+                finish_reason: "tool_calls",
+                message: {
+                  role: "assistant",
+                  content: "I will calculate that.",
+                  tool_calls: [
+                    {
+                      id: "call-pool-calc",
+                      type: "function",
+                      function: {
+                        name: "calc",
+                        arguments: '{"expression":"6*7"}',
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+            usage: { prompt_tokens: 5, completion_tokens: 2, total_tokens: 7 },
+          });
+        }
+        return Response.json({ error: { message: "weekly quota exceeded" } }, { status: 429 });
+      }
+      return Response.json({
+        id: "unexpected-backup-response",
+        object: "chat.completion",
+        model: "gpt-5.2",
+        choices: [
+          {
+            index: 0,
+            finish_reason: "stop",
+            message: { role: "assistant", content: "backup-replayed-the-turn" },
+          },
+        ],
+      });
+    }) as typeof fetch;
+
+    const primary = providerManager.create({
+      provider: "openai",
+      name: "Primary Side Effect Account",
+      api_key: "primary-side-effect-key",
+    });
+    const backup = providerManager.create({
+      provider: "openai",
+      name: "Backup Side Effect Account",
+      api_key: "backup-side-effect-key",
+    });
+    createdProviderIds.push(primary.id, backup.id);
+    const pool = createProviderAccountPool(
+      {
+        name: "Side effect plans",
+        provider: "openai",
+        accounts: [
+          { providerId: primary.id, priority: 10 },
+          { providerId: backup.id, priority: 20 },
+        ],
+      },
+      [primary, backup]
+    );
+    const agent = agentManager.create({
+      name: "Side Effect Pool Agent",
+      type: "main",
+      provider_id: primary.id,
+      provider_pool_id: pool.id,
+      model: "gpt-5.2",
+      tools: [
+        {
+          name: "calc",
+          description: "Evaluate math",
+          input_schema: {
+            type: "object",
+            properties: { expression: { type: "string" } },
+            required: ["expression"],
+          },
+        },
+      ],
+    });
+    createdAgentIds.push(agent.id);
+
+    const result = await agentManager.execute(
+      agent.id,
+      [{ role: "user", content: "Calculate six times seven" }],
+      {
+        useTools: true,
+        sessionId: `provider-side-effect-${crypto.randomUUID()}`,
+      }
+    );
+
+    expect(result.content).not.toContain("backup-replayed-the-turn");
+    expect(primaryCalls).toBe(2);
+    expect(authorizationHeaders).toEqual([
+      "Bearer primary-side-effect-key",
+      "Bearer primary-side-effect-key",
+    ]);
+  });
+
   test("routes Grok OAuth through the Grok Build proxy and retries one transient 429", async () => {
     let requestUrl = "";
     let requestHeaders = new Headers();
@@ -146,12 +414,97 @@ describe("Agent provider API-family routing", () => {
     const result = await agentManager.execute(
       agent.id,
       [{ role: "user", content: "route this request" }],
-      { useTools: false, useModelRouter: true, sessionId: "router-provider-type-session" }
+      {
+        useTools: false,
+        useModelRouter: true,
+        sessionId: "router-provider-type-session",
+      }
     );
 
     expect(result.content).toBe("router-ok");
     expect(requestUrl.endsWith("/messages")).toBe(true);
     expect(requestHeaders.get("x-api-key")).toBe("synthetic-router-key");
+    expect(agentManager.get(agent.id)?.provider_id).toBe(originalProvider.id);
+  });
+
+  test("model router targets a named provider pool and fails over within that pool", async () => {
+    const authorizationHeaders: string[] = [];
+    globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const authorization = new Headers(init?.headers).get("Authorization") || "";
+      authorizationHeaders.push(authorization);
+      if (authorization === "Bearer router-pool-primary") {
+        return Response.json({ error: { message: "quota exhausted" } }, { status: 429 });
+      }
+      return Response.json({
+        id: "router-pool-response",
+        object: "chat.completion",
+        model: "gpt-5.2",
+        choices: [
+          {
+            index: 0,
+            finish_reason: "stop",
+            message: { role: "assistant", content: "router-pool-ok" },
+          },
+        ],
+        usage: { prompt_tokens: 5, completion_tokens: 2, total_tokens: 7 },
+      });
+    }) as typeof fetch;
+
+    const originalProvider = providerManager.create({
+      provider: "synthetic",
+      name: "Router Pool Agent Provider",
+      api_key: "router-pool-agent",
+    });
+    const primary = providerManager.create({
+      provider: "openai",
+      name: "Router Pool Primary",
+      api_key: "router-pool-primary",
+    });
+    const backup = providerManager.create({
+      provider: "openai",
+      name: "Router Pool Backup",
+      api_key: "router-pool-backup",
+    });
+    createdProviderIds.push(originalProvider.id, primary.id, backup.id);
+    const pool = createProviderAccountPool(
+      {
+        name: "Router OpenAI Pool",
+        provider: "openai",
+        accounts: [
+          { providerId: primary.id, priority: 10 },
+          { providerId: backup.id, priority: 20 },
+        ],
+      },
+      [primary, backup]
+    );
+    const agent = agentManager.create({
+      name: "Router Pool Agent",
+      type: "main",
+      provider_id: originalProvider.id,
+      model: "gpt-5.2",
+      tools: [],
+    });
+    createdAgentIds.push(agent.id);
+    config.set("router", {
+      enabled: true,
+      strategy: "priority",
+      fallbackToAny: false,
+      routes: {
+        [`pool:${pool.id}`]: { weight: 100, priority: 0, enabled: true },
+      },
+    });
+
+    const result = await agentManager.execute(
+      agent.id,
+      [{ role: "user", content: "route through the pool" }],
+      { useTools: false, useModelRouter: true }
+    );
+
+    expect(result.content).toBe("router-pool-ok");
+    expect(authorizationHeaders).toEqual([
+      "Bearer router-pool-primary",
+      "Bearer router-pool-backup",
+    ]);
     expect(agentManager.get(agent.id)?.provider_id).toBe(originalProvider.id);
   });
 
@@ -385,7 +738,12 @@ describe("Agent provider API-family routing", () => {
             type: "message",
             role: "assistant",
             model: "claude-sonnet-4-20250514",
-            content: [{ type: "text", text: "I could not run that tool, but I can still help." }],
+            content: [
+              {
+                type: "text",
+                text: "I could not run that tool, but I can still help.",
+              },
+            ],
             usage: { input_tokens: 18, output_tokens: 12 },
           }),
           { status: 200, headers: { "Content-Type": "application/json" } }
@@ -590,7 +948,12 @@ describe("Agent provider API-family routing", () => {
             type: "message",
             role: "assistant",
             model: "claude-sonnet-4-20250514",
-            content: [{ type: "text", text: "Completed work summarized at the safety boundary." }],
+            content: [
+              {
+                type: "text",
+                text: "Completed work summarized at the safety boundary.",
+              },
+            ],
             usage: { input_tokens: 10, output_tokens: 8 },
           }),
           { status: 200, headers: { "Content-Type": "application/json" } }
@@ -1045,13 +1408,20 @@ describe("Agent provider API-family routing", () => {
                     {
                       id: "call-calc-1",
                       type: "function",
-                      function: { name: "calc", arguments: '{"expression":"21*2"}' },
+                      function: {
+                        name: "calc",
+                        arguments: '{"expression":"21*2"}',
+                      },
                     },
                   ],
                 },
               },
             ],
-            usage: { prompt_tokens: 10, completion_tokens: 3, total_tokens: 13 },
+            usage: {
+              prompt_tokens: 10,
+              completion_tokens: 3,
+              total_tokens: 13,
+            },
           }),
           { status: 200, headers: { "Content-Type": "application/json" } }
         );

--- a/tests/core/error-classifier.test.ts
+++ b/tests/core/error-classifier.test.ts
@@ -35,6 +35,18 @@ describe("classifyApiError", () => {
     expect(classifyApiError({ body: "overloaded" }).category).toBe("overloaded");
   });
 
+  test("treats Z.AI provider overload as transient without rotating the account", () => {
+    const classified = classifyApiError({
+      status: 429,
+      body: JSON.stringify({
+        error: { code: 1305, message: "The service may be temporarily overloaded. Try again." },
+      }),
+    });
+    expect(classified.category).toBe("overloaded");
+    expect(classified.retryable).toBe(true);
+    expect(classified.rotateCredential).toBe(false);
+  });
+
   test("classifies context-too-long and suggests reducing context", () => {
     const c = classifyApiError({ body: "context length exceeded the maximum" });
     expect(c.category).toBe("context_too_long");

--- a/tests/core/mcp-registry-unit.test.ts
+++ b/tests/core/mcp-registry-unit.test.ts
@@ -16,18 +16,22 @@ interface ServerShape {
   args?: string;
   url?: string;
   envVars?: string[];
+  envDefaults?: Record<string, string>;
   categories?: string[];
+  homepage?: string;
   installType: string;
 }
 
 interface WorkerReport {
   popularDefault: ServerShape[];
   popularLimited: ServerShape[];
+  popularAllCount: number;
   categories: string[];
   byCategorySearch: string[];
   byCategoryUpper: string[];
   byCategoryMissing: string[];
   detailsGithub: ServerShape | null;
+  detailsBlender: ServerShape | null;
   detailsMissing: boolean;
   registries: Array<{ id: string; name: string; enabled: boolean }>;
   searchGitOfficial: string[];
@@ -37,8 +41,17 @@ interface WorkerReport {
   searchNoMatch: string[];
   searchEmptyNoRegistry: number;
   searchNpmFetchDown: string[];
+  searchBlender: string[];
   fetchCalls: number;
   installKnown: { success: boolean; hasId: boolean; error?: string };
+  installBlender: {
+    success: boolean;
+    hasId: boolean;
+    command?: string;
+    args?: string;
+    env?: string;
+    error?: string;
+  };
   installCustom: { success: boolean; hasId: boolean; error?: string };
   installMalicious: { success: boolean; hasId: boolean; error?: string };
   installValidCustoms: Array<{ name: string; success: boolean; hasId: boolean; error?: string }>;
@@ -51,6 +64,7 @@ interface WorkerReport {
 // thrower so the npm search path can never touch the network.
 const WORKER_SOURCE = `
 import { mcpRegistry } from "${join(ROOT_DIR, "src", "core", "mcp-registry.ts").replace(/\\/g, "/")}";
+import { mcpManager } from "${join(ROOT_DIR, "src", "core", "mcp.ts").replace(/\\/g, "/")}";
 
 let fetchCalls = 0;
 globalThis.fetch = ((..._args: unknown[]) => {
@@ -62,11 +76,13 @@ const ids = (servers: Array<{ id: string }>) => servers.map((s) => s.id).sort();
 
 const popularDefault = mcpRegistry.getPopular();
 const popularLimited = mcpRegistry.getPopular(3);
+const popularAllCount = mcpRegistry.getPopular(100).length;
 const categories = mcpRegistry.getCategories();
 const byCategorySearch = ids(mcpRegistry.getByCategory("search"));
 const byCategoryUpper = ids(mcpRegistry.getByCategory("SEARCH"));
 const byCategoryMissing = ids(mcpRegistry.getByCategory("no-such-category"));
 const detailsGithub = mcpRegistry.getDetails("mcp-github") ?? null;
+const detailsBlender = mcpRegistry.getDetails("mcp-blender") ?? null;
 const detailsMissing = mcpRegistry.getDetails("does-not-exist") === undefined;
 const registries = mcpRegistry.getRegistries();
 
@@ -77,8 +93,13 @@ const searchDescriptionMatch = ids(await mcpRegistry.search("knowledge graph", "
 const searchNoMatch = ids(await mcpRegistry.search("zzz-no-such-server", "official"));
 const searchEmptyNoRegistry = (await mcpRegistry.search("")).length;
 const searchNpmFetchDown = ids(await mcpRegistry.search("filesystem"));
+const searchBlender = ids(await mcpRegistry.search("blender", "mcp.so"));
 
 const installKnown = await mcpRegistry.installByPackage("io.github/github-mcp-server");
+const installBlenderResult = await mcpRegistry.installByPackage("blender-mcp");
+const installedBlender = installBlenderResult.id
+  ? mcpManager.get(installBlenderResult.id)
+  : undefined;
 const installCustom = await mcpRegistry.installByPackage("some-custom-mcp-pkg");
 const installMalicious = await mcpRegistry.installByPackage("safe-name;touch /tmp/cyb-pwned");
 const validCustomNames = ["@scope/pkg.name", "pkg_name", "pkg.name-1"];
@@ -119,11 +140,13 @@ console.log(
     JSON.stringify({
       popularDefault,
       popularLimited,
+      popularAllCount,
       categories,
       byCategorySearch,
       byCategoryUpper,
       byCategoryMissing,
       detailsGithub,
+      detailsBlender,
       detailsMissing,
       registries,
       searchGitOfficial,
@@ -133,11 +156,20 @@ console.log(
       searchNoMatch,
       searchEmptyNoRegistry,
       searchNpmFetchDown,
+      searchBlender,
       fetchCalls,
       installKnown: {
         success: installKnown.success,
         hasId: typeof installKnown.id === "string" && installKnown.id.length > 0,
         error: installKnown.error,
+      },
+      installBlender: {
+        success: installBlenderResult.success,
+        hasId: typeof installBlenderResult.id === "string" && installBlenderResult.id.length > 0,
+        command: installedBlender?.command,
+        args: installedBlender?.args,
+        env: installedBlender?.env,
+        error: installBlenderResult.error,
       },
       installCustom: {
         success: installCustom.success,
@@ -202,10 +234,13 @@ describe("mcpRegistry catalog surface", () => {
       expect(server.name.length).toBeGreaterThan(0);
       expect(server.description.length).toBeGreaterThan(0);
       expect(["smithery", "mcp.so", "npm", "official"]).toContain(server.registry);
-      expect(["bunx", "bun", "smithery", "remote"]).toContain(server.installType);
+      expect(["bunx", "bun", "smithery", "remote", "uvx"]).toContain(server.installType);
       if (server.installType === "remote") {
         expect(server.command).toBe("");
         expect(server.url).toStartWith("https://");
+      } else if (server.installType === "uvx") {
+        expect(server.command).toBe("uvx");
+        expect(server.args).toContain(server.package);
       } else {
         expect(server.command).toBe("bunx");
         expect(server.args).toContain(
@@ -236,6 +271,23 @@ describe("mcpRegistry catalog surface", () => {
     expect(report.detailsGithub?.url).toBe("https://api.githubcopilot.com/mcp/");
     expect(report.detailsGithub?.installType).toBe("remote");
     expect(report.detailsMissing).toBe(true);
+  });
+
+  test("includes community Blender MCP setup metadata", () => {
+    expect(report.popularDefault.map((server) => server.id)).toContain("mcp-blender");
+    expect(report.detailsBlender).toMatchObject({
+      name: "Blender",
+      registry: "mcp.so",
+      package: "blender-mcp",
+      command: "uvx",
+      args: "--python 3.11 blender-mcp",
+      installType: "uvx",
+      homepage: "https://github.com/ahujasid/blender-mcp",
+      envDefaults: {
+        DISABLE_TELEMETRY: "true",
+        UV_PYTHON_PREFERENCE: "only-managed",
+      },
+    });
   });
 
   test("getRegistries lists the four known registries as enabled", () => {
@@ -272,12 +324,16 @@ describe("mcpRegistry search", () => {
   });
 
   test("empty query without registry returns curated list without npm fetch", () => {
-    expect(report.searchEmptyNoRegistry).toBe(report.popularDefault.length);
+    expect(report.searchEmptyNoRegistry).toBe(report.popularAllCount);
   });
 
   test("npm search failure degrades to local matches only", () => {
     expect(report.fetchCalls).toBeGreaterThan(0);
     expect(report.searchNpmFetchDown).toContain("mcp-filesystem");
+  });
+
+  test("finds Blender from the curated community catalog without network access", () => {
+    expect(report.searchBlender).toEqual(["mcp-blender"]);
   });
 });
 
@@ -285,6 +341,17 @@ describe("mcpRegistry install", () => {
   test("installByPackage registers a curated server", () => {
     expect(report.installKnown.success).toBe(true);
     expect(report.installKnown.hasId).toBe(true);
+  });
+
+  test("installs Blender with uvx and privacy defaults", () => {
+    expect(report.installBlender).toMatchObject({
+      success: true,
+      hasId: true,
+      command: "uvx",
+      args: "--python 3.11 blender-mcp",
+    });
+    expect(report.installBlender.env).toContain("DISABLE_TELEMETRY=true");
+    expect(report.installBlender.env).toContain("UV_PYTHON_PREFERENCE=only-managed");
   });
 
   test("installByPackage synthesizes an entry for unknown packages", () => {

--- a/tests/core/oauth-token-refresh.test.ts
+++ b/tests/core/oauth-token-refresh.test.ts
@@ -270,7 +270,7 @@ describe("OAuth token refresh (openai-codex)", () => {
     expect(refreshed?.refresh_token).toBe("fresh-grok-refresh");
   });
 
-  test("refreshes MiniMax Portal tokens with the current client and scope", async () => {
+  test("retries transient MiniMax Portal token failures and refreshes credentials", async () => {
     const provider = providerManager.create({
       provider: "minimax-portal",
       name: "MiniMax Portal OAuth Test",
@@ -280,9 +280,17 @@ describe("OAuth token refresh (openai-codex)", () => {
     });
     createdProviderIds.push(provider.id);
     let request: RequestInit | undefined;
+    let calls = 0;
     globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
       expect(String(input)).toBe("https://account.minimax.io/oauth2/token");
+      calls += 1;
       request = init;
+      if (calls === 1) {
+        return Response.json(
+          { error: "temporarily_unavailable" },
+          { status: 503, headers: { "Retry-After": "0" } }
+        );
+      }
       return Response.json({
         access_token: "fresh-minimax-token",
         refresh_token: "fresh-minimax-refresh",
@@ -295,12 +303,38 @@ describe("OAuth token refresh (openai-codex)", () => {
     );
     const body = new URLSearchParams(String(request?.body || ""));
 
+    expect(calls).toBe(2);
     expect(body.get("grant_type")).toBe("refresh_token");
     expect(body.get("refresh_token")).toBe("minimax-refresh");
     expect(body.get("client_id")).toBe("659cf4c1-615c-45f6-a5f6-4bf15eb476e5");
     expect(body.get("scope")).toBe("openid profile coding_plan");
     expect(refreshed?.access_token).toBe("fresh-minimax-token");
     expect(refreshed?.refresh_token).toBe("fresh-minimax-refresh");
+  });
+
+  test("adopts credentials refreshed by another process instead of reusing an old refresh token", async () => {
+    const provider = createCodexProvider({
+      access_token: "stale-token",
+      refresh_token: "single-use-refresh",
+      expires_at: Date.now() - 1_000,
+    });
+    const stale = providerManager.getWithCredentials(provider.id);
+    providerManager.update(provider.id, {
+      access_token: "externally-refreshed-token",
+      refresh_token: "rotated-refresh-token",
+      expires_at: Date.now() + 3_600_000,
+    });
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls += 1;
+      return Response.json({ error: "should_not_run" }, { status: 400 });
+    }) as typeof fetch;
+
+    const refreshed = await providerManager.refreshOAuthCredentialsIfNeeded(stale, { force: true });
+
+    expect(calls).toBe(0);
+    expect(refreshed?.access_token).toBe("externally-refreshed-token");
+    expect(refreshed?.refresh_token).toBe("rotated-refresh-token");
   });
 
   test("refreshes Kimi coding-plan tokens with stable device identity", async () => {

--- a/tests/core/plugins.test.ts
+++ b/tests/core/plugins.test.ts
@@ -123,6 +123,9 @@ describe("plugin runtime", () => {
       const installed = listInstalledPlugins();
       expect(installed.filter((plugin) => plugin.builtIn)).toHaveLength(5);
       expect(installed.every((plugin) => plugin.enabled)).toBe(true);
+      expect(
+        installed.find((plugin) => plugin.manifest.id === "blender-workflows")?.skillNames
+      ).toEqual(["blender-mcp"]);
 
       setPluginEnabled("developer-essentials", false);
       clearSkillsCache();
@@ -365,7 +368,9 @@ describe("plugin runtime", () => {
       "exactly one"
     );
     expect(() =>
-      parsePluginInstallPayload({ archive: { name: "plugin.zip", dataBase64: "not base64" } })
+      parsePluginInstallPayload({
+        archive: { name: "plugin.zip", dataBase64: "not base64" },
+      })
     ).not.toThrow();
 
     const ambiguous = await validatePluginInstallPayload({
@@ -391,7 +396,10 @@ describe("plugin runtime", () => {
 
     const traversalZip = createStoredZip([{ path: "../escape.txt", content: "blocked" }]);
     const traversal = await validatePluginInstallPayload({
-      archive: { name: "traversal.zip", dataBase64: traversalZip.toString("base64") },
+      archive: {
+        name: "traversal.zip",
+        dataBase64: traversalZip.toString("base64"),
+      },
     });
     expect(traversal.valid).toBe(false);
     expect(traversal.errors.join(" ")).toContain("Unsafe plugin bundle path");
@@ -409,7 +417,10 @@ describe("plugin runtime", () => {
     const mismatchedZip = createStoredZip([{ path: "plugin/file.txt", content: "data" }]);
     mismatchedZip[30] = "x".charCodeAt(0);
     const mismatched = await validatePluginInstallPayload({
-      archive: { name: "mismatch.zip", dataBase64: mismatchedZip.toString("base64") },
+      archive: {
+        name: "mismatch.zip",
+        dataBase64: mismatchedZip.toString("base64"),
+      },
     });
     expect(mismatched.valid).toBe(false);
     expect(mismatched.errors.join(" ")).toContain("local path does not match");

--- a/tests/core/provider-account-pool.test.ts
+++ b/tests/core/provider-account-pool.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { parseAgentConfig } from "../../src/core/agent-internals";
 import { config } from "../../src/core/config";
-import type { Provider } from "../../src/core/database";
+import { tables, type Agent, type Provider } from "../../src/core/database";
 import {
   createProviderAccountPool,
   deleteProviderAccountPool,
@@ -14,6 +15,8 @@ import {
   updateProviderAccountPool,
 } from "../../src/core/provider-account-pool";
 
+const createdAgentIds: string[] = [];
+
 function provider(id: string, providerType: string): Provider {
   return {
     id,
@@ -23,7 +26,29 @@ function provider(id: string, providerType: string): Provider {
   };
 }
 
-afterEach(() => resetProviderAccountPoolsForTests());
+afterEach(() => {
+  for (const agentId of createdAgentIds.splice(0)) tables.agents.delete(agentId);
+  resetProviderAccountPoolsForTests();
+});
+
+function agentForPool(poolId: string, providerId: string): Agent {
+  const agent: Agent = {
+    id: crypto.randomUUID(),
+    name: `Agent ${poolId}`,
+    provider_id: providerId,
+    config: { provider_account_pool_id: poolId, retained: true },
+    status: "stopped",
+    memory_enabled: false,
+  };
+  tables.agents.create(agent);
+  createdAgentIds.push(agent.id);
+  return agent;
+}
+
+function storedAgentConfig(agentId: string): Record<string, unknown> {
+  const stored = tables.agents.get(agentId) as Agent | undefined;
+  return parseAgentConfig(stored?.config, agentId);
+}
 
 describe("provider account pools", () => {
   test("keeps accounts isolated until a named pool includes them", () => {
@@ -143,6 +168,36 @@ describe("provider account pools", () => {
     removeProviderFromAccountPools(backup.id);
     expect(listProviderAccountPools()[0]?.accounts).toEqual([{ providerId: primary.id }]);
     expect(deleteProviderAccountPool(pool.id)).toBe(true);
+    expect(listProviderAccountPools()).toEqual([]);
+  });
+
+  test("detaches agents when pools are deleted or lose their last account", () => {
+    const first = provider("first", "openai-codex");
+    const second = provider("second", "openai-codex");
+    const deletedPool = createProviderAccountPool(
+      {
+        name: "Deleted Pool",
+        provider: "openai-codex",
+        accounts: [{ providerId: first.id }],
+      },
+      [first, second]
+    );
+    const emptiedPool = createProviderAccountPool(
+      {
+        name: "Emptied Pool",
+        provider: "openai-codex",
+        accounts: [{ providerId: second.id }],
+      },
+      [first, second]
+    );
+    const deletedPoolAgent = agentForPool(deletedPool.id, first.id);
+    const emptiedPoolAgent = agentForPool(emptiedPool.id, second.id);
+
+    expect(deleteProviderAccountPool(deletedPool.id)).toBe(true);
+    removeProviderFromAccountPools(second.id);
+
+    expect(storedAgentConfig(deletedPoolAgent.id)).toEqual({ retained: true });
+    expect(storedAgentConfig(emptiedPoolAgent.id)).toEqual({ retained: true });
     expect(listProviderAccountPools()).toEqual([]);
   });
 

--- a/tests/core/provider-account-pool.test.ts
+++ b/tests/core/provider-account-pool.test.ts
@@ -1,0 +1,271 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { config } from "../../src/core/config";
+import type { Provider } from "../../src/core/database";
+import {
+  createProviderAccountPool,
+  deleteProviderAccountPool,
+  listProviderAccountPools,
+  markProviderAccountUnavailable,
+  providerAccountCooldownUntil,
+  providerAccountPoolCandidates,
+  providerAccountRemainingPercent,
+  removeProviderFromAccountPools,
+  resetProviderAccountPoolsForTests,
+  updateProviderAccountPool,
+} from "../../src/core/provider-account-pool";
+
+function provider(id: string, providerType: string): Provider {
+  return {
+    id,
+    provider: providerType,
+    name: id,
+    is_default: false,
+  };
+}
+
+afterEach(() => resetProviderAccountPoolsForTests());
+
+describe("provider account pools", () => {
+  test("keeps accounts isolated until a named pool includes them", () => {
+    const primary = provider("primary", "openai-codex");
+    const backup = provider("backup", "openai-codex");
+
+    expect(
+      providerAccountPoolCandidates(undefined, primary, [primary, backup]).map((item) => item.id)
+    ).toEqual(["primary"]);
+
+    const pool = createProviderAccountPool(
+      {
+        name: "Codex plans",
+        provider: "openai-codex",
+        accounts: [
+          { providerId: primary.id, priority: 20 },
+          { providerId: backup.id, priority: 10 },
+        ],
+      },
+      [primary, backup]
+    );
+
+    expect(
+      providerAccountPoolCandidates(pool.id, primary, [primary, backup]).map((item) => item.id)
+    ).toEqual(["backup", "primary"]);
+  });
+
+  test("supports multiple pools for one provider without crossing membership", () => {
+    const first = provider("first", "openai-codex");
+    const second = provider("second", "openai-codex");
+    const third = provider("third", "openai-codex");
+    const work = createProviderAccountPool(
+      {
+        name: "Work",
+        provider: "openai-codex",
+        accounts: [{ providerId: first.id }, { providerId: second.id }],
+      },
+      [first, second, third]
+    );
+    const personal = createProviderAccountPool(
+      {
+        name: "Personal",
+        provider: "openai-codex",
+        accounts: [{ providerId: third.id }],
+      },
+      [first, second, third]
+    );
+
+    expect(
+      providerAccountPoolCandidates(work.id, first, [first, second, third]).map((item) => item.id)
+    ).toEqual(["first", "second"]);
+    expect(
+      providerAccountPoolCandidates(personal.id, third, [first, second, third]).map(
+        (item) => item.id
+      )
+    ).toEqual(["third"]);
+  });
+
+  test("rejects cross-provider and duplicate pool membership", () => {
+    const codex = provider("codex", "openai-codex");
+    const zai = provider("zai", "z.ai-coding");
+    expect(() =>
+      createProviderAccountPool(
+        {
+          name: "Invalid",
+          provider: "openai-codex",
+          accounts: [{ providerId: zai.id }],
+        },
+        [codex, zai]
+      )
+    ).toThrow("selected provider type");
+    createProviderAccountPool(
+      {
+        name: "First",
+        provider: "openai-codex",
+        accounts: [{ providerId: codex.id }],
+      },
+      [codex, zai]
+    );
+    expect(() =>
+      createProviderAccountPool(
+        {
+          name: "Second",
+          provider: "openai-codex",
+          accounts: [{ providerId: codex.id }],
+        },
+        [codex, zai]
+      )
+    ).toThrow("only one pool");
+  });
+
+  test("updates, disables, removes accounts, and deletes pools", () => {
+    const primary = provider("primary", "z.ai-coding");
+    const backup = provider("backup", "z.ai-coding");
+    const pool = createProviderAccountPool(
+      {
+        name: "Zai plans",
+        provider: "z.ai-coding",
+        accounts: [{ providerId: primary.id }],
+      },
+      [primary, backup]
+    );
+    const updated = updateProviderAccountPool(
+      pool.id,
+      {
+        name: "Zai plans",
+        provider: "z.ai-coding",
+        enabled: false,
+        accounts: [{ providerId: primary.id }, { providerId: backup.id }],
+      },
+      [primary, backup]
+    );
+    expect(updated?.enabled).toBe(false);
+    expect(
+      providerAccountPoolCandidates(pool.id, primary, [primary, backup]).map((item) => item.id)
+    ).toEqual([]);
+    removeProviderFromAccountPools(backup.id);
+    expect(listProviderAccountPools()[0]?.accounts).toEqual([{ providerId: primary.id }]);
+    expect(deleteProviderAccountPool(pool.id)).toBe(true);
+    expect(listProviderAccountPools()).toEqual([]);
+  });
+
+  test("skips exhausted accounts until their failure cooldown expires", () => {
+    const primary = provider("primary", "z.ai-coding");
+    const backup = provider("backup", "z.ai-coding");
+    const pool = createProviderAccountPool(
+      {
+        name: "Zai plans",
+        provider: "z.ai-coding",
+        accounts: [
+          { providerId: primary.id, priority: 10 },
+          { providerId: backup.id, priority: 20 },
+        ],
+      },
+      [primary, backup]
+    );
+    const now = Date.now();
+    markProviderAccountUnavailable(primary.id, "rate_limit", now);
+
+    expect(providerAccountCooldownUntil(primary.id)).toBeGreaterThan(now);
+    expect(
+      providerAccountPoolCandidates(pool.id, primary, [primary, backup], now + 1_000).map(
+        (item) => item.id
+      )
+    ).toEqual(["backup"]);
+    expect(
+      providerAccountPoolCandidates(pool.id, primary, [primary, backup], now + 3_601_000).map(
+        (item) => item.id
+      )
+    ).toEqual(["primary", "backup"]);
+  });
+
+  test("uses tracked remaining usage when no priority override is set", () => {
+    const primary = provider("primary", "openai-codex");
+    const backup = provider("backup", "openai-codex");
+    const pool = createProviderAccountPool(
+      {
+        name: "Codex plans",
+        provider: "openai-codex",
+        accounts: [{ providerId: primary.id }, { providerId: backup.id }],
+      },
+      [primary, backup]
+    );
+
+    expect(
+      providerAccountPoolCandidates(
+        pool.id,
+        primary,
+        [primary, backup],
+        Date.now(),
+        new Map([
+          [primary.id, 15],
+          [backup.id, 80],
+        ])
+      ).map((item) => item.id)
+    ).toEqual(["backup", "primary"]);
+  });
+
+  test("migrates the former default priority to automatic usage balancing", () => {
+    config.set("provider_account_pools", [
+      {
+        id: "legacy-pool",
+        name: "Legacy plans",
+        provider: "openai-codex",
+        enabled: true,
+        accounts: [
+          { providerId: "primary", priority: 100 },
+          { providerId: "backup", priority: 100 },
+        ],
+      },
+    ]);
+
+    expect(listProviderAccountPools()[0]?.accounts).toEqual([
+      { providerId: "primary" },
+      { providerId: "backup" },
+    ]);
+  });
+
+  test("keeps explicit priorities ahead of automatic usage ordering", () => {
+    const primary = provider("primary", "openai-codex");
+    const backup = provider("backup", "openai-codex");
+    const pool = createProviderAccountPool(
+      {
+        name: "Codex plans",
+        provider: "openai-codex",
+        accounts: [{ providerId: primary.id, priority: 20 }, { providerId: backup.id }],
+      },
+      [primary, backup]
+    );
+
+    expect(
+      providerAccountPoolCandidates(
+        pool.id,
+        primary,
+        [primary, backup],
+        Date.now(),
+        new Map([
+          [primary.id, 5],
+          [backup.id, 95],
+        ])
+      ).map((item) => item.id)
+    ).toEqual(["primary", "backup"]);
+  });
+
+  test("uses the lowest finite plan window as remaining account capacity", () => {
+    expect(
+      providerAccountRemainingPercent({
+        source: "oauth_api",
+        fetchedAt: Date.now(),
+        fiveHour: { usedPercent: 20 },
+        weekly: { usedPercent: 70 },
+        monthly: { usedPercent: 0, unlimited: true },
+      })
+    ).toBe(30);
+    expect(
+      providerAccountRemainingPercent({
+        source: "oauth_api",
+        fetchedAt: Date.now(),
+        fiveHour: { usedPercent: 0, unlimited: true },
+        weekly: { usedPercent: 0, unlimited: true },
+      })
+    ).toBe(100);
+    expect(providerAccountRemainingPercent(null)).toBeUndefined();
+  });
+});

--- a/tests/core/provider-plans.test.ts
+++ b/tests/core/provider-plans.test.ts
@@ -45,7 +45,10 @@ function addProviderTokens(providerKey: string, tokens: number): void {
     type: "token_usage_by_provider",
     key: providerKey,
     value: tokens,
-    metadata: JSON.stringify({ providerId: providerKey, provider: providerKey }),
+    metadata: JSON.stringify({
+      providerId: providerKey,
+      provider: providerKey,
+    }),
   });
 }
 
@@ -365,7 +368,10 @@ describe("provider plan monitoring", () => {
   test("refreshes expired xAI OAuth before loading Grok Build usage", async () => {
     const providerId = createProvider("xai-oauth", "o".repeat(64), "https://api.x.ai/v1");
     const stored = tables.providers.get(providerId) as Provider;
-    tables.providers.update(providerId, { ...stored, expires_at: Date.now() - 1 });
+    tables.providers.update(providerId, {
+      ...stored,
+      expires_at: Date.now() - 1,
+    });
     const refreshedToken = "n".repeat(64);
     const seenUrls: string[] = [];
     const hex =
@@ -376,7 +382,10 @@ describe("provider plan monitoring", () => {
     globalThis.fetch = (async (url, init) => {
       seenUrls.push(String(url));
       if (String(url) === "https://auth.x.ai/oauth2/token") {
-        return Response.json({ access_token: refreshedToken, expires_in: 3600 });
+        return Response.json({
+          access_token: refreshedToken,
+          expires_in: 3600,
+        });
       }
       expect(String(url)).toBe(
         "https://grok.com/grok_api_v2.GrokBuildBilling/GetGrokCreditsConfig"
@@ -458,22 +467,33 @@ describe("provider plan monitoring", () => {
         });
       }
       if (String(url).endsWith("v1internal:retrieveUserQuotaSummary")) {
-        expect(JSON.parse(String(init?.body))).toEqual({ project: "managed-project-123" });
+        expect(JSON.parse(String(init?.body))).toEqual({
+          project: "managed-project-123",
+        });
         return Response.json({
           response: {
             groups: [
               {
                 displayName: "Gemini Models",
                 buckets: [
-                  { bucketId: "gemini-5h", remaining: { remainingFraction: 0.91 } },
-                  { bucketId: "gemini-weekly", remaining: { remainingFraction: 0.82 } },
+                  {
+                    bucketId: "gemini-5h",
+                    remaining: { remainingFraction: 0.91 },
+                  },
+                  {
+                    bucketId: "gemini-weekly",
+                    remaining: { remainingFraction: 0.82 },
+                  },
                 ],
               },
               {
                 displayName: "Claude and GPT models",
                 buckets: [
                   { bucketId: "3p-5h", remaining: { remainingFraction: 0.73 } },
-                  { bucketId: "3p-weekly", remaining: { remainingFraction: 0.64 } },
+                  {
+                    bucketId: "3p-weekly",
+                    remaining: { remainingFraction: 0.64 },
+                  },
                 ],
               },
             ],
@@ -546,6 +566,45 @@ describe("provider plan monitoring", () => {
       ["billing_month", 22],
       ["local_30d", undefined],
     ]);
+    expect(snapshot?.windows.find((window) => window.id === "billing_month")?.title).toBe(
+      "Monthly MCP"
+    );
+  });
+
+  test("retries Z.ai usage with bearer authorization after an API-level auth failure", async () => {
+    const providerId = createProvider(
+      "z.ai-coding",
+      "zai-bearer-token",
+      "https://api.z.ai/api/coding/paas/v4"
+    );
+    const seenAuthorization: string[] = [];
+    globalThis.fetch = (async (_url, init) => {
+      const authorization = (init?.headers as Record<string, string>)?.Authorization ?? "";
+      seenAuthorization.push(authorization);
+      if (authorization === "zai-bearer-token") {
+        return Response.json({
+          code: 401,
+          success: false,
+          msg: "token expired",
+        });
+      }
+      return Response.json({
+        code: 200,
+        success: true,
+        data: {
+          limits: [{ type: "TOKENS_LIMIT", unit: 3, number: 5, percentage: 18 }],
+        },
+      });
+    }) as typeof fetch;
+    setProviderPlanMonitoringConfig({ enabled: true, providers: {} });
+
+    const status = await enrichProviderPlanStatusWithLiveUsage(getProviderPlanStatus());
+    const snapshot = status.providers.find(
+      (provider) => provider.configuredProviderId === providerId
+    );
+
+    expect(seenAuthorization).toEqual(["zai-bearer-token", "Bearer zai-bearer-token"]);
+    expect(snapshot?.windows.find((window) => window.id === "5h")?.usedPercent).toBe(18);
   });
 
   test("enriches Kimi coding plan quota from provider usage endpoint", async () => {
@@ -561,10 +620,20 @@ describe("provider plan monitoring", () => {
         "Bearer sk-kimi-test-token"
       );
       return Response.json({
-        usage: { name: "Weekly Usage", limit: 1000, used: 420, resetTime: 1783665881000 },
+        usage: {
+          name: "Weekly Usage",
+          limit: 1000,
+          used: 420,
+          resetTime: 1783665881000,
+        },
         limits: [
           {
-            detail: { name: "5h Limit", limit: 100, used: 64, resetTime: 1783405927000 },
+            detail: {
+              name: "5h Limit",
+              limit: 100,
+              used: 64,
+              resetTime: 1783405927000,
+            },
             window: { duration: 5, time_unit: "HOUR" },
           },
         ],

--- a/tests/core/provider-plans.test.ts
+++ b/tests/core/provider-plans.test.ts
@@ -516,8 +516,14 @@ describe("provider plan monitoring", () => {
       return Response.json({
         data: {
           limits: [
-            { type: "TIME_LIMIT", percentage: 22 },
-            { type: "TOKENS_LIMIT", percentage: 91 },
+            {
+              type: "TIME_LIMIT",
+              unit: 5,
+              percentage: 22,
+              usageDetails: [{ modelCode: "search-prime", usage: 220 }],
+            },
+            { type: "TOKENS_LIMIT", unit: 3, number: 5, percentage: 91 },
+            { type: "TOKENS_LIMIT", unit: 6, number: 1, percentage: 37 },
           ],
         },
       });
@@ -536,7 +542,8 @@ describe("provider plan monitoring", () => {
     expect(snapshot?.manualPlanEditable).toBe(false);
     expect(snapshot?.windows.map((window) => [window.id, window.usedPercent])).toEqual([
       ["5h", 91],
-      ["weekly", 22],
+      ["weekly", 37],
+      ["billing_month", 22],
       ["local_30d", undefined],
     ]);
   });

--- a/tests/core/provider-retry.test.ts
+++ b/tests/core/provider-retry.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import {
+  boundedPoolRetryDelayMs,
+  parseProviderRetryAfterMs,
+  providerExceptionRetryDelayMs,
+  providerRetryDelayMs,
+} from "../../src/core/provider-retry";
+
+describe("provider retry policy", () => {
+  test("parses millisecond, second, and HTTP-date retry hints", () => {
+    expect(parseProviderRetryAfterMs(new Headers({ "retry-after-ms": "125" }), 999, 1_000)).toBe(
+      125
+    );
+    expect(parseProviderRetryAfterMs(new Headers({ "retry-after": "2.5" }), 999, 1_000)).toBe(
+      2_500
+    );
+    expect(
+      parseProviderRetryAfterMs(
+        new Headers({ "retry-after": new Date(6_000).toUTCString() }),
+        999,
+        1_000
+      )
+    ).toBe(5_000);
+  });
+
+  test("uses bounded exponential backoff with nonnegative jitter", () => {
+    expect(providerRetryDelayMs(503, new Headers(), 0, () => 0)).toBe(1_000);
+    expect(providerRetryDelayMs(503, new Headers(), 2, () => 1)).toBe(4_250);
+    expect(providerRetryDelayMs(503, new Headers(), 10, () => 0)).toBe(8_000);
+  });
+
+  test("does not retry caller aborts or non-transient errors", () => {
+    const controller = new AbortController();
+    controller.abort();
+    expect(
+      providerExceptionRetryDelayMs(new Error("fetch failed: ECONNRESET"), 0, controller.signal)
+    ).toBeUndefined();
+    expect(providerExceptionRetryDelayMs(new Error("invalid request"), 0)).toBeUndefined();
+  });
+
+  test("does not allow an empty credential pool to create an infinite delay", () => {
+    expect(boundedPoolRetryDelayMs(Number.POSITIVE_INFINITY, 1_250)).toBe(1_250);
+    expect(boundedPoolRetryDelayMs(3_000, 1_250)).toBe(3_000);
+  });
+});

--- a/tests/core/provider-settings.test.ts
+++ b/tests/core/provider-settings.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import {
+  normalizeProviderSettings,
+  readDevinProviderSettings,
+} from "../../src/core/provider-settings";
+
+describe("provider settings", () => {
+  test("normalizes Devin transport settings", () => {
+    const normalized = normalizeProviderSettings("devin", {
+      organizationId: "org_123",
+      pollIntervalMs: 2500,
+      timeoutMs: 900000,
+    });
+
+    expect(readDevinProviderSettings(normalized)).toEqual({
+      organizationId: "org_123",
+      pollIntervalMs: 2500,
+      timeoutMs: 900000,
+    });
+  });
+
+  test("rejects settings for providers without a settings contract", () => {
+    expect(normalizeProviderSettings("openai", { accountPool: true })).toBeUndefined();
+  });
+});

--- a/tests/core/provider-usage-source.test.ts
+++ b/tests/core/provider-usage-source.test.ts
@@ -344,7 +344,74 @@ describe("parseZaiUsageResponse", () => {
     expect(result?.monthly?.resetsAt).toBe(new Date(1785984001998).toISOString());
   });
 
-  test("maps a weekly tool-call quota by provider unit", () => {
+  test("uses quota totals when they are more precise than the reported percentage", () => {
+    const result = parseZaiUsageResponse(
+      {
+        code: 200,
+        success: true,
+        data: {
+          planName: "GLM Coding Plan Pro",
+          limits: [
+            {
+              type: "TOKENS_LIMIT",
+              unit: 3,
+              number: 5,
+              usage: 400,
+              currentValue: 101,
+              remaining: 299,
+              percentage: 25,
+            },
+            {
+              type: "TOKENS_LIMIT",
+              unit: 6,
+              number: 1,
+              usage: 1000,
+              currentValue: 91,
+              remaining: 909,
+              percentage: 9,
+            },
+            {
+              type: "TIME_LIMIT",
+              unit: 5,
+              number: 1,
+              usage: 1000,
+              currentValue: 224,
+              remaining: 776,
+              percentage: 22,
+            },
+          ],
+        },
+      },
+      904
+    );
+
+    expect(result?.planLabel).toBe("GLM Coding Plan Pro");
+    expect(result?.fiveHour?.usedPercent).toBeCloseTo(25.25);
+    expect(result?.weekly?.usedPercent).toBeCloseTo(9.1);
+    expect(result?.monthly?.usedPercent).toBeCloseTo(22.4);
+  });
+
+  test("computes usage when percentage is absent", () => {
+    const result = parseZaiUsageResponse(
+      {
+        data: {
+          limits: [
+            {
+              type: "TIME_LIMIT",
+              usage: "1000",
+              currentValue: "19",
+              remaining: "981",
+            },
+          ],
+        },
+      },
+      905
+    );
+
+    expect(result?.monthly?.usedPercent).toBe(1.9);
+  });
+
+  test("maps the weekly coding-plan quota by provider unit", () => {
     const result = parseZaiUsageResponse(
       {
         data: {
@@ -356,7 +423,7 @@ describe("parseZaiUsageResponse", () => {
               percentage: 11,
             },
             {
-              type: "TOOL_CALL_LIMIT",
+              type: "TOKENS_LIMIT",
               unit: 6,
               number: 1,
               percentage: 63,
@@ -402,8 +469,16 @@ describe("parseZaiUsageResponse", () => {
       {
         data: {
           limits: [
-            { type: "TOKENS_LIMIT", percentage: 70, nextResetTime: 1783984001998 },
-            { type: "TOKENS_LIMIT", percentage: 20, nextResetTime: 1783489036671 },
+            {
+              type: "TOKENS_LIMIT",
+              percentage: 70,
+              nextResetTime: 1783984001998,
+            },
+            {
+              type: "TOKENS_LIMIT",
+              percentage: 20,
+              nextResetTime: 1783489036671,
+            },
           ],
         },
       },
@@ -412,6 +487,37 @@ describe("parseZaiUsageResponse", () => {
 
     expect(result?.fiveHour?.usedPercent).toBe(20);
     expect(result?.weekly?.usedPercent).toBe(70);
+  });
+
+  test("does not mislabel a daily token quota as the five-hour quota", () => {
+    const result = parseZaiUsageResponse(
+      {
+        data: {
+          limits: [
+            { type: "TOKENS_LIMIT", unit: 4, percentage: 35 },
+            { type: "TOKENS_LIMIT", unit: 6, percentage: 70 },
+          ],
+        },
+      },
+      906
+    );
+
+    expect(result?.fiveHour).toBeUndefined();
+    expect(result?.weekly?.usedPercent).toBe(70);
+  });
+
+  test("rejects API-level failures returned with HTTP-success payloads", () => {
+    expect(
+      parseZaiUsageResponse(
+        {
+          code: 401,
+          success: false,
+          msg: "token expired",
+          data: { limits: [{ type: "TOKENS_LIMIT", unit: 3, percentage: 0 }] },
+        },
+        907
+      )
+    ).toBeNull();
   });
 
   test("returns null when no recognized quota limit is present", () => {
@@ -424,14 +530,28 @@ describe("parseKimiUsageResponse", () => {
   test("maps coding-plan usage payloads into 5h, weekly, and monthly windows", () => {
     const result = parseKimiUsageResponse(
       {
-        usage: { name: "Weekly Usage", limit: 1000, used: 300, resetTime: 1783665881000 },
+        usage: {
+          name: "Weekly Usage",
+          limit: 1000,
+          used: 300,
+          resetTime: 1783665881000,
+        },
         limits: [
           {
-            detail: { name: "Fast 5h", limit: 100, remaining: 25, reset_in: 3600 },
+            detail: {
+              name: "Fast 5h",
+              limit: 100,
+              remaining: 25,
+              reset_in: 3600,
+            },
             window: { duration: 5, time_unit: "HOUR" },
           },
           {
-            detail: { name: "Monthly", percent: 41, reset_at: "2026-07-31T00:00:00Z" },
+            detail: {
+              name: "Monthly",
+              percent: 41,
+              reset_at: "2026-07-31T00:00:00Z",
+            },
             window: { duration: 1, time_unit: "MONTH" },
           },
         ],
@@ -547,7 +667,11 @@ describe("parseOpenCodeUsageResponse", () => {
           renewAt: "2026-08-01T00:00:00Z",
           usage: {
             rollingUsage: { usagePercent: 12.5, resetInSec: 3600 },
-            weeklyUsage: { used: 44, limit: 100, resetAt: "2026-07-14T00:00:00Z" },
+            weeklyUsage: {
+              used: 44,
+              limit: 100,
+              resetAt: "2026-07-14T00:00:00Z",
+            },
             monthlyUsage: { usage_percent: 65 },
           },
         },

--- a/tests/core/provider-usage-source.test.ts
+++ b/tests/core/provider-usage-source.test.ts
@@ -253,13 +253,28 @@ describe("parseAntigravityUsageResponse", () => {
 });
 
 describe("parseZaiUsageResponse", () => {
-  test("maps quota-limit token and time percentages into five-hour and weekly windows", () => {
+  test("does not infer unlimited weekly usage when the provider omits the weekly bucket", () => {
     const result = parseZaiUsageResponse(
       {
         data: {
+          level: "pro",
           limits: [
-            { type: "TIME_LIMIT", percentage: 7, nextResetTime: 1783984001998 },
-            { type: "TOKENS_LIMIT", percentage: 44, nextResetTime: 1783489036671 },
+            {
+              type: "TIME_LIMIT",
+              percentage: 7,
+              nextResetTime: 1783984001998,
+              usageDetails: [
+                { modelCode: "search-prime", usage: 2 },
+                { modelCode: "web-reader", usage: 5 },
+              ],
+            },
+            {
+              type: "TOKENS_LIMIT",
+              unit: 3,
+              number: 5,
+              percentage: 44,
+              nextResetTime: 1783489036671,
+            },
           ],
         },
       },
@@ -270,15 +285,137 @@ describe("parseZaiUsageResponse", () => {
     expect(result?.source).toBe("provider_api");
     expect(result?.fiveHour?.usedPercent).toBe(44);
     expect(result?.fiveHour?.resetsAt).toBe(new Date(1783489036671).toISOString());
-    expect(result?.weekly?.usedPercent).toBe(7);
-    expect(result?.weekly?.resetsAt).toBe(new Date(1783984001998).toISOString());
+    expect(result?.weekly).toBeUndefined();
+    expect(result?.monthly?.usedPercent).toBe(7);
+    expect(result?.monthly?.resetsAt).toBe(new Date(1783984001998).toISOString());
     expect(result?.fetchedAt).toBe(800);
   });
 
-  test("returns null when no token quota limit is present", () => {
-    expect(
-      parseZaiUsageResponse({ data: { limits: [{ type: "TIME_LIMIT", percentage: 7 }] } }, 1)
-    ).toBeNull();
+  test("does not infer unlimited weekly usage for unknown plan levels", () => {
+    const result = parseZaiUsageResponse(
+      {
+        data: {
+          limits: [{ type: "TOKENS_LIMIT", unit: 3, percentage: 44 }],
+        },
+      },
+      801
+    );
+
+    expect(result?.fiveHour?.usedPercent).toBe(44);
+    expect(result?.weekly).toBeUndefined();
+  });
+
+  test("maps separate five-hour, weekly, and monthly limits by provider unit", () => {
+    const result = parseZaiUsageResponse(
+      {
+        data: {
+          limits: [
+            {
+              type: "TOKENS_LIMIT",
+              unit: 6,
+              number: 1,
+              percentage: 31,
+              nextResetTime: 1783984001998,
+            },
+            {
+              type: "TOKENS_LIMIT",
+              unit: 3,
+              number: 5,
+              percentage: 19,
+              nextResetTime: 1784084001998,
+            },
+            {
+              type: "TIME_LIMIT",
+              unit: 5,
+              number: 1,
+              percentage: 12,
+              nextResetTime: 1785984001998,
+            },
+          ],
+        },
+      },
+      900
+    );
+
+    expect(result?.fiveHour?.usedPercent).toBe(19);
+    expect(result?.weekly?.usedPercent).toBe(31);
+    expect(result?.weekly?.resetsAt).toBe(new Date(1783984001998).toISOString());
+    expect(result?.monthly?.usedPercent).toBe(12);
+    expect(result?.monthly?.resetsAt).toBe(new Date(1785984001998).toISOString());
+  });
+
+  test("maps a weekly tool-call quota by provider unit", () => {
+    const result = parseZaiUsageResponse(
+      {
+        data: {
+          limits: [
+            {
+              type: "TOKENS_LIMIT",
+              unit: 3,
+              number: 5,
+              percentage: 11,
+            },
+            {
+              type: "TOOL_CALL_LIMIT",
+              unit: 6,
+              number: 1,
+              percentage: 63,
+              nextResetTime: 1784584001998,
+            },
+            {
+              type: "TIME_LIMIT",
+              unit: 5,
+              number: 1,
+              percentage: 7,
+            },
+          ],
+        },
+      },
+      902
+    );
+
+    expect(result?.fiveHour?.usedPercent).toBe(11);
+    expect(result?.weekly?.usedPercent).toBe(63);
+    expect(result?.weekly?.resetsAt).toBe(new Date(1784584001998).toISOString());
+    expect(result?.monthly?.usedPercent).toBe(7);
+  });
+
+  test("uses an explicit unlimited weekly entitlement", () => {
+    const result = parseZaiUsageResponse(
+      {
+        data: {
+          limits: [
+            { type: "TOKENS_LIMIT", unit: 3, percentage: 22 },
+            { type: "WEEKLY_LIMIT", unit: 6, unlimited: true },
+          ],
+        },
+      },
+      903
+    );
+
+    expect(result?.weekly?.usedPercent).toBe(0);
+    expect(result?.weekly?.unlimited).toBe(true);
+  });
+
+  test("falls back to reset order for legacy token limits without unit metadata", () => {
+    const result = parseZaiUsageResponse(
+      {
+        data: {
+          limits: [
+            { type: "TOKENS_LIMIT", percentage: 70, nextResetTime: 1783984001998 },
+            { type: "TOKENS_LIMIT", percentage: 20, nextResetTime: 1783489036671 },
+          ],
+        },
+      },
+      901
+    );
+
+    expect(result?.fiveHour?.usedPercent).toBe(20);
+    expect(result?.weekly?.usedPercent).toBe(70);
+  });
+
+  test("returns null when no recognized quota limit is present", () => {
+    expect(parseZaiUsageResponse({ data: { limits: [{ type: "OTHER_LIMIT" }] } }, 1)).toBeNull();
     expect(parseZaiUsageResponse({}, 1)).toBeNull();
   });
 });

--- a/tests/core/reasoning-levels.test.ts
+++ b/tests/core/reasoning-levels.test.ts
@@ -115,6 +115,7 @@ describe("reasoning level support matrix", () => {
   test("Kimi K3 uses the current max-only reasoning contract", () => {
     expect(supportedReasoningEfforts("kimi-code", "k3")).toEqual(["max"]);
     expect(supportedReasoningEfforts("kimi-code-oauth", "k3")).toEqual(["max"]);
+    expect(supportedReasoningEfforts("kimi-code-subscription", "k3")).toEqual(["max"]);
     expect(coerceReasoningEffort("high", "kimi-code-oauth", "k3")).toBe("max");
   });
 

--- a/tests/core/router.test.ts
+++ b/tests/core/router.test.ts
@@ -342,6 +342,39 @@ describe("provider selection", () => {
       tables.metrics.getKeyTotalsForWindows = originalGetKeyTotalsForWindows;
     }
   });
+
+  test("usage_aware prefers verified quota over unknown usage", () => {
+    setRouterConfig({
+      strategy: "usage_aware",
+      routes: {
+        minimax: { weight: 10 },
+        unknown: { weight: 100 },
+      },
+    });
+    config.set("provider_plan_monitoring", {
+      enabled: true,
+      routerEnforcement: true,
+      providers: {
+        minimax: { fiveHour: { tokenLimit: 1000 } },
+      },
+    });
+    const originalGetKeyTotalsForWindows = tables.metrics.getKeyTotalsForWindows;
+    tables.metrics.getKeyTotalsForWindows = ((type: string, startsSql: string[]) =>
+      type === "token_usage_by_provider"
+        ? [
+            {
+              key: "minimax",
+              totals: startsSql.map(() => 500),
+            },
+          ]
+        : []) as typeof tables.metrics.getKeyTotalsForWindows;
+
+    try {
+      expect(selectProvider()).toBe("minimax");
+    } finally {
+      tables.metrics.getKeyTotalsForWindows = originalGetKeyTotalsForWindows;
+    }
+  });
 });
 
 // ─── Input validation ───────────────────────────────────────────────────────

--- a/tests/core/router.test.ts
+++ b/tests/core/router.test.ts
@@ -22,6 +22,7 @@ afterEach(() => {
   resetRouterForTests();
   config.set("router", null);
   config.set("provider_plan_monitoring", null);
+  config.set("provider_account_pools", null);
 });
 
 describe("mixture-of-agents strategy", () => {
@@ -371,6 +372,60 @@ describe("provider selection", () => {
 
     try {
       expect(selectProvider()).toBe("minimax");
+    } finally {
+      tables.metrics.getKeyTotalsForWindows = originalGetKeyTotalsForWindows;
+    }
+  });
+
+  test("keeps pool plan constraints isolated by route", () => {
+    config.set("provider_account_pools", [
+      {
+        id: "primary-pool",
+        name: "Primary Pool",
+        provider: "z.ai-coding",
+        enabled: true,
+        accounts: [{ providerId: "primary-account" }],
+      },
+      {
+        id: "backup-pool",
+        name: "Backup Pool",
+        provider: "z.ai-coding",
+        enabled: true,
+        accounts: [{ providerId: "backup-account" }],
+      },
+    ]);
+    setRouterConfig({
+      strategy: "priority",
+      fallbackToAny: false,
+      routes: {
+        "pool:primary-pool": { weight: 100, priority: 0 },
+        "pool:backup-pool": { weight: 100, priority: 1 },
+      },
+    });
+    config.set("provider_plan_monitoring", {
+      enabled: true,
+      routerEnforcement: true,
+      providers: {
+        "pool:primary-pool": { fiveHour: { tokenLimit: 100 } },
+        "pool:backup-pool": { fiveHour: { tokenLimit: 100 } },
+      },
+    });
+    const originalGetKeyTotalsForWindows = tables.metrics.getKeyTotalsForWindows;
+    tables.metrics.getKeyTotalsForWindows = ((type: string, startsSql: string[]) =>
+      type === "token_usage_by_provider"
+        ? [
+            {
+              key: "pool:primary-pool",
+              totals: startsSql.map(() => 100),
+            },
+          ]
+        : []) as typeof tables.metrics.getKeyTotalsForWindows;
+
+    try {
+      expect(selectProvider()).toBe("pool:backup-pool");
+      const status = getRouterStatus();
+      expect(status.routes[0].plan.status).toBe("exhausted");
+      expect(status.routes[1].plan.status).toBe("ok");
     } finally {
       tables.metrics.getKeyTotalsForWindows = originalGetKeyTotalsForWindows;
     }

--- a/tests/core/skills-resolution.test.ts
+++ b/tests/core/skills-resolution.test.ts
@@ -48,6 +48,7 @@ describe("Skills SKILL.md resolution", () => {
       "authorized-web-pentest",
       "adversarial-ux-test",
       "cloudflare-temporary-deploy",
+      "blender-mcp",
     ];
 
     for (const name of expected) {
@@ -125,5 +126,28 @@ describe("Skills SKILL.md resolution", () => {
       hasConfig: () => true,
     });
     expect(ready.eligible).toBe(true);
+  });
+
+  test("gates Blender MCP on an available Python runner", async () => {
+    const entry = (await loadAllSkills({})).find((skill) => skill.skill.name === "blender-mcp");
+    expect(entry).toBeDefined();
+    if (!entry) throw new Error("Blender MCP skill was not loaded");
+
+    const missingRuntime = checkSkillEligibility(entry, {
+      platform: "darwin",
+      hasBin: () => false,
+      hasEnv: () => true,
+      hasConfig: () => true,
+    });
+    expect(missingRuntime.eligible).toBe(false);
+    expect(missingRuntime.missing.anyBins).toEqual(["uvx", "blender-mcp"]);
+
+    const uvxReady = checkSkillEligibility(entry, {
+      platform: "win32",
+      hasBin: (name) => name === "uvx",
+      hasEnv: () => true,
+      hasConfig: () => true,
+    });
+    expect(uvxReady.eligible).toBe(true);
   });
 });

--- a/tests/core/subagent-execution.test.ts
+++ b/tests/core/subagent-execution.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { existsSync, readFileSync, rmSync } from "fs";
+import { existsSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { agentManager } from "../../src/core/agent";
@@ -15,10 +15,12 @@ import { broadcastStatus, createStatusSnapshotEvent } from "../../src/core/statu
 import {
   getRun,
   getRunsByRequester,
+  initSubagentRegistry,
   markRunCompleted,
   onSubagentLifecycle,
   registerSubagentRun,
   resetSubagentRegistryForTests,
+  configureSubagentRegistry,
 } from "../../src/core/subagent-registry";
 import {
   configureChannelChatRuntime,
@@ -76,6 +78,62 @@ afterEach(() => {
 });
 
 describe("Subagent execution wiring", () => {
+  test("leaves ordinary subagent runs unbounded unless a timeout is requested", () => {
+    const run = registerSubagentRun({
+      childSessionKey: `child-default-timeout-${process.pid}`,
+      requesterSessionKey: `parent-default-timeout-${process.pid}`,
+      task: "Continue until the delegated work is complete",
+    });
+
+    expect(run.runTimeoutSeconds).toBe(0);
+  });
+
+  test("closes restored active runs as interrupted while retaining partial details", () => {
+    const restorePath = join(tmpdir(), `cybara-subagent-restore-${process.pid}.json`);
+    const runId = `restored-active-${process.pid}`;
+    resetSubagentRegistryForTests();
+    configureSubagentRegistry({ persistPath: restorePath });
+    writeFileSync(
+      restorePath,
+      JSON.stringify([
+        [
+          runId,
+          {
+            runId,
+            childSessionKey: `child-${runId}`,
+            requesterSessionKey: `parent-${runId}`,
+            requesterDisplayKey: `parent-${runId}`,
+            task: "Long-running review",
+            cleanup: "keep",
+            createdAt: Date.now() - 60_000,
+            startedAt: Date.now() - 59_000,
+            activities: [
+              {
+                id: "read-1",
+                phase: "result",
+                text: "Read package metadata",
+                timestamp: Date.now() - 30_000,
+                toolName: "read",
+              },
+            ],
+          },
+        ],
+      ])
+    );
+
+    initSubagentRegistry();
+
+    expect(getRun(runId)?.outcome).toEqual({
+      status: "error",
+      error: "Subagent interrupted by gateway restart",
+    });
+    expect(getRun(runId)?.endedAt).toBeNumber();
+    expect(getRun(runId)?.activities?.[0]?.text).toBe("Read package metadata");
+    resetSubagentRegistryForTests();
+    configureSubagentRegistry({ persistPath: testRegistryPath });
+    rmSync(restorePath, { force: true });
+  });
+
   test("preserves oversized final results in the private recovery cache", () => {
     const runId = `result-recovery-${process.pid}`;
     registerSubagentRun({
@@ -164,6 +222,11 @@ describe("Subagent execution wiring", () => {
         }
       | undefined;
     let capturedLiveActivities: string[] = [];
+    let capturedLiveToolCalls: Array<{
+      name: string;
+      status?: "pending" | "executing" | "completed" | "failed";
+      result: unknown;
+    }> = [];
 
     const originalExecute = agentManager.execute.bind(agentManager) as ExecuteShape;
     (agentManager as unknown as { execute: ExecuteShape }).execute = async (
@@ -197,6 +260,12 @@ describe("Subagent execution wiring", () => {
       });
       capturedLiveActivities =
         getRunsByRequester("main")[0]?.activities?.map((activity) => activity.text) || [];
+      capturedLiveToolCalls =
+        getRunsByRequester("main")[0]?.toolCalls?.map((toolCall) => ({
+          name: toolCall.name,
+          status: toolCall.status,
+          result: toolCall.result,
+        })) || [];
       return {
         content: "subagent complete",
         thinking: "The package metadata confirms the result.",
@@ -253,6 +322,13 @@ describe("Subagent execution wiring", () => {
       expect(capturedLiveActivities).toEqual([
         "Inspecting the requested files",
         "Read package metadata",
+      ]);
+      expect(capturedLiveToolCalls).toEqual([
+        {
+          name: "read",
+          status: "completed",
+          result: "Read package metadata",
+        },
       ]);
       expect(
         createStatusSnapshotEvent().activeSessionIds.includes(spawnResult.childSessionKey)

--- a/tests/scripts/package-native-macos.test.ts
+++ b/tests/scripts/package-native-macos.test.ts
@@ -56,6 +56,7 @@ describe("native macOS packaging helpers", () => {
     expect(layout.onnxRuntimeDir).toBe("/bundle/Cybara.app/Contents/Resources/sidecar/onnxruntime");
     expect(layout.runtimeDir).toBe("/bundle/Cybara.app/Contents/Resources/sidecar/runtime");
     expect(layout.cuaDriverDir).toBe("/bundle/Cybara.app/Contents/Resources/sidecar/cua-driver");
+    expect(layout.pluginsDir).toBe("/bundle/Cybara.app/Contents/Resources/sidecar/plugins");
     expect(layout.nodeModulesDir).toBe(
       "/bundle/Cybara.app/Contents/Resources/sidecar/node_modules"
     );

--- a/tests/tauri/wiring.test.ts
+++ b/tests/tauri/wiring.test.ts
@@ -11,7 +11,11 @@ describe("Tauri wiring", () => {
   test("tauri.conf.json includes Cybara sidecar + bundled UI assets", () => {
     const confPath = join(ROOT_DIR, "src-tauri", "tauri.conf.json");
     const conf = JSON.parse(readFileSync(confPath, "utf8")) as {
-      build?: { frontendDist?: string; beforeDevCommand?: string; beforeBuildCommand?: string };
+      build?: {
+        frontendDist?: string;
+        beforeDevCommand?: string;
+        beforeBuildCommand?: string;
+      };
       bundle?: {
         resources?: string[] | Record<string, string>;
         externalBin?: string[];
@@ -29,6 +33,7 @@ describe("Tauri wiring", () => {
         "bin/ui/dist": "ui/dist",
         "bin/node_modules": "node_modules",
         "bin/cua-driver": "cua-driver",
+        "bin/plugins": "plugins",
       });
     }
     expect(conf.bundle?.externalBin).toContain("bin/cybara");

--- a/tests/ui/chat-appearance.test.ts
+++ b/tests/ui/chat-appearance.test.ts
@@ -103,9 +103,13 @@ describe("chat appearance settings", () => {
     const activity = await Bun.file(
       join(ROOT_DIR, "ui", "src", "pages", "chat", "ActivityTimeline.tsx")
     ).text();
-    const subagents = await Bun.file(
-      join(ROOT_DIR, "ui", "src", "pages", "chat", "SubagentPanel.tsx")
-    ).text();
+    const subagents = (
+      await Promise.all(
+        ["SubagentPanel.tsx", "SubagentDetailPanel.tsx", "SubagentTimeline.tsx"].map((file) =>
+          Bun.file(join(ROOT_DIR, "ui", "src", "pages", "chat", file)).text()
+        )
+      )
+    ).join("\n");
     const styles = await Bun.file(join(ROOT_DIR, "ui", "src", "index.css")).text();
     const routes = await Bun.file(join(ROOT_DIR, "src", "api", "routes.ts")).text();
 

--- a/tests/ui/chat-workspace-panel.test.ts
+++ b/tests/ui/chat-workspace-panel.test.ts
@@ -75,6 +75,9 @@ describe("chat workspace panel", () => {
     expect(chatSource).toContain("openWorkspaceFile");
     expect(chatSource).toContain("<SessionDiffPanel");
     expect(chatSource).toContain("<SubagentPanel");
+    expect(chatSource).toContain("<SubagentDetailPanel");
+    expect(chatSource).toContain("openSubagent");
+    expect(chatSource).toContain("onOpenSubagent");
     expect(chatSource).toContain('toggleWorkspaceTab("review")');
     expect(chatSource).toContain('toggleWorkspaceTab("subagents")');
     expect(panelSource).toContain('aria-label="Add workspace tool"');
@@ -170,7 +173,17 @@ describe("chat workspace panel", () => {
     expect(panelSource).toContain("WORKSPACE_SINGLETON_KINDS");
     expect(chatSource).toContain("tabIdRef");
     expect(chatSource).toContain('kind === "browser"');
-    expect(chatSource).toContain('current.some((instance) => instance.kind === "browser")');
+    expect(chatSource).toContain('tabs.some((instance) => instance.kind === "browser")');
+  });
+
+  test("opens each subagent run in a durable workspace tab", () => {
+    expect(chatSource).toContain(
+      'instance.kind === "subagents" && instance.pageKey === normalizedRunId'
+    );
+    expect(chatSource).toContain("id = `subagent-${(tabIdRef.current += 1)}`");
+    expect(chatSource).toContain("runId={instance.pageKey}");
+    expect(chatSource).toContain("previousSessionIdRef.current === sessionId");
+    expect(chatSource).toContain('instance.kind === "subagents" && instance.pageKey');
   });
 
   test("workspace tools remain mounted when the panel is hidden", () => {

--- a/tests/ui/router-provider-metrics-ui.test.ts
+++ b/tests/ui/router-provider-metrics-ui.test.ts
@@ -35,7 +35,9 @@ describe("router, provider, and metrics UI wiring", () => {
     expect(source).toContain("providerPlanUsageClasses");
     expect(source).toContain("presetLimitSummary(preset)");
     expect(source).toContain("Array.isArray(p.info?.models)");
-    expect(source).toContain("displayName={plan?.providerName || providerName(routeType)}");
+    expect(source).toContain(
+      "displayName={route.targetName || plan?.providerName || providerName(routeType)}"
+    );
     expect(source).toContain("formatTokenPrice(route.priceInputPerM, route.priceOutputPerM)");
     expect(source).toContain("Lowest cost");
   });
@@ -55,8 +57,15 @@ describe("router, provider, and metrics UI wiring", () => {
 
   test("providers page renders empty model lists without a stray zero label", () => {
     const source = read("ui/src/pages/Providers.tsx");
+    const poolsSource = read("ui/src/components/providers/ProviderAccountPools.tsx");
     const displaySource = read("ui/src/lib/providerPlanDisplay.ts");
 
+    expect(source).toContain("import { ProviderAccountPools }");
+    expect(source).toContain("<ProviderAccountPools");
+    expect(poolsSource).toContain("Account pools");
+    expect(poolsSource).toContain("automatic usage");
+    expect(poolsSource).toContain("balancing and failover");
+    expect(poolsSource).toContain("Model Router route");
     expect(source).toContain("No bundled models listed");
     expect(source).toContain("provider.models.length > 0");
     expect(source).toContain("selectedProviderInfo.models.length > 0");

--- a/tests/ui/subagent-live-detail.test.ts
+++ b/tests/ui/subagent-live-detail.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const panelSource = readFileSync(
+  fileURLToPath(new URL("../../ui/src/pages/chat/SubagentPanel.tsx", import.meta.url)),
+  "utf8"
+);
+const detailSource = readFileSync(
+  fileURLToPath(new URL("../../ui/src/pages/chat/SubagentDetailPanel.tsx", import.meta.url)),
+  "utf8"
+);
+const hookSource = readFileSync(
+  fileURLToPath(new URL("../../ui/src/hooks/useApi.ts", import.meta.url)),
+  "utf8"
+);
+
+describe("subagent live detail", () => {
+  test("uses workspace tabs instead of a detail modal", () => {
+    expect(panelSource).toContain("onOpenSubagent?.(subagent.id, subagent.label)");
+    expect(panelSource).not.toContain('title={selectedSubagent?.label || "Subagent Details"}');
+    expect(detailSource).toContain("export function SubagentDetailPanel");
+  });
+
+  test("refreshes active detail from child status events with polling recovery", () => {
+    expect(detailSource).toContain('event.type !== "status"');
+    expect(detailSource).toContain("event.sessionId !== sessionKeyRef.current");
+    expect(detailSource).toContain("void refetch()");
+    expect(hookSource).toContain("? 2_000\n        : false");
+  });
+
+  test("shows live timing, activity, tools, and final output in one panel", () => {
+    expect(detailSource).toContain("formatElapsed");
+    expect(detailSource).toContain("<SubagentTimeline subagent={subagent}");
+    expect(detailSource).toContain("Waiting for the first update");
+    expect(detailSource).toContain("Final output");
+  });
+});

--- a/ui/src/components/providers/ProviderAccountPools.tsx
+++ b/ui/src/components/providers/ProviderAccountPools.tsx
@@ -1,0 +1,403 @@
+import { useMemo, useState } from "react";
+import { Edit2, KeyRound, Layers3, Plus, Trash2 } from "lucide-react";
+import {
+  useCreateProviderAccountPool,
+  useDeleteProviderAccountPool,
+  useProviderAccountPools,
+  useUpdateProviderAccountPool,
+} from "@/hooks/useApi";
+import { useUIStore } from "@/stores/uiStore";
+import type {
+  Provider,
+  ProviderAccountPool,
+  ProviderAccountPoolInput,
+  ProviderPlanSnapshot,
+} from "@/types";
+import { Badge } from "@/components/ui/Badge";
+import { Button } from "@/components/ui/Button";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
+import { Input, Select } from "@/components/ui/Input";
+import { Modal } from "@/components/ui/Modal";
+import { Switch } from "@/components/ui/Switch";
+
+interface ProviderAccountPoolsProps {
+  providers: Provider[];
+  plans: ProviderPlanSnapshot[];
+}
+
+interface PoolEditorProps {
+  pool: ProviderAccountPool | null;
+  pools: ProviderAccountPool[];
+  providers: Provider[];
+  isSaving: boolean;
+  onClose: () => void;
+  onSave: (input: ProviderAccountPoolInput) => Promise<void>;
+}
+
+function providerType(provider: Provider): string {
+  return provider.provider || provider.type || "";
+}
+
+function planRemainingPercent(plan: ProviderPlanSnapshot | undefined): number | undefined {
+  if (!plan) return undefined;
+  const windows = plan.windows.filter(
+    (window) => window.usageKnown && (window.unlimited || window.remainingPercent !== undefined)
+  );
+  if (windows.length === 0) return undefined;
+  const limited = windows.filter((window) => window.unlimited !== true);
+  if (limited.length === 0) return 100;
+  const remaining = limited.flatMap((window) =>
+    window.remainingPercent === undefined ? [] : [window.remainingPercent]
+  );
+  return remaining.length > 0 ? Math.min(...remaining) : undefined;
+}
+
+function PoolEditor({ pool, pools, providers, isSaving, onClose, onSave }: PoolEditorProps) {
+  const providerTypes = useMemo(
+    () => Array.from(new Set(providers.map(providerType).filter(Boolean))).sort(),
+    [providers]
+  );
+  const initialProvider = pool?.provider || providerTypes[0] || "";
+  const [name, setName] = useState(pool?.name || "");
+  const [selectedProvider, setSelectedProvider] = useState(initialProvider);
+  const [enabled, setEnabled] = useState(pool?.enabled !== false);
+  const [selectedAccounts, setSelectedAccounts] = useState<Record<string, boolean>>(() =>
+    Object.fromEntries((pool?.accounts || []).map((account) => [account.provider_id, true]))
+  );
+  const [priorities, setPriorities] = useState<Record<string, string>>(() =>
+    Object.fromEntries(
+      (pool?.accounts || []).map((account) => [
+        account.provider_id,
+        typeof account.priority === "number" ? String(account.priority) : "",
+      ])
+    )
+  );
+  const occupiedAccounts = useMemo(
+    () =>
+      new Set(
+        pools
+          .filter((entry) => entry.id !== pool?.id)
+          .flatMap((entry) => entry.accounts.map((account) => account.provider_id))
+      ),
+    [pool?.id, pools]
+  );
+  const matchingAccounts = providers.filter(
+    (provider) => providerType(provider) === selectedProvider
+  );
+  const selectedCount = matchingAccounts.filter(
+    (provider) => selectedAccounts[provider.id] === true
+  ).length;
+
+  const changeProvider = (value: string) => {
+    setSelectedProvider(value);
+    setSelectedAccounts({});
+    setPriorities({});
+  };
+
+  const submit = async () => {
+    await onSave({
+      name,
+      provider: selectedProvider,
+      enabled,
+      accounts: matchingAccounts
+        .filter((provider) => selectedAccounts[provider.id] === true)
+        .map((provider) => {
+          const rawPriority = priorities[provider.id]?.trim();
+          const priority = rawPriority ? Number(rawPriority) : undefined;
+          return priority !== undefined && Number.isFinite(priority)
+            ? {
+                provider_id: provider.id,
+                priority: Math.max(0, Math.min(10_000, priority)),
+              }
+            : { provider_id: provider.id };
+        }),
+    });
+  };
+
+  return (
+    <Modal
+      isOpen
+      onClose={onClose}
+      title={pool ? "Edit account pool" : "New account pool"}
+      size="lg"
+    >
+      <div className="space-y-5">
+        <div className="grid gap-4 sm:grid-cols-2">
+          <Input
+            label="Pool name"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            placeholder="Coding plans"
+            data-autofocus
+          />
+          <Select
+            label="Provider type"
+            value={selectedProvider}
+            onChange={changeProvider}
+            options={providerTypes.map((value) => ({ value, label: value }))}
+          />
+        </div>
+
+        <Switch
+          checked={enabled}
+          onChange={setEnabled}
+          label="Pool enabled"
+          description="Prefer the account with the most remaining tracked usage and rotate after authentication, billing, or rate limit failures."
+        />
+
+        <div>
+          <div className="mb-2 flex items-center justify-between gap-3">
+            <div>
+              <h3 className="text-sm font-medium text-[var(--text-primary)]">Accounts</h3>
+              <p className="mt-0.5 text-xs text-[var(--text-muted)]">
+                Usage chooses the account automatically. Add a priority only when you want an
+                account to override that order.
+              </p>
+            </div>
+            <Badge>{selectedCount} selected</Badge>
+          </div>
+          <div className="space-y-2">
+            {matchingAccounts.map((provider) => {
+              const occupied = occupiedAccounts.has(provider.id);
+              const selected = selectedAccounts[provider.id] === true;
+              return (
+                <div
+                  key={provider.id}
+                  className="grid items-center gap-3 rounded-lg border border-[var(--surface-border)] bg-[var(--surface-panel)] px-3 py-2.5 sm:grid-cols-[minmax(0,1fr)_112px_auto]"
+                >
+                  <div className="min-w-0">
+                    <p className="truncate text-sm font-medium text-[var(--text-primary)]">
+                      {provider.name}
+                    </p>
+                    <p className="truncate text-xs text-[var(--text-muted)]">
+                      {occupied ? "Already assigned to another pool" : provider.id}
+                    </p>
+                  </div>
+                  <Input
+                    aria-label={`Priority for ${provider.name}`}
+                    type="number"
+                    min={0}
+                    max={10000}
+                    value={priorities[provider.id] || ""}
+                    placeholder="Auto"
+                    onChange={(event) =>
+                      setPriorities((current) => ({
+                        ...current,
+                        [provider.id]: event.target.value,
+                      }))
+                    }
+                    disabled={!selected || occupied}
+                    className="px-3 py-2"
+                  />
+                  <Switch
+                    ariaLabel={`Include ${provider.name}`}
+                    checked={selected}
+                    disabled={occupied}
+                    onChange={(value) =>
+                      setSelectedAccounts((current) => ({ ...current, [provider.id]: value }))
+                    }
+                  />
+                </div>
+              );
+            })}
+            {matchingAccounts.length === 0 ? (
+              <div className="rounded-lg border border-dashed border-[var(--surface-border)] px-4 py-6 text-center text-sm text-[var(--text-muted)]">
+                Add an account for this provider before creating a pool.
+              </div>
+            ) : null}
+          </div>
+        </div>
+
+        <div className="flex justify-end gap-2">
+          <Button variant="ghost" onClick={onClose} disabled={isSaving}>
+            Cancel
+          </Button>
+          <Button
+            onClick={() => void submit()}
+            isLoading={isSaving}
+            disabled={!name.trim() || selectedCount === 0}
+          >
+            {pool ? "Save pool" : "Create pool"}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+export function ProviderAccountPools({ providers, plans }: ProviderAccountPoolsProps) {
+  const { data: pools = [], isLoading } = useProviderAccountPools();
+  const createPool = useCreateProviderAccountPool();
+  const updatePool = useUpdateProviderAccountPool();
+  const deletePool = useDeleteProviderAccountPool();
+  const { addToast } = useUIStore();
+  const [editor, setEditor] = useState<ProviderAccountPool | "new" | null>(null);
+  const [deleting, setDeleting] = useState<ProviderAccountPool | null>(null);
+  const providersById = useMemo(
+    () => new Map(providers.map((provider) => [provider.id, provider])),
+    [providers]
+  );
+  const plansByProviderId = useMemo(
+    () =>
+      new Map(
+        plans.flatMap((plan) => {
+          const id = plan.configuredProviderId ?? plan.providerId;
+          return id ? [[id, plan] as const] : [];
+        })
+      ),
+    [plans]
+  );
+
+  const save = async (input: ProviderAccountPoolInput) => {
+    try {
+      if (editor && editor !== "new") {
+        await updatePool.mutateAsync({ id: editor.id, data: input });
+      } else {
+        await createPool.mutateAsync(input);
+      }
+      addToast("success", editor === "new" ? "Account pool created" : "Account pool updated");
+      setEditor(null);
+    } catch (error) {
+      addToast("error", error instanceof Error ? error.message : "Failed to save account pool");
+    }
+  };
+
+  const remove = async () => {
+    if (!deleting) return;
+    try {
+      await deletePool.mutateAsync(deleting.id);
+      addToast("success", "Account pool deleted");
+      setDeleting(null);
+    } catch (error) {
+      addToast("error", error instanceof Error ? error.message : "Failed to delete account pool");
+    }
+  };
+
+  return (
+    <section className="border-b border-[var(--surface-border)] pb-6">
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h3 className="flex items-center gap-2 text-sm font-semibold text-[var(--text-primary)]">
+            <Layers3 className="h-4 w-4 text-[rgb(var(--accent-primary))]" />
+            Account pools
+          </h3>
+          <p className="mt-1 text-xs text-[var(--text-muted)]">
+            Add provider accounts first, then group same-provider accounts for automatic usage
+            balancing and failover.
+          </p>
+        </div>
+        <Button
+          size="sm"
+          variant="secondary"
+          leftIcon={<Plus className="h-4 w-4" />}
+          onClick={() => setEditor("new")}
+          disabled={providers.length === 0}
+        >
+          New pool
+        </Button>
+      </div>
+
+      {isLoading ? (
+        <div className="h-20 animate-pulse rounded-lg bg-[var(--surface-panel)]" />
+      ) : pools.length > 0 ? (
+        <div className="grid gap-3 lg:grid-cols-2">
+          {pools.map((pool) => (
+            <div
+              key={pool.id}
+              className="rounded-lg border border-[var(--surface-border)] bg-[var(--surface-panel)] p-3"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <h4 className="truncate text-sm font-medium text-[var(--text-primary)]">
+                      {pool.name}
+                    </h4>
+                    <Badge variant={pool.enabled ? "success" : "default"}>
+                      {pool.enabled ? "Active" : "Paused"}
+                    </Badge>
+                    <Badge>
+                      {pool.routing_mode === "usage" ? "Usage balanced" : "Priority override"}
+                    </Badge>
+                  </div>
+                  <p className="mt-1 text-xs text-[var(--text-muted)]">{pool.provider}</p>
+                </div>
+                <div className="flex shrink-0 items-center gap-1">
+                  <button
+                    type="button"
+                    aria-label={`Edit ${pool.name}`}
+                    className="rounded-md p-1.5 text-[var(--text-muted)] hover:bg-[var(--surface-hover)] hover:text-[var(--text-primary)]"
+                    onClick={() => setEditor(pool)}
+                  >
+                    <Edit2 className="h-4 w-4" />
+                  </button>
+                  <button
+                    type="button"
+                    aria-label={`Delete ${pool.name}`}
+                    className="rounded-md p-1.5 text-[var(--text-muted)] hover:bg-red-500/10 hover:text-red-400"
+                    onClick={() => setDeleting(pool)}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </button>
+                </div>
+              </div>
+              <div className="mt-3 space-y-1.5">
+                {pool.accounts.map((account, index) => {
+                  const provider = providersById.get(account.provider_id);
+                  const remaining = planRemainingPercent(
+                    plansByProviderId.get(account.provider_id)
+                  );
+                  return (
+                    <div
+                      key={account.provider_id}
+                      className="flex items-center gap-2 text-xs text-[var(--text-secondary)]"
+                    >
+                      <KeyRound className="h-3.5 w-3.5 shrink-0 text-[var(--text-muted)]" />
+                      <span className="min-w-0 flex-1 truncate">
+                        {provider?.name || account.provider_name || account.provider_id}
+                      </span>
+                      <span className="tabular-nums text-[var(--text-muted)]">
+                        {account.priority === null
+                          ? remaining === undefined
+                            ? `${index + 1} · automatic · no usage data`
+                            : `${index + 1} · ${Math.round(remaining)}% available`
+                          : `${index + 1} · priority ${account.priority}`}
+                      </span>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="flex items-center gap-3 rounded-lg border border-dashed border-[var(--surface-border)] px-4 py-4 text-sm text-[var(--text-muted)]">
+          <Layers3 className="h-5 w-5 shrink-0" />
+          Add multiple accounts for one provider, then create a pool and select it on an agent or
+          Model Router route.
+        </div>
+      )}
+
+      {editor ? (
+        <PoolEditor
+          key={editor === "new" ? "new" : editor.id}
+          pool={editor === "new" ? null : editor}
+          pools={pools}
+          providers={providers}
+          isSaving={createPool.isPending || updatePool.isPending}
+          onClose={() => setEditor(null)}
+          onSave={save}
+        />
+      ) : null}
+
+      <ConfirmDialog
+        isOpen={deleting !== null}
+        onClose={() => setDeleting(null)}
+        onConfirm={() => void remove()}
+        title="Delete account pool?"
+        description={`Accounts in ${deleting?.name || "this pool"} remain configured and can be added to another pool.`}
+        confirmText="Delete pool"
+        isLoading={deletePool.isPending}
+      />
+    </section>
+  );
+}

--- a/ui/src/hooks/useApi.ts
+++ b/ui/src/hooks/useApi.ts
@@ -5,6 +5,8 @@ import type {
   AgentReasoningEffort,
   AgentMessage,
   Provider,
+  ProviderAccountPool,
+  ProviderAccountPoolInput,
   Channel,
   Task,
   Skill,
@@ -227,6 +229,46 @@ export function useProviders() {
   });
 }
 
+export function useProviderAccountPools() {
+  return useQuery({
+    queryKey: ["provider-account-pools"],
+    queryFn: () => fetchApi<ProviderAccountPool[]>("/provider-account-pools"),
+  });
+}
+
+export function useCreateProviderAccountPool() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: ProviderAccountPoolInput) =>
+      fetchApi<ProviderAccountPool>("/provider-account-pools", {
+        method: "POST",
+        body: JSON.stringify(data),
+      }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["provider-account-pools"] }),
+  });
+}
+
+export function useUpdateProviderAccountPool() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, data }: { id: string; data: ProviderAccountPoolInput }) =>
+      fetchApi<ProviderAccountPool>(`/provider-account-pools/${id}`, {
+        method: "PUT",
+        body: JSON.stringify(data),
+      }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["provider-account-pools"] }),
+  });
+}
+
+export function useDeleteProviderAccountPool() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) =>
+      fetchApi<{ success: boolean }>(`/provider-account-pools/${id}`, { method: "DELETE" }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["provider-account-pools"] }),
+  });
+}
+
 export function useAvailableProviders() {
   return useQuery({
     queryKey: ["providers", "available"],
@@ -271,7 +313,10 @@ export function useDeleteProvider() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (id: string) => fetchApi<void>(`/providers/${id}`, { method: "DELETE" }),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["providers"] }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["providers"] });
+      queryClient.invalidateQueries({ queryKey: ["provider-account-pools"] });
+    },
   });
 }
 

--- a/ui/src/hooks/useApi.ts
+++ b/ui/src/hooks/useApi.ts
@@ -1076,8 +1076,11 @@ export function useSubagent(id?: string | null) {
       throw new Error(response.error || "Failed to fetch subagent details");
     },
     enabled: !!id,
+    refetchOnWindowFocus: true,
     refetchInterval: (query) =>
-      (query.state.data as Subagent | null)?.status === "running" ? LIST_POLL_INTERVAL_MS : false,
+      ["pending", "running"].includes((query.state.data as Subagent | null)?.status || "")
+        ? 2_000
+        : false,
   });
 }
 

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -431,7 +431,9 @@ export interface MCPRegistryServer {
   args?: string;
   url?: string;
   envVars?: string[];
+  envDefaults?: Record<string, string>;
   categories?: string[];
+  homepage?: string;
   installType?: string;
 }
 

--- a/ui/src/lib/reasoning.test.ts
+++ b/ui/src/lib/reasoning.test.ts
@@ -63,6 +63,23 @@ describe("supportedReasoningOptions per-model matrix", () => {
     expect(reasoningEffortLabel(null, "minimax-portal", "MiniMax-M3")).toBe("Adaptive");
   });
 
+  test("Kimi K3 exposes its max-only coding-plan reasoning contract", () => {
+    for (const provider of [
+      "kimi-code",
+      "kimi-code-oauth",
+      "kimi-coding",
+      "kimi-oauth",
+      "kimi-code-subscription",
+    ]) {
+      expect(supportedReasoningOptions(provider, "k3")).toEqual([
+        { value: "", label: "Default" },
+        { value: "max", label: "Max" },
+      ]);
+    }
+    expect(supportsXHighReasoning("kimi-code-oauth", "k3")).toBe(false);
+    expect(reasoningEffortLabel("max", "kimi-code-oauth", "k3")).toBe("Max");
+  });
+
   test("codex models expose Low..Max and exclude Minimal", () => {
     const codex = supportedReasoningOptions("openai", "gpt-5.3-codex");
     expect(codex.map((o) => o.value)).toEqual(["", "low", "medium", "high", "xhigh"]);

--- a/ui/src/lib/reasoning.ts
+++ b/ui/src/lib/reasoning.ts
@@ -22,6 +22,13 @@ const ADAPTIVE_THINKING_PROVIDERS = new Set([
   "minimax-portal",
   "minimax-portal-cn",
 ]);
+const KIMI_CODE_PROVIDERS = new Set([
+  "kimi-code",
+  "kimi-code-oauth",
+  "kimi-coding",
+  "kimi-oauth",
+  "kimi-code-subscription",
+]);
 
 const LEVEL_LABELS: Record<ReasoningEffort, string> = {
   minimal: "Minimal",
@@ -85,6 +92,9 @@ function supportedEfforts(provider?: string | null, model?: string | null): Reas
     return ["medium"];
   }
   const modelId = normalizeModelId(model);
+  if (KIMI_CODE_PROVIDERS.has(providerId) && modelId === "k3") {
+    return ["max"];
+  }
   if (providerId === "anthropic" || providerId === "anthropic_vertex") {
     return resolveAnthropicModelEfforts(modelId);
   }

--- a/ui/src/pages/Agents.tsx
+++ b/ui/src/pages/Agents.tsx
@@ -13,6 +13,7 @@ import {
   useAgent,
   useAgentSummaries,
   useProviders,
+  useProviderAccountPools,
   useProviderModels,
   useCreateAgent,
   useCreateDefaultAgent,
@@ -28,7 +29,9 @@ import {
   supportedReasoningOptions,
 } from "@/lib/reasoning";
 import { buildAgentChatPath } from "./chat/chatRoute";
-import type { Agent, AgentSummary } from "@/types";
+import type { Agent, AgentSummary, ProviderAccountPool } from "@/types";
+
+const POOL_TARGET_PREFIX = "pool:";
 
 const agentTypes = [
   { value: "main", label: "Main Assistant" },
@@ -88,6 +91,7 @@ export function Agents() {
   const { data: agents, isLoading } = useAgentSummaries();
   const { data: editingAgent } = useAgent(editingAgentId);
   const { data: providers } = useProviders();
+  const { data: providerPools } = useProviderAccountPools();
   const { addToast } = useUIStore();
 
   const createAgent = useCreateAgent();
@@ -143,6 +147,7 @@ export function Agents() {
         type: formData.get("type") as string,
         model: formData.get("model") as string,
         provider_id: formData.get("provider_id") as string,
+        provider_pool_id: formData.get("provider_pool_id") as string,
         system_prompt: formData.get("system_prompt") as string,
         config: buildConfig(formData),
       });
@@ -172,6 +177,7 @@ export function Agents() {
           type: formData.get("type") as string,
           model: formData.get("model") as string,
           provider_id: formData.get("provider_id") as string,
+          provider_pool_id: formData.get("provider_pool_id") as string,
           system_prompt: formData.get("system_prompt") as string,
           config: buildConfig(formData, editingAgent.config),
         },
@@ -275,6 +281,7 @@ export function Agents() {
         onSubmit={handleCreate}
         title="Create Agent"
         providers={providers || []}
+        pools={providerPools || []}
         isLoading={createAgent.isPending}
       />
 
@@ -284,6 +291,7 @@ export function Agents() {
         onSubmit={handleUpdate}
         title="Edit Agent"
         providers={providers || []}
+        pools={providerPools || []}
         isLoading={updateAgent.isPending}
         initialData={editingAgent}
       />
@@ -347,6 +355,12 @@ function AgentCard({
             <span className="text-gray-300">{agent.model}</span>
           </div>
           <div className="flex justify-between">
+            <span className="text-gray-500">Provider</span>
+            <span className="text-gray-300">
+              {agent.provider_pool_name || agent.provider_type || "Default"}
+            </span>
+          </div>
+          <div className="flex justify-between">
             <span className="text-gray-500">Reasoning</span>
             <span className="text-gray-300">{agentReasoningLabel(agent)}</span>
           </div>
@@ -393,6 +407,7 @@ function AgentModal({
   onSubmit,
   title,
   providers,
+  pools,
   isLoading,
   initialData,
 }: {
@@ -401,12 +416,19 @@ function AgentModal({
   onSubmit: (formData: FormData) => void;
   title: string;
   providers: Array<{ id: string; name: string; provider?: string }>;
+  pools: ProviderAccountPool[];
   isLoading: boolean;
   initialData?: Agent;
 }) {
-  const [selectedProvider, setSelectedProvider] = useState(
-    initialData?.provider || providers[0]?.id || ""
-  );
+  const initialTarget = initialData?.provider_pool_id
+    ? `${POOL_TARGET_PREFIX}${initialData.provider_pool_id}`
+    : initialData?.provider_id || initialData?.provider || providers[0]?.id || "";
+  const [selectedTarget, setSelectedTarget] = useState(initialTarget);
+  const selectedPoolId = selectedTarget.startsWith(POOL_TARGET_PREFIX)
+    ? selectedTarget.slice(POOL_TARGET_PREFIX.length)
+    : "";
+  const selectedPool = pools.find((pool) => pool.id === selectedPoolId);
+  const selectedProvider = selectedPool?.accounts[0]?.provider_id || selectedTarget;
   const [selectedModel, setSelectedModel] = useState(initialData?.model || "");
   const [customModel, setCustomModel] = useState("");
   const [useCustomModel, setUseCustomModel] = useState(false);
@@ -420,11 +442,15 @@ function AgentModal({
       setUseCustomModel(false);
     }
     providerChangedRef.current = true;
-  }, [selectedProvider]);
+  }, [selectedTarget]);
 
   useEffect(() => {
     if (isOpen) {
-      setSelectedProvider(initialData?.provider || providers[0]?.id || "");
+      setSelectedTarget(
+        initialData?.provider_pool_id
+          ? `${POOL_TARGET_PREFIX}${initialData.provider_pool_id}`
+          : initialData?.provider_id || initialData?.provider || providers[0]?.id || ""
+      );
       setSelectedModel(initialData?.model || "");
       setCustomModel("");
       setUseCustomModel(false);
@@ -438,6 +464,7 @@ function AgentModal({
     const modelValue = useCustomModel ? customModel : selectedModel;
     formData.set("model", modelValue);
     formData.set("provider_id", selectedProvider);
+    formData.set("provider_pool_id", selectedPoolId);
     onSubmit(formData);
   };
 
@@ -451,7 +478,9 @@ function AgentModal({
 
   const activeFormModel = useCustomModel ? customModel : selectedModel;
   const selectedProviderType =
-    providers.find((provider) => provider.id === selectedProvider)?.provider ?? selectedProvider;
+    selectedPool?.provider ??
+    providers.find((provider) => provider.id === selectedProvider)?.provider ??
+    selectedProvider;
   const reasoningEffortOptions = useMemo(
     () => supportedReasoningOptions(selectedProviderType, activeFormModel),
     [selectedProviderType, activeFormModel]
@@ -479,10 +508,21 @@ function AgentModal({
 
           <Select
             label="Provider"
-            name="provider_id"
-            value={selectedProvider}
-            onChange={(val) => setSelectedProvider(val)}
-            options={providers.map((p) => ({ value: p.id, label: p.name }))}
+            name="provider_target"
+            value={selectedTarget}
+            onChange={(val) => setSelectedTarget(val)}
+            options={[
+              ...pools
+                .filter((pool) => pool.enabled && pool.accounts.length > 0)
+                .map((pool) => ({
+                  value: `${POOL_TARGET_PREFIX}${pool.id}`,
+                  label: `${pool.name} pool (${pool.accounts.length})`,
+                })),
+              ...providers.map((provider) => ({
+                value: provider.id,
+                label: `${provider.name} account`,
+              })),
+            ]}
           />
 
           <div className="space-y-2">

--- a/ui/src/pages/Chat.tsx
+++ b/ui/src/pages/Chat.tsx
@@ -7,10 +7,10 @@ import { PageLayout } from "@/components/layout";
 import { Badge, Button, GlassCard, Input, Modal } from "@/components/ui";
 import { useAgentSummaries, useInfo, useSubagents, useUpdateAgentReasoning } from "@/hooks/useApi";
 import {
+  type LoadedChatSession,
   useChat,
   useLoadSession,
   useUpdateSessionAgent,
-  type LoadedChatSession,
 } from "@/hooks/useChat";
 import { canShareNearbySession, useNearbyStatus } from "@/hooks/useNearbyStatus";
 import { chatApi, providerPlansApi, settingsApi } from "@/lib/api";
@@ -39,11 +39,6 @@ import {
 } from "@/lib/status-stream";
 import { cn } from "@/lib/utils";
 import { useUIStore } from "@/stores/uiStore";
-import {
-  resolveSessionEventOrder,
-  type SessionEventCursor,
-  type SessionEventIdentity,
-} from "../../../shared/session-event-order";
 import type {
   Agent,
   ProviderPlanSnapshot,
@@ -51,6 +46,11 @@ import type {
   SessionContextUsage,
   SessionTokenUsage,
 } from "@/types";
+import {
+  resolveSessionEventOrder,
+  type SessionEventCursor,
+  type SessionEventIdentity,
+} from "../../../shared/session-event-order";
 import { LiveActivityTimeline } from "./chat/ActivityTimeline";
 import { ArtifactViewerPanel } from "./chat/ArtifactViewerPanel";
 import { parseTimestampMs } from "./chat/assistantMetaModel";
@@ -98,9 +98,9 @@ import {
   readPersistedWorkspaceDir,
   resolvePathForIde,
   resolveStatusSnapshotActivities,
-  shouldShowSessionPlanInComposer,
   type SessionStatusResponse,
   type SessionStatusSnapshot,
+  shouldShowSessionPlanInComposer,
   type ToolCall,
   toLiveActivityItems,
 } from "./chat/chatModel";
@@ -121,8 +121,13 @@ import {
   writeCachedOptimisticPendingMessages,
 } from "./chat/pendingQueueCache";
 import { mergePendingChatMessages, normalizePendingChatMessages } from "./chat/pendingQueueState";
-import { useChatAttachments } from "./chat/useChatAttachments";
+import {
+  isStoppedRunSuppressed,
+  markStoppedRun,
+  type StoppedRunSuppressions,
+} from "./chat/stopSuppression";
 import { useArtifactViewer } from "./chat/useArtifactViewer";
+import { useChatAttachments } from "./chat/useChatAttachments";
 import { useChatCapabilityPicker } from "./chat/useChatCapabilityPicker";
 import { useChatDictation } from "./chat/useChatDictation";
 import { useChatMessageActions } from "./chat/useChatMessageActions";
@@ -130,11 +135,6 @@ import { useChatScroll } from "./chat/useChatScroll";
 import { useChatWorkspaceTabs } from "./chat/useChatWorkspaceTabs";
 import { useEnvironmentGitBranches } from "./chat/useEnvironmentGitBranches";
 import { useSessionFileChanges } from "./chat/useSessionFileChanges";
-import {
-  isStoppedRunSuppressed,
-  markStoppedRun,
-  type StoppedRunSuppressions,
-} from "./chat/stopSuppression";
 
 type LiveStatusSnapshotLike = StatusSessionSnapshot | SessionStatusSnapshot;
 
@@ -254,12 +254,13 @@ export function Chat() {
     isOpen: showWorkspacePanel,
     openTab: openWorkspaceTab,
     openFile: openWorkspaceFile,
+    openSubagent: openWorkspaceSubagent,
     selectTab: setActiveWorkspaceTab,
     setOpen: setShowWorkspacePanel,
     tabs: workspaceTabs,
     toggleTab: toggleWorkspaceTab,
     updateTabTitle: updateWorkspaceTabTitle,
-  } = useChatWorkspaceTabs({ onOpen: closeEnvironmentOverview });
+  } = useChatWorkspaceTabs({ onOpen: closeEnvironmentOverview, sessionId });
   const [hiddenComposerPlanKey, setHiddenComposerPlanKey] = useState<string | null>(null);
   const [diffPanelWidth, setDiffPanelWidth] = useState<number>(() => readPersistedDiffPanelWidth());
   const [selectedDiffPath, setSelectedDiffPath] = useState<string | null>(null);
@@ -2886,6 +2887,7 @@ export function Chat() {
             onOpenDiffInWorkspace={handleOpenDiffFileInWorkspace}
             onOpenFullIde={handleOpenPathInIde}
             onOpenTab={openWorkspaceTab}
+            onOpenSubagent={openWorkspaceSubagent}
             onRefreshDiff={refreshSessionFileChanges}
             onResizeStart={handleDiffPanelResizeStart}
             onSelectDiffPath={setSelectedDiffPath}

--- a/ui/src/pages/MCPServers.tsx
+++ b/ui/src/pages/MCPServers.tsx
@@ -1,6 +1,7 @@
 import {
   CheckCircle,
   Download,
+  ExternalLink,
   Globe2,
   KeyRound,
   Package,
@@ -409,6 +410,16 @@ export function MCPServers() {
                 >
                   Install
                 </Button>
+                {server.homepage ? (
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    leftIcon={<ExternalLink className="w-4 h-4" />}
+                    onClick={() => void openExternal(server.homepage ?? "")}
+                  >
+                    Setup
+                  </Button>
+                ) : null}
               </div>
             </Card>
           ))}

--- a/ui/src/pages/Providers.tsx
+++ b/ui/src/pages/Providers.tsx
@@ -16,6 +16,7 @@ import {
 } from "lucide-react";
 import { openExternal } from "@/utils/openExternal";
 import { ProviderIcon, hasProviderIcon } from "@/components/ProviderIcon";
+import { ProviderAccountPools } from "@/components/providers/ProviderAccountPools";
 import { SearchableSelect } from "@/components/SearchableSelect";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/Card";
 import { Button } from "@/components/ui/Button";
@@ -350,7 +351,7 @@ export function Providers() {
   return (
     <PageLayout
       title="Providers"
-      subtitle="Manage AI model providers"
+      subtitle="Manage provider accounts and usage-aware account pools"
       actions={
         <div className="flex gap-2">
           <Button
@@ -371,6 +372,11 @@ export function Providers() {
       }
     >
       <div className="space-y-6">
+        <ProviderAccountPools
+          providers={providers || []}
+          plans={providerPlanStatus?.providers || []}
+        />
+
         <div className="flex gap-4">
           <div className="relative flex-1 max-w-md">
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-500" />

--- a/ui/src/pages/RouterSettings.tsx
+++ b/ui/src/pages/RouterSettings.tsx
@@ -26,10 +26,14 @@ import type {
   ProviderPlanSnapshot,
   ProviderPlanStatusResponse,
   ProviderPlanPresetSuggestion,
+  ProviderAccountPool,
 } from "@/types";
 
 interface RouteStatus {
   providerId: string;
+  providerType?: string;
+  targetName?: string;
+  targetType?: "provider" | "pool";
   weight: number;
   enabled: boolean;
   available: boolean;
@@ -99,10 +103,26 @@ const STRATEGY_OPTIONS: Array<{
   label: string;
   costHint: string;
 }> = [
-  { value: "weighted", label: "Weighted", costHint: "Best when you want a blended plan." },
-  { value: "round_robin", label: "Round robin", costHint: "Useful for even provider testing." },
-  { value: "lowest_cost", label: "Lowest cost", costHint: "Uses your $/M token prices." },
-  { value: "priority", label: "Priority", costHint: "Best for a primary subscription plan." },
+  {
+    value: "weighted",
+    label: "Weighted",
+    costHint: "Best when you want a blended plan.",
+  },
+  {
+    value: "round_robin",
+    label: "Round robin",
+    costHint: "Useful for even provider testing.",
+  },
+  {
+    value: "lowest_cost",
+    label: "Lowest cost",
+    costHint: "Uses your $/M token prices.",
+  },
+  {
+    value: "priority",
+    label: "Priority",
+    costHint: "Best for a primary subscription plan.",
+  },
   {
     value: "usage_aware",
     label: "Usage aware",
@@ -177,6 +197,7 @@ export function RouterSettings() {
   const [planStatus, setPlanStatus] = useState<ProviderPlanStatusResponse | null>(null);
   const [planConfig, setPlanConfig] = useState<ProviderPlanMonitoringConfig | null>(null);
   const [providers, setProviders] = useState<ProviderMeta[]>([]);
+  const [providerPools, setProviderPools] = useState<ProviderAccountPool[]>([]);
   const [agents, setAgents] = useState<Array<{ id: string; name: string }>>([]);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -255,6 +276,16 @@ export function RouterSettings() {
     }
   }, []);
 
+  const fetchProviderPools = useCallback(async () => {
+    try {
+      const res = await apiFetch("/api/provider-account-pools");
+      const data = await res.json();
+      setProviderPools(Array.isArray(data) ? data : []);
+    } catch {
+      setProviderPools([]);
+    }
+  }, []);
+
   const fetchAgents = useCallback(async () => {
     try {
       const res = await apiFetch("/api/agents/summary");
@@ -263,7 +294,10 @@ export function RouterSettings() {
       setAgents(
         list
           .filter((a: { id?: unknown }) => typeof a?.id === "string")
-          .map((a: { id: string; name?: string }) => ({ id: a.id, name: a.name || a.id }))
+          .map((a: { id: string; name?: string }) => ({
+            id: a.id,
+            name: a.name || a.id,
+          }))
       );
     } catch {
       /* ignore */
@@ -278,6 +312,7 @@ export function RouterSettings() {
       void fetchPlanStatus();
       void fetchPlanConfig();
       void fetchProviders();
+      void fetchProviderPools();
       void fetchAgents();
     };
     const refreshStatus = () => {
@@ -295,7 +330,15 @@ export function RouterSettings() {
       clearInterval(statusInterval);
       clearInterval(planInterval);
     };
-  }, [fetchStatus, fetchConfig, fetchPlanStatus, fetchPlanConfig, fetchProviders, fetchAgents]);
+  }, [
+    fetchStatus,
+    fetchConfig,
+    fetchPlanStatus,
+    fetchPlanConfig,
+    fetchProviders,
+    fetchProviderPools,
+    fetchAgents,
+  ]);
 
   const [saveError, setSaveError] = useState<string | null>(null);
 
@@ -347,9 +390,18 @@ export function RouterSettings() {
   }
 
   const routedTypes = Object.keys(config.routes);
-  const unroutedProviders = providers.filter((p) => !routedTypes.includes(p.type));
+  const poolTargets: ProviderMeta[] = providerPools
+    .filter((pool) => pool.enabled && pool.accounts.length > 0)
+    .map((pool) => ({
+      id: pool.id,
+      type: `pool:${pool.id}`,
+      name: `${pool.name} pool`,
+      models: providerModels(pool.provider),
+    }));
+  const routeTargets = [...providers, ...poolTargets];
+  const unroutedProviders = routeTargets.filter((target) => !routedTypes.includes(target.type));
   // Routing is only meaningful between at least two providers.
-  const hasEnoughProviders = providers.length >= 2;
+  const hasEnoughProviders = routeTargets.length >= 2;
   const hasEnoughRoutes = routedTypes.length >= 2;
   const setupComplete = hasEnoughProviders && hasEnoughRoutes && config.enabled;
   const activeRoutes = status?.routes.filter((route) => route.enabled && route.available) || [];
@@ -570,7 +622,10 @@ export function RouterSettings() {
                 <select
                   value={config.moaAggregatorAgentId ?? ""}
                   onChange={(e) =>
-                    saveConfig({ ...config, moaAggregatorAgentId: e.target.value || undefined })
+                    saveConfig({
+                      ...config,
+                      moaAggregatorAgentId: e.target.value || undefined,
+                    })
                   }
                   className={`${SELECT_CONTROL_CLASS} w-full`}
                 >
@@ -676,7 +731,9 @@ export function RouterSettings() {
                       ? "bg-amber-400"
                       : "bg-emerald-400"
                 )}
-                style={{ width: `${dailyLimit > 0 ? Math.max(2, budgetUsedPct) : 0}%` }}
+                style={{
+                  width: `${dailyLimit > 0 ? Math.max(2, budgetUsedPct) : 0}%`,
+                }}
               />
             </div>
           </div>
@@ -720,7 +777,11 @@ export function RouterSettings() {
               </button>
               <button
                 type="button"
-                onClick={() => savePlanConfigPatch({ routerEnforcement: !planEnforcementEnabled })}
+                onClick={() =>
+                  savePlanConfigPatch({
+                    routerEnforcement: !planEnforcementEnabled,
+                  })
+                }
                 disabled={!planConfigLoaded}
                 className={cn(
                   "flex items-center justify-between gap-2 rounded-lg border border-cyan-200/15 bg-black/20 px-3 py-2 text-left",
@@ -755,14 +816,14 @@ export function RouterSettings() {
         {status && status.routes.length > 0 ? (
           status.routes.map((route) => {
             const plan = planByRoute.get(route.providerId);
-            const routeType = plan?.providerType || route.providerId;
+            const routeType = route.providerType || plan?.providerType || route.providerId;
             return (
               <RouteRow
                 key={route.providerId}
                 route={route}
                 config={config}
                 onSave={saveConfig}
-                displayName={plan?.providerName || providerName(routeType)}
+                displayName={route.targetName || plan?.providerName || providerName(routeType)}
                 models={providerModels(routeType)}
                 plan={plan}
                 planConfig={planConfig?.providers?.[route.providerId] || null}

--- a/ui/src/pages/chat/ChatWorkspaceDock.tsx
+++ b/ui/src/pages/chat/ChatWorkspaceDock.tsx
@@ -12,6 +12,7 @@ import {
 import type { FileChangeItem, FileChangeSummary } from "./chatModel";
 import { SessionDiffPanel } from "./SessionDiffPanel";
 import { SubagentPanel } from "./SubagentPanel";
+import { SubagentDetailPanel } from "./SubagentDetailPanel";
 
 interface ChatWorkspaceDockProps {
   activeTab: string | null;
@@ -30,6 +31,7 @@ interface ChatWorkspaceDockProps {
   onOpenDiffInWorkspace: (file: FileChangeItem) => void;
   onOpenFullIde: (path: string) => void;
   onOpenTab: (kind: ChatWorkspaceTab) => void;
+  onOpenSubagent: (runId: string, title: string) => void;
   onRefreshDiff: () => void;
   onResizeStart: (event: MouseEvent<HTMLDivElement>) => void;
   onSelectDiffPath: (path: string | null) => void;
@@ -55,6 +57,7 @@ export function ChatWorkspaceDock({
   onOpenDiffInWorkspace,
   onOpenFullIde,
   onOpenTab,
+  onOpenSubagent,
   onRefreshDiff,
   onResizeStart,
   onSelectDiffPath,
@@ -142,6 +145,17 @@ export function ChatWorkspaceDock({
             </div>
           );
         }
+        if (instance.pageKey) {
+          return (
+            <div key={instance.id} className={hiddenClass}>
+              <SubagentDetailPanel
+                runId={instance.pageKey}
+                onClear={() => onCloseTab(instance.id)}
+                onViewSession={onViewSubagentSession}
+              />
+            </div>
+          );
+        }
         return (
           <div key={instance.id} className={hiddenClass}>
             <SubagentPanel
@@ -151,7 +165,7 @@ export function ChatWorkspaceDock({
               onClose={() => onCloseTab(instance.id)}
               sessionId={sessionId}
               workspaceDir={workspaceDir}
-              onViewSession={onViewSubagentSession}
+              onOpenSubagent={onOpenSubagent}
             />
           </div>
         );

--- a/ui/src/pages/chat/SubagentDetailPanel.tsx
+++ b/ui/src/pages/chat/SubagentDetailPanel.tsx
@@ -1,0 +1,155 @@
+import { useEffect, useRef, useState, type ReactElement } from "react";
+import { Loader2, MessageSquare, Square, Trash2 } from "lucide-react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { type Subagent, useClearSubagent, useKillSubagent, useSubagent } from "@/hooks/useApi";
+import { preprocessChatMarkdown } from "@/lib/chatMarkdownPreprocessor";
+import { connectStatusStream } from "@/lib/status-stream";
+import { Button, Badge } from "@/components/ui";
+import { SubagentTimeline } from "./SubagentTimeline";
+
+function statusVariant(status: Subagent["status"]): "success" | "error" | "default" {
+  if (status === "completed") return "success";
+  if (status === "failed" || status === "timeout" || status === "killed") return "error";
+  return "default";
+}
+
+function formatElapsed(startedAt?: string, endedAt?: string, now = Date.now()): string {
+  if (!startedAt) return "Starting";
+  const elapsedSeconds = Math.max(
+    0,
+    Math.floor(
+      ((endedAt ? new Date(endedAt).getTime() : now) - new Date(startedAt).getTime()) / 1000
+    )
+  );
+  const minutes = Math.floor(elapsedSeconds / 60);
+  const seconds = elapsedSeconds % 60;
+  return minutes > 0 ? `${minutes}m ${seconds.toString().padStart(2, "0")}s` : `${seconds}s`;
+}
+
+export function SubagentDetailPanel({
+  onClear,
+  onViewSession,
+  runId,
+}: {
+  onClear: () => void;
+  onViewSession: (sessionKey: string) => void;
+  runId: string;
+}): ReactElement {
+  const { data: subagent, isLoading, refetch } = useSubagent(runId);
+  const killSubagent = useKillSubagent();
+  const clearSubagent = useClearSubagent();
+  const refreshTimerRef = useRef<number | null>(null);
+  const sessionKeyRef = useRef<string | undefined>(subagent?.sessionKey);
+  const [now, setNow] = useState(Date.now());
+
+  useEffect(() => {
+    sessionKeyRef.current = subagent?.sessionKey;
+  }, [subagent?.sessionKey]);
+
+  useEffect(() => {
+    if (!subagent || !["pending", "running"].includes(subagent.status)) return;
+    const timer = window.setInterval(() => setNow(Date.now()), 1_000);
+    return () => window.clearInterval(timer);
+  }, [subagent]);
+
+  useEffect(() => {
+    const disconnect = connectStatusStream({
+      onEvent: (event) => {
+        if (event.type !== "status" || event.sessionId !== sessionKeyRef.current) return;
+        if (refreshTimerRef.current !== null) window.clearTimeout(refreshTimerRef.current);
+        refreshTimerRef.current = window.setTimeout(() => {
+          void refetch();
+          refreshTimerRef.current = null;
+        }, 100);
+      },
+    });
+    return () => {
+      disconnect();
+      if (refreshTimerRef.current !== null) window.clearTimeout(refreshTimerRef.current);
+    };
+  }, [refetch]);
+
+  if (isLoading || !subagent) {
+    return (
+      <div className="flex h-full items-center justify-center text-gray-500">
+        <Loader2 className="h-5 w-5 animate-spin" />
+      </div>
+    );
+  }
+
+  const active = subagent.status === "pending" || subagent.status === "running";
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="flex shrink-0 items-center gap-3 border-b border-white/5 px-4 py-3">
+        <Badge variant={statusVariant(subagent.status)}>{subagent.status}</Badge>
+        {active ? <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-emerald-400" /> : null}
+        <span className="chat-meta-text text-gray-500">
+          {formatElapsed(subagent.startedAt, subagent.endedAt, now)}
+        </span>
+        <span className="chat-meta-text ml-auto text-gray-600">
+          {subagent.activityCount} updates · {subagent.toolCallCount} tools
+        </span>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4">
+        <div className="mx-auto max-w-3xl space-y-5">
+          <section>
+            <h4 className="mb-2 text-[11px] font-semibold uppercase text-gray-500">Task</h4>
+            <div className="chat-activity-text whitespace-pre-wrap rounded-md bg-white/[0.025] p-3 text-gray-300">
+              {subagent.task}
+            </div>
+          </section>
+
+          {active && (subagent.activities?.length || 0) === 0 ? (
+            <div className="flex items-center gap-2 py-3 text-[12px] text-gray-500">
+              <Loader2 className="h-3.5 w-3.5 animate-spin" /> Waiting for the first update
+            </div>
+          ) : null}
+
+          <SubagentTimeline subagent={subagent} />
+
+          {subagent.result || subagent.error ? (
+            <section>
+              <h4 className="mb-2 text-[11px] font-semibold uppercase text-gray-500">
+                Final output
+              </h4>
+              <div className="chat-activity-text rounded-md bg-white/[0.025] p-3 text-gray-300">
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                  {preprocessChatMarkdown(subagent.result || subagent.error || "")}
+                </ReactMarkdown>
+              </div>
+            </section>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="flex shrink-0 justify-end gap-2 border-t border-white/5 px-3 py-2.5">
+        <Button variant="secondary" onClick={() => onViewSession(subagent.sessionKey)}>
+          <MessageSquare className="mr-2 h-4 w-4" /> View chat
+        </Button>
+        {active ? (
+          <Button
+            variant="danger"
+            disabled={killSubagent.isPending}
+            onClick={() => void killSubagent.mutateAsync(subagent.id)}
+          >
+            <Square className="mr-2 h-4 w-4" /> Stop
+          </Button>
+        ) : (
+          <Button
+            variant="danger"
+            disabled={clearSubagent.isPending}
+            onClick={async () => {
+              await clearSubagent.mutateAsync(subagent.id);
+              onClear();
+            }}
+          >
+            <Trash2 className="mr-2 h-4 w-4" /> Clear
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/ui/src/pages/chat/SubagentPanel.tsx
+++ b/ui/src/pages/chat/SubagentPanel.tsx
@@ -1,29 +1,21 @@
-import { useEffect, useMemo, useRef, useState, type MouseEvent as ReactMouseEvent } from "react";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
+import { Loader2, Plus, Square, Trash2, X } from "lucide-react";
 import {
-  ChevronDown,
-  ChevronRight,
-  Loader2,
-  MessageSquare,
-  Plus,
-  Square,
-  Trash2,
-  X,
-} from "lucide-react";
+  type ReactElement,
+  type MouseEvent as ReactMouseEvent,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { Badge, Button, Modal } from "@/components/ui";
 import {
   type Subagent,
-  useClearSubagent,
   useClearSubagentHistory,
   useKillSubagent,
   useSpawnSubagent,
-  useSubagent,
   useSubagents,
 } from "@/hooks/useApi";
 import { connectStatusStream } from "@/lib/status-stream";
-import { preprocessChatMarkdown } from "@/lib/chatMarkdownPreprocessor";
 import { useUIStore } from "@/stores/uiStore";
-import { Badge, Button, Modal } from "@/components/ui";
 import { SubagentIcon } from "./SubagentIcon";
 import {
   clampSubagentPanelWidth,
@@ -36,7 +28,7 @@ interface SubagentPanelProps {
   embedded?: boolean;
   isOpen: boolean;
   onClose: () => void;
-  onViewSession?: (sessionKey: string) => void;
+  onOpenSubagent?: (runId: string, title: string) => void;
   sessionId: string | null;
   workspaceDir?: string | null;
 }
@@ -59,174 +51,46 @@ function statusVariant(status: Subagent["status"]): "success" | "error" | "defau
   return "default";
 }
 
-function formatJson(value: unknown): string {
-  if (typeof value === "string") return value;
-  if (value && typeof value === "object" && !Array.isArray(value)) {
-    const record = value as Record<string, unknown>;
-    for (const key of ["content", "output", "stdout"]) {
-      if (typeof record[key] === "string" && record[key].trim()) return record[key];
-    }
-  }
-  try {
-    return JSON.stringify(value, null, 2);
-  } catch {
-    return String(value);
-  }
-}
-
-function SubagentTimeline({ subagent }: { subagent: Subagent }) {
-  const activities = useMemo(
-    () => [...(subagent.activities || [])].sort((a, b) => a.timestamp - b.timestamp),
-    [subagent.activities]
-  );
-  const toolCalls = useMemo(
-    () =>
-      [...(subagent.toolCalls || [])].sort(
-        (a, b) =>
-          (a.timeline_index ?? Number.MAX_SAFE_INTEGER) -
-          (b.timeline_index ?? Number.MAX_SAFE_INTEGER)
-      ),
-    [subagent.toolCalls]
-  );
-  const [expandedTools, setExpandedTools] = useState<Set<string>>(new Set());
-
-  return (
-    <div className="space-y-4">
-      {activities.length > 0 && (
-        <section>
-          <h4 className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-gray-500">
-            Activity
-          </h4>
-          <div className="space-y-1.5 border-l border-white/10 pl-3">
-            {activities.map((activity) => (
-              <div key={activity.id} className="chat-activity-text flex gap-2 text-gray-400">
-                <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-gray-500" />
-                <div className="min-w-0">
-                  <ReactMarkdown remarkPlugins={[remarkGfm]}>
-                    {preprocessChatMarkdown(activity.text)}
-                  </ReactMarkdown>
-                  {activity.toolName && activity.toolName !== "__thought" && (
-                    <span className="chat-meta-text mt-0.5 block font-mono text-gray-600">
-                      {activity.toolName} · {activity.phase}
-                    </span>
-                  )}
-                </div>
-              </div>
-            ))}
-          </div>
-        </section>
-      )}
-
-      {subagent.thinking && activities.every((activity) => activity.toolName !== "__thought") && (
-        <section>
-          <h4 className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-gray-500">
-            Thinking
-          </h4>
-          <div className="chat-thought-text max-h-52 overflow-y-auto rounded-lg border border-white/10 bg-black/20 p-3 text-gray-400">
-            <ReactMarkdown remarkPlugins={[remarkGfm]}>
-              {preprocessChatMarkdown(subagent.thinking)}
-            </ReactMarkdown>
-          </div>
-        </section>
-      )}
-
-      {toolCalls.length > 0 && (
-        <section>
-          <h4 className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-gray-500">
-            Tool calls
-          </h4>
-          <div className="space-y-1.5">
-            {toolCalls.map((toolCall, index) => {
-              const key = toolCall.id || `${toolCall.name}-${index}`;
-              const expanded = expandedTools.has(key);
-              return (
-                <div
-                  key={key}
-                  className="overflow-hidden rounded-lg border border-white/10 bg-black/20"
-                >
-                  <button
-                    type="button"
-                    className="chat-activity-text flex w-full items-center gap-2 px-3 py-2 text-left text-gray-300 hover:bg-white/[0.04]"
-                    onClick={() =>
-                      setExpandedTools((current) => {
-                        const next = new Set(current);
-                        if (next.has(key)) next.delete(key);
-                        else next.add(key);
-                        return next;
-                      })
-                    }
-                  >
-                    {expanded ? (
-                      <ChevronDown className="h-3 w-3" />
-                    ) : (
-                      <ChevronRight className="h-3 w-3" />
-                    )}
-                    <span className="min-w-0 flex-1 truncate font-mono">{toolCall.name}</span>
-                    <span className="chat-meta-text capitalize text-gray-600">
-                      {toolCall.status || "completed"}
-                    </span>
-                  </button>
-                  {expanded && (
-                    <div className="grid gap-2 border-t border-white/10 p-2.5">
-                      {toolCall.args && Object.keys(toolCall.args).length > 0 && (
-                        <div>
-                          <div className="chat-meta-text mb-1 uppercase text-gray-600">
-                            Arguments
-                          </div>
-                          <pre className="chat-code-text max-h-40 overflow-auto whitespace-pre-wrap break-all rounded bg-black/30 p-2 text-gray-400">
-                            {formatJson(toolCall.args)}
-                          </pre>
-                        </div>
-                      )}
-                      <div>
-                        <div className="chat-meta-text mb-1 uppercase text-gray-600">Output</div>
-                        <pre className="chat-code-text max-h-56 overflow-auto whitespace-pre-wrap break-all rounded bg-black/30 p-2 text-gray-300">
-                          {formatJson(toolCall.result)}
-                        </pre>
-                      </div>
-                    </div>
-                  )}
-                </div>
-              );
-            })}
-          </div>
-        </section>
-      )}
-    </div>
-  );
-}
-
 export function SubagentPanel({
   agentId,
   embedded = false,
   isOpen,
   onClose,
-  onViewSession,
+  onOpenSubagent,
   sessionId,
   workspaceDir,
-}: SubagentPanelProps) {
+}: SubagentPanelProps): ReactElement | null {
   const { data: subagents = [], isLoading, refetch } = useSubagents(sessionId);
   const spawnSubagent = useSpawnSubagent();
   const killSubagent = useKillSubagent();
   const clearHistory = useClearSubagentHistory();
-  const clearSubagent = useClearSubagent();
   const [newTask, setNewTask] = useState("");
   const [showSpawnModal, setShowSpawnModal] = useState(false);
   const [showClearModal, setShowClearModal] = useState(false);
-  const [selectedSubagentId, setSelectedSubagentId] = useState<string | null>(null);
   const [panelWidth, setPanelWidth] = useState(readSubagentPanelWidth);
-  const { data: selectedSubagent, isLoading: detailLoading } = useSubagent(selectedSubagentId);
   const subagentRefreshTimerRef = useRef<number | null>(null);
+  const subagentSessionKeysRef = useRef<Set<string>>(new Set());
   const panelResizeCleanupRef = useRef<(() => void) | null>(null);
   const completedCount = subagents.filter(
     (subagent) => subagent.status !== "running" && subagent.status !== "pending"
   ).length;
 
   useEffect(() => {
+    subagentSessionKeysRef.current = new Set(
+      subagents.map((subagent) => subagent.sessionKey).filter(Boolean)
+    );
+  }, [subagents]);
+
+  useEffect(() => {
     const disconnect = connectStatusStream({
       onEvent: (event) => {
-        if (!event || typeof event !== "object") return;
-        if (event.type !== "status" && event.type !== "task_completed") return;
+        if (
+          event.type !== "status" ||
+          !event.sessionId ||
+          !subagentSessionKeysRef.current.has(event.sessionId)
+        ) {
+          return;
+        }
         if (subagentRefreshTimerRef.current !== null) {
           window.clearTimeout(subagentRefreshTimerRef.current);
         }
@@ -243,10 +107,6 @@ export function SubagentPanel({
       }
     };
   }, [refetch]);
-
-  useEffect(() => {
-    setSelectedSubagentId(null);
-  }, [sessionId]);
 
   useEffect(() => {
     const handleWindowResize = () => {
@@ -315,15 +175,17 @@ export function SubagentPanel({
     const task = newTask.trim();
     if (!task || !sessionId || spawnSubagent.isPending) return;
     try {
-      await spawnSubagent.mutateAsync({
+      const label = `Task: ${task.slice(0, 30)}${task.length > 30 ? "..." : ""}`;
+      const spawned = await spawnSubagent.mutateAsync({
         task,
-        label: `Task: ${task.slice(0, 30)}${task.length > 30 ? "..." : ""}`,
+        label,
         agentId,
         workspaceDir: workspaceDir || undefined,
         requesterSessionId: sessionId,
       });
       setNewTask("");
       setShowSpawnModal(false);
+      onOpenSubagent?.(spawned.subagentId, label);
     } catch (error) {
       useUIStore
         .getState()
@@ -426,14 +288,14 @@ export function SubagentPanel({
                 <button
                   type="button"
                   className="min-w-0 flex-1 text-left"
-                  onClick={() => setSelectedSubagentId(subagent.id)}
+                  onClick={() => onOpenSubagent?.(subagent.id, subagent.label)}
                 >
                   <div className="min-w-0 flex-1">
                     <p className="truncate text-[12px] font-medium text-gray-200">
                       {subagent.label}
                     </p>
                     <p className="mt-0.5 text-[10px] text-gray-600">
-                      {subagent.toolCallCount} tools ·{" "}
+                      {subagent.activityCount} updates · {subagent.toolCallCount} tools ·{" "}
                       {new Date(subagent.createdAt).toLocaleTimeString()}
                     </p>
                   </div>
@@ -525,78 +387,6 @@ export function SubagentPanel({
             </Button>
           </div>
         </div>
-      </Modal>
-
-      <Modal
-        isOpen={!!selectedSubagentId}
-        onClose={() => setSelectedSubagentId(null)}
-        title={selectedSubagent?.label || "Subagent Details"}
-        size="lg"
-      >
-        {detailLoading || !selectedSubagent ? (
-          <div className="py-12 text-center text-gray-500">
-            <Loader2 className="mx-auto h-5 w-5 animate-spin" />
-          </div>
-        ) : (
-          <div className="space-y-4">
-            <div className="flex items-center justify-between gap-3">
-              <Badge variant={statusVariant(selectedSubagent.status)}>
-                {selectedSubagent.status}
-              </Badge>
-              <span className="text-[11px] text-gray-600">
-                {selectedSubagent.toolCallCount} tool{" "}
-                {selectedSubagent.toolCallCount === 1 ? "call" : "calls"}
-              </span>
-            </div>
-            <div className="chat-activity-text rounded-lg border border-white/10 bg-white/[0.03] p-3 text-gray-300 whitespace-pre-wrap">
-              {selectedSubagent.task}
-            </div>
-            <SubagentTimeline subagent={selectedSubagent} />
-            {(selectedSubagent.result || selectedSubagent.error) && (
-              <section>
-                <h4 className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-gray-500">
-                  Final output
-                </h4>
-                <div className="chat-activity-text max-h-64 overflow-auto rounded-lg border border-white/10 bg-black/20 p-3 text-gray-300">
-                  <ReactMarkdown remarkPlugins={[remarkGfm]}>
-                    {preprocessChatMarkdown(
-                      selectedSubagent.result || selectedSubagent.error || ""
-                    )}
-                  </ReactMarkdown>
-                </div>
-              </section>
-            )}
-            <div className="flex flex-wrap justify-end gap-2 border-t border-white/10 pt-4">
-              {onViewSession && (
-                <Button
-                  variant="secondary"
-                  onClick={() => onViewSession(selectedSubagent.sessionKey)}
-                >
-                  <MessageSquare className="mr-2 h-4 w-4" /> View Session
-                </Button>
-              )}
-              {selectedSubagent.status === "running" ? (
-                <Button
-                  variant="danger"
-                  onClick={() => void killSubagent.mutateAsync(selectedSubagent.id)}
-                >
-                  <Square className="mr-2 h-4 w-4" /> Stop
-                </Button>
-              ) : (
-                <Button
-                  variant="danger"
-                  disabled={clearSubagent.isPending}
-                  onClick={async () => {
-                    await clearSubagent.mutateAsync(selectedSubagent.id);
-                    setSelectedSubagentId(null);
-                  }}
-                >
-                  <Trash2 className="mr-2 h-4 w-4" /> Clear
-                </Button>
-              )}
-            </div>
-          </div>
-        )}
       </Modal>
     </>
   );

--- a/ui/src/pages/chat/SubagentTimeline.tsx
+++ b/ui/src/pages/chat/SubagentTimeline.tsx
@@ -1,0 +1,152 @@
+import { useMemo, useState, type ReactElement } from "react";
+import { ChevronDown, ChevronRight } from "lucide-react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import type { Subagent } from "@/hooks/useApi";
+import { preprocessChatMarkdown } from "@/lib/chatMarkdownPreprocessor";
+
+function formatJson(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    const record = value as Record<string, unknown>;
+    for (const key of ["content", "output", "stdout"]) {
+      if (typeof record[key] === "string" && record[key].trim()) return record[key];
+    }
+  }
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+export function SubagentTimeline({ subagent }: { subagent: Subagent }): ReactElement {
+  const activities = useMemo(
+    () => [...(subagent.activities || [])].sort((a, b) => a.timestamp - b.timestamp),
+    [subagent.activities]
+  );
+  const toolCalls = useMemo(
+    () =>
+      [...(subagent.toolCalls || [])].sort(
+        (a, b) =>
+          (a.timeline_index ?? Number.MAX_SAFE_INTEGER) -
+          (b.timeline_index ?? Number.MAX_SAFE_INTEGER)
+      ),
+    [subagent.toolCalls]
+  );
+  const [expandedTools, setExpandedTools] = useState<Set<string>>(new Set());
+
+  return (
+    <div className="space-y-5">
+      {activities.length > 0 ? (
+        <section>
+          <h4 className="mb-2 text-[11px] font-semibold uppercase text-gray-500">Activity</h4>
+          <div className="space-y-2 border-l border-white/10 pl-3">
+            {activities.map((activity) => (
+              <div key={activity.id} className="chat-activity-text flex gap-2 text-gray-400">
+                <span
+                  className={
+                    activity.phase === "error" || activity.phase === "blocked"
+                      ? "mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-red-400"
+                      : activity.phase === "start"
+                        ? "mt-1.5 h-1.5 w-1.5 shrink-0 animate-pulse rounded-full bg-[rgb(var(--accent-primary))]"
+                        : "mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-gray-500"
+                  }
+                />
+                <div className="min-w-0">
+                  <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                    {preprocessChatMarkdown(activity.text)}
+                  </ReactMarkdown>
+                  {activity.toolName && activity.toolName !== "__thought" ? (
+                    <span className="chat-meta-text mt-0.5 block font-mono text-gray-600">
+                      {activity.toolName} · {activity.phase}
+                    </span>
+                  ) : null}
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      {subagent.thinking && activities.every((activity) => activity.toolName !== "__thought") ? (
+        <section>
+          <h4 className="mb-2 text-[11px] font-semibold uppercase text-gray-500">Thinking</h4>
+          <div className="chat-thought-text rounded-md bg-white/[0.025] p-3 text-gray-400">
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>
+              {preprocessChatMarkdown(subagent.thinking)}
+            </ReactMarkdown>
+          </div>
+        </section>
+      ) : null}
+
+      {toolCalls.length > 0 ? (
+        <section>
+          <h4 className="mb-2 text-[11px] font-semibold uppercase text-gray-500">Tool calls</h4>
+          <div className="space-y-1.5">
+            {toolCalls.map((toolCall, index) => {
+              const key = toolCall.id || `${toolCall.name}-${index}`;
+              const expanded = expandedTools.has(key);
+              return (
+                <div key={key} className="overflow-hidden rounded-md bg-white/[0.025]">
+                  <button
+                    type="button"
+                    className="chat-activity-text flex w-full items-center gap-2 px-3 py-2 text-left text-gray-300 hover:bg-white/[0.04]"
+                    onClick={() =>
+                      setExpandedTools((current) => {
+                        const next = new Set(current);
+                        if (next.has(key)) next.delete(key);
+                        else next.add(key);
+                        return next;
+                      })
+                    }
+                  >
+                    {expanded ? (
+                      <ChevronDown className="h-3 w-3" />
+                    ) : (
+                      <ChevronRight className="h-3 w-3" />
+                    )}
+                    <span className="min-w-0 flex-1 truncate font-mono">{toolCall.name}</span>
+                    <span
+                      className={
+                        toolCall.status === "failed"
+                          ? "chat-meta-text capitalize text-red-400"
+                          : toolCall.status === "executing" || toolCall.status === "pending"
+                            ? "chat-meta-text capitalize text-[rgb(var(--accent-primary))]"
+                            : "chat-meta-text capitalize text-gray-600"
+                      }
+                    >
+                      {toolCall.status || "completed"}
+                    </span>
+                  </button>
+                  {expanded ? (
+                    <div className="grid gap-2 border-t border-white/10 p-2.5">
+                      {toolCall.args && Object.keys(toolCall.args).length > 0 ? (
+                        <div>
+                          <div className="chat-meta-text mb-1 uppercase text-gray-600">
+                            Arguments
+                          </div>
+                          <pre className="chat-code-text max-h-40 overflow-auto whitespace-pre-wrap break-all rounded bg-black/20 p-2 text-gray-400">
+                            {formatJson(toolCall.args)}
+                          </pre>
+                        </div>
+                      ) : null}
+                      {toolCall.result !== null && toolCall.result !== undefined ? (
+                        <div>
+                          <div className="chat-meta-text mb-1 uppercase text-gray-600">Output</div>
+                          <pre className="chat-code-text max-h-56 overflow-auto whitespace-pre-wrap break-all rounded bg-black/20 p-2 text-gray-300">
+                            {formatJson(toolCall.result)}
+                          </pre>
+                        </div>
+                      ) : null}
+                    </div>
+                  ) : null}
+                </div>
+              );
+            })}
+          </div>
+        </section>
+      ) : null}
+    </div>
+  );
+}

--- a/ui/src/pages/chat/useChatWorkspaceTabs.ts
+++ b/ui/src/pages/chat/useChatWorkspaceTabs.ts
@@ -8,6 +8,7 @@ import {
 
 interface UseChatWorkspaceTabsOptions {
   onOpen: () => void;
+  sessionId: string | null;
 }
 
 interface UseChatWorkspaceTabsResult {
@@ -17,6 +18,7 @@ interface UseChatWorkspaceTabsResult {
   isOpen: boolean;
   openTab: (kind: ChatWorkspaceTab) => void;
   openFile: (path: string) => void;
+  openSubagent: (runId: string, title: string) => void;
   selectTab: Dispatch<SetStateAction<string | null>>;
   setOpen: Dispatch<SetStateAction<boolean>>;
   tabs: WorkspaceTabInstance[];
@@ -26,11 +28,13 @@ interface UseChatWorkspaceTabsResult {
 
 export function useChatWorkspaceTabs({
   onOpen,
+  sessionId,
 }: UseChatWorkspaceTabsOptions): UseChatWorkspaceTabsResult {
   const [isOpen, setOpen] = useState(false);
   const [tabs, setTabs] = useState<WorkspaceTabInstance[]>([]);
   const [activeTabId, selectTab] = useState<string | null>(null);
   const tabIdRef = useRef(0);
+  const previousSessionIdRef = useRef(sessionId);
   const activeKind = useMemo(
     () => tabs.find((instance) => instance.id === activeTabId)?.kind ?? null,
     [activeTabId, tabs]
@@ -42,28 +46,40 @@ export function useChatWorkspaceTabs({
     selectTab(tabs[0].id);
   }, [activeTabId, isOpen, tabs]);
 
+  useEffect(() => {
+    if (previousSessionIdRef.current === sessionId) return;
+    previousSessionIdRef.current = sessionId;
+    const detailTabIds = new Set(
+      tabs
+        .filter((instance) => instance.kind === "subagents" && instance.pageKey)
+        .map((instance) => instance.id)
+    );
+    if (detailTabIds.size === 0) return;
+    const next = tabs.filter((instance) => !detailTabIds.has(instance.id));
+    if (activeTabId && detailTabIds.has(activeTabId)) {
+      selectTab(next[0]?.id ?? null);
+    }
+    setTabs(next);
+  }, [activeTabId, sessionId, tabs]);
+
   const openTab = useCallback(
     (kind: ChatWorkspaceTab): void => {
       setOpen(true);
       onOpen();
-      setTabs((current) => {
-        if (WORKSPACE_SINGLETON_KINDS.has(kind)) {
-          const existing = current.find((instance) => instance.kind === kind);
-          if (existing) {
-            selectTab(existing.id);
-            return current;
-          }
-        }
-        const id = `${kind}-${(tabIdRef.current += 1)}`;
-        const pageKey =
-          kind === "browser" && current.some((instance) => instance.kind === "browser")
-            ? id
-            : undefined;
-        selectTab(id);
-        return [...current, { id, kind, pageKey }];
-      });
+      const existing = WORKSPACE_SINGLETON_KINDS.has(kind)
+        ? tabs.find((instance) => instance.kind === kind)
+        : undefined;
+      if (existing) {
+        selectTab(existing.id);
+        return;
+      }
+      const id = `${kind}-${(tabIdRef.current += 1)}`;
+      const pageKey =
+        kind === "browser" && tabs.some((instance) => instance.kind === "browser") ? id : undefined;
+      selectTab(id);
+      setTabs((current) => [...current, { id, kind, pageKey }]);
     },
-    [onOpen]
+    [onOpen, tabs]
   );
 
   const toggleTab = useCallback(
@@ -83,33 +99,63 @@ export function useChatWorkspaceTabs({
       if (!normalizedPath) return;
       setOpen(true);
       onOpen();
-      setTabs((current) => {
-        const existing = current.find((instance) => instance.kind === "files");
-        if (existing) {
-          selectTab(existing.id);
-          return current.map((instance) =>
+      const existing = tabs.find((instance) => instance.kind === "files");
+      if (existing) {
+        selectTab(existing.id);
+        setTabs((current) =>
+          current.map((instance) =>
             instance.id === existing.id ? { ...instance, pageKey: normalizedPath } : instance
-          );
-        }
-        const id = `files-${(tabIdRef.current += 1)}`;
-        selectTab(id);
-        return [...current, { id, kind: "files", pageKey: normalizedPath }];
-      });
+          )
+        );
+        return;
+      }
+      const id = `files-${(tabIdRef.current += 1)}`;
+      selectTab(id);
+      setTabs((current) => [...current, { id, kind: "files", pageKey: normalizedPath }]);
     },
-    [onOpen]
+    [onOpen, tabs]
   );
 
-  const closeTab = useCallback((id: string): void => {
-    setTabs((current) => {
-      const index = current.findIndex((instance) => instance.id === id);
-      if (index === -1) return current;
-      const next = current.filter((instance) => instance.id !== id);
-      selectTab((previous) =>
-        previous === id ? (next[Math.min(index, next.length - 1)]?.id ?? null) : previous
+  const openSubagent = useCallback(
+    (runId: string, title: string): void => {
+      const normalizedRunId = runId.trim();
+      if (!normalizedRunId) return;
+      setOpen(true);
+      onOpen();
+      const existing = tabs.find(
+        (instance) => instance.kind === "subagents" && instance.pageKey === normalizedRunId
       );
-      return next;
-    });
-  }, []);
+      if (existing) {
+        selectTab(existing.id);
+        return;
+      }
+      const id = `subagent-${(tabIdRef.current += 1)}`;
+      selectTab(id);
+      setTabs((current) => [
+        ...current,
+        {
+          id,
+          kind: "subagents",
+          pageKey: normalizedRunId,
+          title: title.trim() || "Subagent",
+        },
+      ]);
+    },
+    [onOpen, tabs]
+  );
+
+  const closeTab = useCallback(
+    (id: string): void => {
+      const index = tabs.findIndex((instance) => instance.id === id);
+      if (index === -1) return;
+      const next = tabs.filter((instance) => instance.id !== id);
+      if (activeTabId === id) {
+        selectTab(next[Math.min(index, next.length - 1)]?.id ?? null);
+      }
+      setTabs(next);
+    },
+    [activeTabId, tabs]
+  );
 
   const updateTabTitle = useCallback((id: string, title: string): void => {
     setTabs((current) =>
@@ -123,6 +169,7 @@ export function useChatWorkspaceTabs({
     closeTab,
     isOpen,
     openFile,
+    openSubagent,
     openTab,
     selectTab,
     setOpen,

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -6,6 +6,8 @@ export interface Agent {
   provider: string;
   provider_id?: string;
   provider_type?: string;
+  provider_pool_id?: string;
+  provider_pool_name?: string;
   fallback_provider_id?: string;
   type?: string;
   status?: "active" | "inactive" | "idle" | "running" | "stopped";
@@ -30,6 +32,8 @@ export interface AgentSummary {
   provider?: string;
   provider_id?: string;
   provider_type?: string;
+  provider_pool_id?: string;
+  provider_pool_name?: string;
   fallback_provider_id?: string;
   status?: Agent["status"];
   created_at?: string;
@@ -77,6 +81,30 @@ export interface Provider {
   authType?: ProviderAuthType;
   createdAt?: string;
   created_at?: string;
+}
+
+export interface ProviderAccountPool {
+  id: string;
+  name: string;
+  provider: string;
+  enabled: boolean;
+  routing_mode: "usage" | "priority_then_usage";
+  accounts: Array<{
+    provider_id: string;
+    provider_name?: string;
+    priority: number | null;
+  }>;
+}
+
+export interface ProviderAccountPoolInput {
+  name: string;
+  provider: string;
+  enabled: boolean;
+  accounts: Array<{
+    provider_id: string;
+    provider_name?: string;
+    priority?: number;
+  }>;
 }
 
 export type ProviderPlanStatusState = "ok" | "warning" | "exhausted" | "unconfigured" | "disabled";


### PR DESCRIPTION
Introduces named same-provider account pools across core, API, CLI, TUI, and web UI, including CRUD endpoints, agent assignment, router targets, usage-aware ordering, cooldown-based failover, and safeguards to avoid replaying turns after tool side effects. Adds full test coverage for pool behavior, routing, and CLI parsing.

Also bundles a new Blender Workflows plugin/skill, adds Blender MCP registry support via uvx with setup metadata/default env vars, and updates packaging/Tauri resource wiring to ship bundled plugins. Includes related provider improvements (settings merge behavior, z.ai usage window parsing, Kimi subscription reasoning support) and UI updates to surface pool and route target metadata.

## What does this PR do?

## How was it tested?
- [x] `bun test` passes
- [x] `bunx tsc --noEmit` passes (and `cd ui && bunx tsc --noEmit` for UI changes)
- [x] Verified against a running gateway (if behavior changed)

## Checklist
- [x] No secrets/keys in the diff
- [x] Follows the import/style rules in CLAUDE.md

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agent provider selection, pool failover, and broad LLM retry paths that affect live completions; mitigated by tool-side-effect guards and new tests but still touches core routing and auth refresh.
> 
> **Overview**
> Adds **named same-provider account pools** end to end: storage and routing via `pool:` route IDs, REST CRUD, `cybara provider pool` CLI, TUI listing, and agent `provider_pool_id` assignment with priority or usage-balanced ordering, per-account cooldown failover, and **no account rotation after a tool call has started** on a failed turn.
> 
> **Provider runtime** gains shared retry/OAuth refresh behavior (transient errors, 401 refresh, overloaded vs rate-limit handling) across major LLM transports, plus router/plan monitoring awareness of pool routes and **token usage attributed to `routerRouteId`**.
> 
> Ships a **Blender Workflows** bundled plugin/skill, **Blender MCP** registry entry (`uvx`, default env), and copies `plugins/` through sidecar/Tauri/macOS release layouts.
> 
> Smaller fixes: provider **settings merge** on update, richer **Z.ai** usage windows, Kimi subscription in reasoning providers, subagent runs **marked interrupted on gateway restart** (no resume), and live **subagent tool-call** capture from status events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bfc620acce59ab1a3a2b91d68e5d5d63573cece. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- GITZILLA_SUMMARY -->
> [!NOTE]
> **Medium Risk**
>
> **Overview**
> This PR introduces named same-provider account pools spanning core, API, CLI, TUI, and web UI layers, adding CRUD endpoints, agent assignment, router targets, usage-aware ordering, cooldown-based failover, and safeguards against turn replay after tool side effects. The web UI gains a dedicated ProviderAccountPools page plus a redesigned subagent live-detail/timeline experience, while the CLI gains new `provider pool` commands and the core adds extensive new modules (`provider-account-pool.ts`, `provider-retry.ts`) alongside significant rewrites of the agent runtime, router, providers, and usage source. A new Blender Workflows plugin with an `blender-mcp` skill is bundled, Blender MCP is registered via uvx with setup metadata and default env vars, and packaging/Tauri resource wiring is updated accordingly. The change is backed by comprehensive new and updated tests covering pool behavior, routing, retry, OAuth refresh, plugin loading, CLI parsing, and Tauri resource wiring.
>
> <sup>Written by [Gitzilla](https://gitzilla.ai) for commit 0bfc620. This will update automatically on new runs. Configure in the [Gitzilla dashboard](https://gitzilla.ai/dashboard).</sup>
<!-- /GITZILLA_SUMMARY -->