### PR TITLE
New release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -243,6 +243,8 @@ jobs:
         env:
           CYBARA_SIDECAR_BUN_TARGET: ${{ matrix.bun_target }}
         run: bun run scripts/build-sidecar.ts
+      - name: Smoke Tauri sidecar embedded UI
+        run: bun run scripts/smoke-tauri-sidecar-ui.ts "${{ matrix.sidecar }}"
       - name: Prepare updater config
         env:
           CYBARA_TAURI_UPDATER_PUBKEY: ${{ secrets.TAURI_SIGNING_PUBLIC_KEY }}

--- a/apps/macos/Cybara/Sources/Cybara/GatewayChatModels.swift
+++ b/apps/macos/Cybara/Sources/Cybara/GatewayChatModels.swift
@@ -39,6 +39,8 @@ struct GatewayAgent: Decodable, Identifiable, Hashable {
     let provider_type: String?
     let system_prompt: String?
     let reasoning_effort: String?
+    let reasoning_mode: String?
+    let reasoning_efforts: [String]?
     let supports_images: Bool?
     let created_at: String?
     let config: [String: JSONValue]?
@@ -46,7 +48,9 @@ struct GatewayAgent: Decodable, Identifiable, Hashable {
     private enum CodingKeys: String, CodingKey {
         case id, name, label, type, model, status, state, provider, provider_id, providerId
         case provider_type, providerType
-        case system_prompt, systemPrompt, reasoning_effort, reasoningEffort, supports_images, supportsImages
+        case system_prompt, systemPrompt, reasoning_effort, reasoningEffort
+        case reasoning_mode, reasoningMode, reasoning_efforts, reasoningEfforts
+        case supports_images, supportsImages
         case created_at, createdAt, config
     }
 
@@ -63,6 +67,9 @@ struct GatewayAgent: Decodable, Identifiable, Hashable {
         provider_type = try container.decodeFlexibleString(forKeys: [.provider_type, .providerType])
         system_prompt = try container.decodeFlexibleString(forKeys: [.system_prompt, .systemPrompt])
         reasoning_effort = try container.decodeFlexibleString(forKeys: [.reasoning_effort, .reasoningEffort])
+        reasoning_mode = try container.decodeFlexibleString(forKeys: [.reasoning_mode, .reasoningMode])
+        reasoning_efforts = try container.decodeIfPresent([String].self, forKey: .reasoning_efforts)
+            ?? container.decodeIfPresent([String].self, forKey: .reasoningEfforts)
         supports_images = try container.decodeIfPresent(Bool.self, forKey: .supports_images)
             ?? container.decodeIfPresent(Bool.self, forKey: .supportsImages)
         created_at = try container.decodeFlexibleString(forKeys: [.created_at, .createdAt])

--- a/apps/macos/Cybara/Sources/Cybara/NativeAgentsScreen.swift
+++ b/apps/macos/Cybara/Sources/Cybara/NativeAgentsScreen.swift
@@ -26,6 +26,15 @@ private let nativeBinaryThinkingProviders: Set<String> = [
 private let nativeAdaptiveThinkingProviders: Set<String> = [
     "minimax", "minimax-cn", "minimax-portal", "minimax-portal-cn",
 ]
+private let nativeKimiCodeProviders: Set<String> = [
+    "kimi-code", "kimi-code-oauth", "kimi-coding", "kimi-oauth", "kimi-code-subscription",
+]
+private let nativeAnthropicProviders: Set<String> = [
+    "anthropic", "anthropic-oauth", "anthropic_vertex", "claude-oauth",
+]
+private let nativeGoogleProviders: Set<String> = [
+    "antigravity", "gemini-cli", "google", "google-antigravity", "google-gemini-cli", "google_vertex",
+]
 
 private let nativeEffortLabels: [String: String] = [
     "minimal": "Minimal",
@@ -50,7 +59,9 @@ private let nativeAnthropicLegacyEfforts = ["minimal", "low", "medium", "high"]
 private let nativeAnthropic46Efforts = ["low", "medium", "high", "max"]
 private let nativeAnthropicModernEfforts = ["low", "medium", "high", "xhigh", "max"]
 private let nativeGoogleEfforts = ["low", "medium", "high"]
+private let nativeGoogleFlashEfforts = ["minimal", "low", "medium", "high"]
 private let nativeGoogleProEfforts = ["low", "high"]
+private let nativeKimiK3Efforts = ["low", "high", "max"]
 
 private func nativeNormalizeModelId(_ id: String?) -> String {
     var model = (id ?? "").trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
@@ -108,12 +119,19 @@ private func nativeSupportedEfforts(provider: String?, model: String?) -> [Strin
         return ["medium"]
     }
     let modelId = nativeNormalizeModelId(model)
-    if providerId == "anthropic" || providerId == "anthropic_vertex" {
+    if nativeKimiCodeProviders.contains(providerId),
+       modelId.range(of: #"(?:^|/)k3$"#, options: .regularExpression) != nil {
+        return nativeKimiK3Efforts
+    }
+    if nativeAnthropicProviders.contains(providerId) {
         return nativeResolveAnthropicEfforts(modelId)
     }
-    if providerId == "google" || providerId == "google_vertex" {
-        if modelId.range(of: #"^gemini-3(?:\.1)?-.*pro"#, options: .regularExpression) != nil {
+    if nativeGoogleProviders.contains(providerId) {
+        if modelId.range(of: #"^gemini-3(?:\.\d+)?-.*pro"#, options: .regularExpression) != nil {
             return nativeGoogleProEfforts
+        }
+        if modelId.range(of: #"^gemini-3(?:\.\d+)?-.*flash"#, options: .regularExpression) != nil {
+            return nativeGoogleFlashEfforts
         }
         return nativeGoogleEfforts
     }
@@ -132,7 +150,7 @@ func nativeSupportedReasoningEfforts(provider: String?, model: String?) -> [(val
     let providerId = (provider ?? "").trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     let modelId = nativeNormalizeModelId(model)
     if nativeAdaptiveThinkingProviders.contains(providerId),
-       modelId.range(of: #"^minimax-m3(?:[.-]|$)"#, options: .regularExpression) != nil {
+       modelId.range(of: #"(?:^|/)minimax-m3(?:[.-]|$)"#, options: .regularExpression) != nil {
         return [("", "Adaptive")]
     }
     if nativeBinaryThinkingProviders.contains(providerId) {
@@ -145,7 +163,27 @@ func nativeSupportedReasoningEfforts(provider: String?, model: String?) -> [(val
     return levels
 }
 
+func nativeSupportedReasoningEfforts(agent: GatewayAgent) -> [(value: String, label: String)] {
+    if agent.reasoning_mode == "adaptive" { return [("", "Adaptive")] }
+    if agent.reasoning_mode == "binary" { return [("", "Default"), ("medium", "Thinking")] }
+    if let efforts = agent.reasoning_efforts {
+        return [("", "Default")] + efforts.map { ($0, nativeEffortLabels[$0] ?? $0.capitalized) }
+    }
+    return nativeSupportedReasoningEfforts(
+        provider: agent.providerType ?? agent.providerID,
+        model: agent.model
+    )
+}
+
 func nativeCoerceReasoningEffort(_ effort: String, provider: String?, model: String?) -> String {
+    let providerID = (provider ?? "").trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    let modelID = nativeNormalizeModelId(model)
+    if nativeKimiCodeProviders.contains(providerID),
+       modelID.range(of: #"(?:^|/)k3$"#, options: .regularExpression) != nil {
+        if effort == "minimal" || effort == "low" { return "low" }
+        if effort == "medium" || effort == "high" { return "high" }
+        return "max"
+    }
     let supported = nativeSupportedReasoningEfforts(provider: provider, model: model)
     if supported.contains(where: { $0.value == effort }) { return effort }
     let supportedValues = supported.map(\.value).filter { !$0.isEmpty }

--- a/apps/macos/Cybara/Sources/Cybara/NativeAgentsScreen.swift
+++ b/apps/macos/Cybara/Sources/Cybara/NativeAgentsScreen.swift
@@ -166,7 +166,7 @@ func nativeSupportedReasoningEfforts(provider: String?, model: String?) -> [(val
 func nativeSupportedReasoningEfforts(agent: GatewayAgent) -> [(value: String, label: String)] {
     if agent.reasoning_mode == "adaptive" { return [("", "Adaptive")] }
     if agent.reasoning_mode == "binary" { return [("", "Default"), ("medium", "Thinking")] }
-    if let efforts = agent.reasoning_efforts {
+    if let efforts = agent.reasoning_efforts, !efforts.isEmpty {
         return [("", "Default")] + efforts.map { ($0, nativeEffortLabels[$0] ?? $0.capitalized) }
     }
     return nativeSupportedReasoningEfforts(
@@ -196,6 +196,13 @@ func nativeCoerceReasoningEffort(_ effort: String, provider: String?, model: Str
 func nativeReasoningLabel(effort: String, provider: String?, model: String?) -> String {
     let options = nativeSupportedReasoningEfforts(provider: provider, model: model)
     return options.first { $0.value == effort }?.label ?? "Default"
+}
+
+func nativeReasoningLabel(effort: String, agent: GatewayAgent) -> String {
+    let options = nativeSupportedReasoningEfforts(agent: agent)
+    return options.first { $0.value == effort }?.label
+        ?? options.first { $0.value.isEmpty }?.label
+        ?? "Default"
 }
 
 struct AgentsScreen: View {
@@ -342,7 +349,7 @@ struct AgentsScreen: View {
                     .font(.system(size: 12, design: .rounded))
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
-                Text("Reasoning · \(nativeReasoningLabel(effort: agent.reasoningEffort, provider: agent.providerType ?? agent.providerID, model: agent.model))")
+                Text("Reasoning · \(nativeReasoningLabel(effort: agent.reasoningEffort, agent: agent))")
                     .font(.system(size: 11, design: .rounded))
                     .foregroundStyle(.tertiary)
             }

--- a/apps/macos/Cybara/Sources/Cybara/NativeChatDerivedState.swift
+++ b/apps/macos/Cybara/Sources/Cybara/NativeChatDerivedState.swift
@@ -75,10 +75,8 @@ extension ChatScreen {
     }
 
     var composerReasoningEfforts: [(value: String, label: String)] {
-        nativeSupportedReasoningEfforts(
-            provider: selectedChatAgent?.providerType ?? selectedChatAgent?.providerID,
-            model: selectedChatAgent?.model
-        )
+        guard let selectedChatAgent else { return nativeReasoningEfforts }
+        return nativeSupportedReasoningEfforts(agent: selectedChatAgent)
     }
 
     var agentSelectionBinding: Binding<String> {

--- a/apps/macos/Cybara/Sources/Cybara/NativeChatDerivedState.swift
+++ b/apps/macos/Cybara/Sources/Cybara/NativeChatDerivedState.swift
@@ -67,11 +67,8 @@ extension ChatScreen {
     }
 
     var activeReasoningEffortLabel: String {
-        nativeReasoningLabel(
-            effort: activeReasoningEffort,
-            provider: selectedChatAgent?.providerType ?? selectedChatAgent?.providerID,
-            model: selectedChatAgent?.model
-        )
+        guard let selectedChatAgent else { return "Default" }
+        return nativeReasoningLabel(effort: activeReasoningEffort, agent: selectedChatAgent)
     }
 
     var composerReasoningEfforts: [(value: String, label: String)] {

--- a/apps/macos/Cybara/Sources/Cybara/SidecarCore.swift
+++ b/apps/macos/Cybara/Sources/Cybara/SidecarCore.swift
@@ -34,6 +34,25 @@ public enum SidecarCore {
         "\(serverURLString(port: port))/api/health"
     }
 
+    public static func fallbackPorts(after preferredPort: Int, count: Int = 20) -> [Int] {
+        guard count > 0 else { return [] }
+        let lowerBound = 1024
+        let upperBound = 65535
+        let rangeSize = upperBound - lowerBound + 1
+        let normalized = min(max(preferredPort, lowerBound), upperBound)
+        return (1...min(count, rangeSize - 1)).map { offset in
+            lowerBound + ((normalized - lowerBound + offset) % rangeSize)
+        }
+    }
+
+    public static func firstAvailableFallbackPort(
+        after preferredPort: Int,
+        count: Int = 20,
+        isAvailable: (Int) -> Bool
+    ) -> Int? {
+        fallbackPorts(after: preferredPort, count: count).first(where: isAvailable)
+    }
+
     public static func isHealthyResponse(statusCode: Int, body: String) -> Bool {
         gatewayHealthProbe(statusCode: statusCode, body: body) != nil
     }

--- a/apps/macos/Cybara/Sources/Cybara/SidecarCore.swift
+++ b/apps/macos/Cybara/Sources/Cybara/SidecarCore.swift
@@ -13,6 +13,11 @@ public struct GatewayHealthProbe: Equatable {
     public let processID: Int?
 }
 
+public enum FallbackPortDecision: Equatable {
+    case attach(Int)
+    case launch(Int)
+}
+
 /// Pure, side-effect-free logic for the macOS sidecar shell. Kept separate from
 /// `SidecarManager` (which is @MainActor and owns Process/network/UI state) so it
 /// is straightforward to unit-test without spawning processes or hitting sockets.
@@ -51,6 +56,18 @@ public enum SidecarCore {
         isAvailable: (Int) -> Bool
     ) -> Int? {
         fallbackPorts(after: preferredPort, count: count).first(where: isAvailable)
+    }
+
+    public static func fallbackPortDecision(
+        candidates: [Int], compatiblePorts: Set<Int>, availablePorts: Set<Int>
+    ) -> FallbackPortDecision? {
+        if let compatible = candidates.first(where: compatiblePorts.contains) {
+            return .attach(compatible)
+        }
+        if let available = candidates.first(where: availablePorts.contains) {
+            return .launch(available)
+        }
+        return nil
     }
 
     public static func isHealthyResponse(statusCode: Int, body: String) -> Bool {

--- a/apps/macos/Cybara/Sources/Cybara/SidecarManager.swift
+++ b/apps/macos/Cybara/Sources/Cybara/SidecarManager.swift
@@ -79,7 +79,7 @@ final class SidecarManager: ObservableObject {
     @Published private(set) var logs: [String] = ["Cybara initialized."]
     @Published private(set) var gatewayMode: GatewayMode = .idle
 
-    let port: Int
+    @Published private(set) var port: Int
     var serverURL: URL {
         URL(string: "http://127.0.0.1:\(port)")!
     }
@@ -119,6 +119,7 @@ final class SidecarManager: ObservableObject {
     private var process: Process?
     private var outputHandle: FileHandle?
     private var readinessTask: Task<Void, Never>?
+    private let allowsAutomaticPortFallback: Bool
     /// Set when the user explicitly stops/restarts, so an expected exit isn't
     /// treated as a crash by the auto-restart logic.
     private var userInitiatedStop = false
@@ -126,7 +127,10 @@ final class SidecarManager: ObservableObject {
     private var restartAttempts = 0
 
     init() {
-        port = SidecarCore.port(fromEnv: ProcessInfo.processInfo.environment["CYBARA_NATIVE_PORT"])
+        let configuredPort = ProcessInfo.processInfo.environment["CYBARA_NATIVE_PORT"]
+        port = SidecarCore.port(fromEnv: configuredPort)
+        allowsAutomaticPortFallback =
+            configuredPort?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty != false
     }
 
     deinit {
@@ -375,6 +379,21 @@ final class SidecarManager: ObservableObject {
             return .launch
         }
 
+        let occupiedURL = serverURL
+        if allowsAutomaticPortFallback,
+           let fallbackPort = SidecarCore.firstAvailableFallbackPort(
+            after: port,
+            isAvailable: isPortAvailable
+           )
+        {
+            port = fallbackPort
+            gatewayMode = .idle
+            appendLog(
+                "Gateway at \(occupiedURL.absoluteString) is incompatible; launching the bundled gateway at \(serverURL.absoluteString)."
+            )
+            return .launch
+        }
+
         let runningVersion = probe.version.map { "v\($0)" } ?? "an unknown version"
         let requiredVersion = minimumGatewayVersion.map { "v\($0) or newer" } ?? "this app version"
         status = .failed(
@@ -382,6 +401,28 @@ final class SidecarManager: ObservableObject {
         )
         appendLog("Refused incompatible gateway \(runningVersion) at \(serverURL.absoluteString)")
         return .blocked
+    }
+
+    private func isPortAvailable(_ candidate: Int) -> Bool {
+        let descriptor = Darwin.socket(AF_INET, SOCK_STREAM, 0)
+        guard descriptor >= 0 else { return false }
+        defer { Darwin.close(descriptor) }
+
+        var address = sockaddr_in()
+        address.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        address.sin_family = sa_family_t(AF_INET)
+        address.sin_port = in_port_t(candidate).bigEndian
+        address.sin_addr = in_addr(s_addr: inet_addr("127.0.0.1"))
+
+        return withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { socketAddress in
+                Darwin.bind(
+                    descriptor,
+                    socketAddress,
+                    socklen_t(MemoryLayout<sockaddr_in>.size)
+                ) == 0
+            }
+        }
     }
 
     private func terminateStaleNativeGateway(_ probe: GatewayHealthProbe) async -> Bool {

--- a/apps/macos/Cybara/Sources/Cybara/SidecarManager.swift
+++ b/apps/macos/Cybara/Sources/Cybara/SidecarManager.swift
@@ -330,10 +330,6 @@ final class SidecarManager: ObservableObject {
         }
     }
 
-    private var healthURL: URL {
-        serverURL.appending(path: "api/health")
-    }
-
     private var minimumGatewayVersion: String? {
         let environmentVersion = ProcessInfo.processInfo.environment["CYBARA_NATIVE_APP_VERSION"]?
             .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -341,9 +337,17 @@ final class SidecarManager: ObservableObject {
         return SidecarCore.bundleVersion(infoDictionary: Bundle.main.infoDictionary)
     }
 
-    private func gatewayProbe() async -> GatewayHealthProbe? {
+    private var healthURL: URL {
+        serverURL.appending(path: "api/health")
+    }
+
+    private func gatewayProbe(port candidatePort: Int? = nil, timeoutInterval: TimeInterval = 2) async -> GatewayHealthProbe? {
+        let targetPort = candidatePort ?? port
+        guard let url = URL(string: SidecarCore.healthURLString(port: targetPort)) else { return nil }
+        var request = URLRequest(url: url)
+        request.timeoutInterval = timeoutInterval
         do {
-            let (data, response) = try await URLSession.shared.data(from: healthURL)
+            let (data, response) = try await URLSession.shared.data(for: request)
             let code = (response as? HTTPURLResponse)?.statusCode ?? 0
             return SidecarCore.gatewayHealthProbe(
                 statusCode: code, body: String(data: data, encoding: .utf8) ?? "")
@@ -380,18 +384,43 @@ final class SidecarManager: ObservableObject {
         }
 
         let occupiedURL = serverURL
-        if allowsAutomaticPortFallback,
-           let fallbackPort = SidecarCore.firstAvailableFallbackPort(
-            after: port,
-            isAvailable: isPortAvailable
-           )
-        {
-            port = fallbackPort
-            gatewayMode = .idle
-            appendLog(
-                "Gateway at \(occupiedURL.absoluteString) is incompatible; launching the bundled gateway at \(serverURL.absoluteString)."
-            )
-            return .launch
+        if allowsAutomaticPortFallback {
+            let candidates = SidecarCore.fallbackPorts(after: port)
+            var compatiblePorts = Set<Int>()
+            var availablePorts = Set<Int>()
+            for candidate in candidates {
+                if let candidateProbe = await gatewayProbe(port: candidate, timeoutInterval: 0.25),
+                   SidecarCore.isGatewayVersionCompatible(
+                    gatewayVersion: candidateProbe.version,
+                    minimumVersion: minimumGatewayVersion
+                   )
+                {
+                    compatiblePorts.insert(candidate)
+                } else if isPortAvailable(candidate) {
+                    availablePorts.insert(candidate)
+                }
+            }
+            switch SidecarCore.fallbackPortDecision(
+                candidates: candidates,
+                compatiblePorts: compatiblePorts,
+                availablePorts: availablePorts
+            ) {
+            case .attach(let fallbackPort):
+                port = fallbackPort
+                gatewayMode = .attached
+                status = .ready
+                appendLog("Attached to compatible Cybara gateway at \(serverURL.absoluteString)")
+                return .attached
+            case .launch(let fallbackPort):
+                port = fallbackPort
+                gatewayMode = .idle
+                appendLog(
+                    "Gateway at \(occupiedURL.absoluteString) is incompatible; launching the bundled gateway at \(serverURL.absoluteString)."
+                )
+                return .launch
+            case nil:
+                break
+            }
         }
 
         let runningVersion = probe.version.map { "v\($0)" } ?? "an unknown version"

--- a/apps/macos/Cybara/Tests/CybaraTests/GatewayClientModelTests.swift
+++ b/apps/macos/Cybara/Tests/CybaraTests/GatewayClientModelTests.swift
@@ -172,6 +172,22 @@ final class GatewayClientModelTests: XCTestCase {
             nativeSupportedReasoningEfforts(provider: "minimax", model: "MiniMax-M3").map(\.label),
             ["Adaptive"]
         )
+        XCTAssertEqual(
+            nativeSupportedReasoningEfforts(provider: "kimi-code-oauth", model: "kimi-code/k3").map(\.value),
+            ["", "low", "high", "max"]
+        )
+        XCTAssertEqual(
+            nativeSupportedReasoningEfforts(provider: "google", model: "gemini-3.5-flash").map(\.value),
+            ["", "minimal", "low", "medium", "high"]
+        )
+        XCTAssertEqual(
+            nativeSupportedReasoningEfforts(provider: "google-gemini-cli", model: "gemini-3.5-flash").map(\.value),
+            ["", "minimal", "low", "medium", "high"]
+        )
+        XCTAssertEqual(
+            nativeSupportedReasoningEfforts(provider: "anthropic-oauth", model: "claude-opus-4-8").map(\.value),
+            ["", "low", "medium", "high", "xhigh", "max"]
+        )
     }
 
     func testSessionDisplayTitleTrimsGatewayTitle() throws {
@@ -589,6 +605,8 @@ final class GatewayClientModelTests: XCTestCase {
                   "status": "running",
                   "provider_id": "provider-1",
                   "system_prompt": "Be useful.",
+                  "reasoning_mode": "effort",
+                  "reasoning_efforts": ["low", "medium", "high"],
                   "config": {
                     "autostart": true,
                     "model_params": {
@@ -604,6 +622,8 @@ final class GatewayClientModelTests: XCTestCase {
         XCTAssertEqual(agent.providerID, "provider-1")
         XCTAssertTrue(agent.autostart)
         XCTAssertEqual(agent.reasoningEffort, "high")
+        XCTAssertEqual(agent.reasoning_mode, "effort")
+        XCTAssertEqual(agent.reasoning_efforts, ["low", "medium", "high"])
     }
 
     func testAgentDecodesGatewayListRowWithPersistedJsonConfigString() throws {

--- a/apps/macos/Cybara/Tests/CybaraTests/GatewayClientModelTests.swift
+++ b/apps/macos/Cybara/Tests/CybaraTests/GatewayClientModelTests.swift
@@ -190,6 +190,32 @@ final class GatewayClientModelTests: XCTestCase {
         )
     }
 
+    func testNativeReasoningOptionsPreferNonEmptyGatewayCapabilities() throws {
+        let adaptive = try decodeAgent(
+            #"{"id":"adaptive","name":"Adaptive","provider_type":"custom","reasoning_mode":"adaptive","reasoning_efforts":[],"reasoning_effort":null}"#
+        )
+        let explicit = try decodeAgent(
+            #"{"id":"explicit","name":"Explicit","provider_type":"custom","reasoning_mode":"effort","reasoning_efforts":["low","max"],"reasoning_effort":"max"}"#
+        )
+
+        XCTAssertEqual(nativeSupportedReasoningEfforts(agent: adaptive).map(\.label), ["Adaptive"])
+        XCTAssertEqual(nativeReasoningLabel(effort: adaptive.reasoningEffort, agent: adaptive), "Adaptive")
+        XCTAssertEqual(nativeSupportedReasoningEfforts(agent: explicit).map(\.value), ["", "low", "max"])
+        XCTAssertEqual(nativeReasoningLabel(effort: explicit.reasoningEffort, agent: explicit), "Max")
+    }
+
+    func testNativeReasoningOptionsFallBackWhenGatewayEffortsAreEmpty() throws {
+        let agent = try decodeAgent(
+            #"{"id":"fallback","name":"Fallback","model":"gpt-5.6-sol","provider_type":"openai-codex","reasoning_mode":"effort","reasoning_efforts":[],"reasoning_effort":"xhigh"}"#
+        )
+
+        XCTAssertEqual(
+            nativeSupportedReasoningEfforts(agent: agent).map(\.value),
+            ["", "low", "medium", "high", "xhigh", "max"]
+        )
+        XCTAssertEqual(nativeReasoningLabel(effort: agent.reasoningEffort, agent: agent), "Extra High")
+    }
+
     func testSessionDisplayTitleTrimsGatewayTitle() throws {
         let session = try decodeSession(#"{"id":"session-123456789","title":"  Release planning  "}"#)
 

--- a/apps/macos/Cybara/Tests/CybaraTests/SidecarCoreTests.swift
+++ b/apps/macos/Cybara/Tests/CybaraTests/SidecarCoreTests.swift
@@ -81,6 +81,35 @@ final class SidecarCoreTests: XCTestCase {
         )
     }
 
+    func testFallbackPortDecisionPrefersCompatibleGatewayOverEarlierFreePort() {
+        XCTAssertEqual(
+            SidecarCore.fallbackPortDecision(
+                candidates: [4270, 4271, 4272],
+                compatiblePorts: [4272],
+                availablePorts: [4270, 4271]
+            ),
+            .attach(4272)
+        )
+    }
+
+    func testFallbackPortDecisionUsesFirstFreePortWhenNoGatewayIsCompatible() {
+        XCTAssertEqual(
+            SidecarCore.fallbackPortDecision(
+                candidates: [4270, 4271, 4272],
+                compatiblePorts: [],
+                availablePorts: [4271, 4272]
+            ),
+            .launch(4271)
+        )
+        XCTAssertNil(
+            SidecarCore.fallbackPortDecision(
+                candidates: [4270],
+                compatiblePorts: [],
+                availablePorts: []
+            )
+        )
+    }
+
     // MARK: - isHealthyResponse
 
     func testHealthyResponseAccepts200WithStatus() {

--- a/apps/macos/Cybara/Tests/CybaraTests/SidecarCoreTests.swift
+++ b/apps/macos/Cybara/Tests/CybaraTests/SidecarCoreTests.swift
@@ -47,6 +47,40 @@ final class SidecarCoreTests: XCTestCase {
         XCTAssertEqual(SidecarCore.healthURLString(port: 4269), "http://127.0.0.1:4269/api/health")
     }
 
+    func testFallbackPortsFollowPreferredPort() {
+        XCTAssertEqual(
+            SidecarCore.fallbackPorts(after: 4269, count: 4),
+            [4270, 4271, 4272, 4273]
+        )
+        XCTAssertEqual(SidecarCore.fallbackPorts(after: 4269, count: 0), [])
+    }
+
+    func testFallbackPortsWrapWithinUnprivilegedRange() {
+        XCTAssertEqual(
+            SidecarCore.fallbackPorts(after: 65535, count: 3),
+            [1024, 1025, 1026]
+        )
+    }
+
+    func testFirstAvailableFallbackPortSkipsOccupiedPorts() {
+        let occupied = Set([4270, 4271, 4272])
+        XCTAssertEqual(
+            SidecarCore.firstAvailableFallbackPort(
+                after: 4269,
+                count: 5,
+                isAvailable: { !occupied.contains($0) }
+            ),
+            4273
+        )
+        XCTAssertNil(
+            SidecarCore.firstAvailableFallbackPort(
+                after: 4269,
+                count: 3,
+                isAvailable: { !occupied.contains($0) }
+            )
+        )
+    }
+
     // MARK: - isHealthyResponse
 
     func testHealthyResponseAccepts200WithStatus() {

--- a/apps/mobile/src/components/NewChatPanel.tsx
+++ b/apps/mobile/src/components/NewChatPanel.tsx
@@ -1,3 +1,4 @@
+import { Brain, ChevronRight, CircleHelp, Send, ShieldAlert } from "lucide-react-native";
 import { useEffect, useRef, useState } from "react";
 import {
   ActionSheetIOS,
@@ -11,13 +12,11 @@ import {
   TextInput,
   View,
 } from "react-native";
-import { Brain, ChevronRight, CircleHelp, Send, ShieldAlert } from "lucide-react-native";
-import { GlassPanel } from "./Glass";
-import { CybaraMobileApi, type AgentSummary } from "../lib/api";
+import { type AgentSummary, CybaraMobileApi } from "../lib/api";
 import {
-  MOBILE_CHAT_COMPOSER,
   boundedMobileComposerHeight,
   createMobileSessionId,
+  MOBILE_CHAT_COMPOSER,
   mobileComposerHeightForDraft,
   mobileReasoningLabel,
   mobileSupportedReasoningEfforts,
@@ -26,6 +25,7 @@ import { haptics } from "../lib/haptics";
 import { liveAssistantMessage, writeCachedMobileLiveAssistant } from "../screens/dashboardLiveChat";
 import { writeCachedMobileOptimisticTranscriptMessage } from "../screens/dashboardOptimisticTranscript";
 import { colors, radius, spacing, subscribeColors, typography } from "../theme/liquidGlass";
+import { GlassPanel } from "./Glass";
 
 function normalizeApprovalMode(value?: string): "always_allow" | "ask" {
   return value === "ask" ? "ask" : "always_allow";
@@ -115,7 +115,9 @@ export function NewChatPanel({
       : (selectedAgent?.reasoning_effort ?? null);
   const reasoningOptions = mobileSupportedReasoningEfforts(
     selectedAgent?.provider_type ?? selectedAgent?.provider_id ?? selectedAgent?.provider,
-    selectedAgent?.model
+    selectedAgent?.model,
+    selectedAgent?.reasoning_mode,
+    selectedAgent?.reasoning_efforts
   ).map((option) => ({
     label: option.label,
     value: option.value === "" ? null : option.value,
@@ -123,7 +125,9 @@ export function NewChatPanel({
   const reasoningLabel = mobileReasoningLabel(
     reasoningEffort,
     selectedAgent?.provider_type ?? selectedAgent?.provider_id ?? selectedAgent?.provider,
-    selectedAgent?.model
+    selectedAgent?.model,
+    selectedAgent?.reasoning_mode,
+    selectedAgent?.reasoning_efforts
   );
 
   const saveReasoningEffort = async (effort: AgentSummary["reasoning_effort"]) => {

--- a/apps/mobile/src/lib/api-normalizers.ts
+++ b/apps/mobile/src/lib/api-normalizers.ts
@@ -957,6 +957,22 @@ export function normalizeAgent(agent: unknown, index = 0): AgentSummary {
   const reasoningEffort =
     readString(record, ["reasoning_effort", "reasoningEffort"]) ??
     readString(modelParams, ["reasoning_effort", "reasoningEffort"]);
+  const reasoningModeValue = readString(record, ["reasoning_mode", "reasoningMode"]);
+  const reasoningMode =
+    reasoningModeValue === "adaptive" ||
+    reasoningModeValue === "binary" ||
+    reasoningModeValue === "effort"
+      ? reasoningModeValue
+      : undefined;
+  const rawReasoningEfforts = record.reasoning_efforts ?? record.reasoningEfforts;
+  const reasoningEfforts = Array.isArray(rawReasoningEfforts)
+    ? rawReasoningEfforts.flatMap((value) =>
+        typeof value === "string" &&
+        ["minimal", "low", "medium", "high", "xhigh", "max"].includes(value)
+          ? [value as NonNullable<AgentSummary["reasoning_efforts"]>[number]]
+          : []
+      )
+    : undefined;
   return {
     id,
     name: readString(record, ["name", "label", "id"]) || id,
@@ -972,6 +988,8 @@ export function normalizeAgent(agent: unknown, index = 0): AgentSummary {
     )
       ? (reasoningEffort as AgentSummary["reasoning_effort"])
       : null,
+    reasoning_mode: reasoningMode,
+    reasoning_efforts: reasoningEfforts,
     supports_images: readBoolean(record, ["supports_images", "supportsImages"]),
     config,
   };

--- a/apps/mobile/src/lib/api-types.ts
+++ b/apps/mobile/src/lib/api-types.ts
@@ -168,6 +168,8 @@ export interface AgentSummary {
   provider_type?: string;
   system_prompt?: string;
   reasoning_effort?: "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | null;
+  reasoning_mode?: "adaptive" | "binary" | "effort";
+  reasoning_efforts?: Array<"minimal" | "low" | "medium" | "high" | "xhigh" | "max">;
   supports_images?: boolean;
   config?: Record<string, unknown>;
 }

--- a/apps/mobile/src/lib/dashboard.ts
+++ b/apps/mobile/src/lib/dashboard.ts
@@ -1,3 +1,9 @@
+import {
+  supportedReasoningEfforts,
+  supportsXHighReasoning,
+  usesBinaryReasoning,
+  usesProviderAdaptiveReasoning,
+} from "cybara-shared/reasoning-capabilities";
 import type {
   FeatureEndpointKey,
   FeatureSummary,
@@ -6,12 +12,6 @@ import type {
   SessionSummary,
 } from "./api";
 import type { GatewayProfile } from "./connection";
-import {
-  supportedReasoningEfforts,
-  supportsXHighReasoning,
-  usesBinaryReasoning,
-  usesProviderAdaptiveReasoning,
-} from "cybara-shared/reasoning-capabilities";
 
 export type MobileTabKey = "overview" | "sessions" | "metrics" | "usage" | "tasks" | "settings";
 export type MobileSettingsTab =
@@ -220,20 +220,25 @@ export function mobileSupportsXHighReasoning(
 
 export function mobileSupportedReasoningEfforts(
   provider?: string | null,
-  model?: string | null
+  model?: string | null,
+  mode?: "adaptive" | "binary" | "effort",
+  supportedEfforts?: Array<"minimal" | "low" | "medium" | "high" | "xhigh" | "max">
 ): readonly { label: string; value: MobileReasoningEffort }[] {
-  if (usesProviderAdaptiveReasoning(provider, model)) {
+  if (mode === "adaptive" || (!mode && usesProviderAdaptiveReasoning(provider, model))) {
     return [{ label: "Adaptive", value: "" }];
   }
-  if (usesBinaryReasoning(provider)) {
+  if (mode === "binary" || (!mode && usesBinaryReasoning(provider))) {
     return [
       { label: "Default", value: "" },
       { label: "Thinking", value: "medium" },
     ];
   }
+  const efforts = supportedEfforts?.length
+    ? supportedEfforts
+    : supportedReasoningEfforts(provider, model);
   return [
     { label: "Default", value: "" },
-    ...supportedReasoningEfforts(provider, model).map((level) => ({
+    ...efforts.map((level) => ({
       label: MOBILE_EFFORT_LABELS[level] ?? level,
       value: level as MobileReasoningEffort,
     })),
@@ -243,9 +248,11 @@ export function mobileSupportedReasoningEfforts(
 export function mobileReasoningLabel(
   effort: string | null | undefined,
   provider?: string | null,
-  model?: string | null
+  model?: string | null,
+  mode?: "adaptive" | "binary" | "effort",
+  supportedEfforts?: Array<"minimal" | "low" | "medium" | "high" | "xhigh" | "max">
 ): string {
-  const options = mobileSupportedReasoningEfforts(provider, model);
+  const options = mobileSupportedReasoningEfforts(provider, model, mode, supportedEfforts);
   return options.find((option) => option.value === (effort ?? ""))?.label ?? "Default";
 }
 

--- a/apps/mobile/src/lib/dashboard.ts
+++ b/apps/mobile/src/lib/dashboard.ts
@@ -6,6 +6,12 @@ import type {
   SessionSummary,
 } from "./api";
 import type { GatewayProfile } from "./connection";
+import {
+  supportedReasoningEfforts,
+  supportsXHighReasoning,
+  usesBinaryReasoning,
+  usesProviderAdaptiveReasoning,
+} from "cybara-shared/reasoning-capabilities";
 
 export type MobileTabKey = "overview" | "sessions" | "metrics" | "usage" | "tasks" | "settings";
 export type MobileSettingsTab =
@@ -205,119 +211,21 @@ const MOBILE_EFFORT_LABELS: Record<string, string> = {
   max: "Max",
 };
 
-const MOBILE_BINARY_THINKING_PROVIDERS = new Set([
-  "z.ai",
-  "z.ai-coding",
-  "zai",
-  "z-ai",
-  "qwen-portal",
-  "alibaba",
-  "alibaba-coding-plan",
-  "qwen-token-plan",
-  "qwen-token-plan-cn",
-]);
-const MOBILE_ADAPTIVE_THINKING_PROVIDERS = new Set([
-  "minimax",
-  "minimax-cn",
-  "minimax-portal",
-  "minimax-portal-cn",
-]);
-
-const MOBILE_GPT_5_EFFORTS = ["minimal", "low", "medium", "high"] as const;
-const MOBILE_GPT_51_EFFORTS = ["low", "medium", "high"] as const;
-const MOBILE_GPT_52_EFFORTS = ["low", "medium", "high", "xhigh"] as const;
-const MOBILE_GPT_56_EFFORTS = ["low", "medium", "high", "xhigh", "max"] as const;
-const MOBILE_GPT_CODEX_EFFORTS = ["low", "medium", "high", "xhigh"] as const;
-const MOBILE_GPT_CODEX_MINI_EFFORTS = ["medium"] as const;
-const MOBILE_GPT_CODEX_MAX_EFFORTS = ["medium", "high", "xhigh"] as const;
-const MOBILE_GPT_PRO_EFFORTS = ["medium", "high", "xhigh"] as const;
-const MOBILE_GPT_5_PRO_EFFORTS = ["high"] as const;
-const MOBILE_GENERIC_OPENAI_EFFORTS = ["low", "medium", "high"] as const;
-const MOBILE_ANTHROPIC_LEGACY_EFFORTS = ["minimal", "low", "medium", "high"] as const;
-const MOBILE_ANTHROPIC_46_EFFORTS = ["low", "medium", "high", "max"] as const;
-const MOBILE_ANTHROPIC_MODERN_EFFORTS = ["low", "medium", "high", "xhigh", "max"] as const;
-const MOBILE_GOOGLE_EFFORTS = ["low", "medium", "high"] as const;
-const MOBILE_GOOGLE_PRO_EFFORTS = ["low", "high"] as const;
-
-function mobileNormalizeModelId(id: string | null | undefined): string {
-  return (id ?? "")
-    .trim()
-    .toLowerCase()
-    .replace(/^(?:openai\/|anthropic\/|google\/)?/, "")
-    .replace(/-\d{4}-\d{2}-\d{2}$/, "");
-}
-
-function mobileResolveOpenAIModelEfforts(modelId: string): readonly string[] {
-  if (/^gpt-5\.6(?:-|$)/.test(modelId)) return MOBILE_GPT_56_EFFORTS;
-  if (modelId === "gpt-5.1-codex-mini") return MOBILE_GPT_CODEX_MINI_EFFORTS;
-  if (modelId === "gpt-5.1-codex-max") return MOBILE_GPT_CODEX_MAX_EFFORTS;
-  if (/^gpt-5(?:\.\d+)?-codex(?:-|$)/.test(modelId)) return MOBILE_GPT_CODEX_EFFORTS;
-  if (modelId === "gpt-5-pro") return MOBILE_GPT_5_PRO_EFFORTS;
-  if (/^gpt-5\.[2-9](?:\.\d+)?-pro(?:-|$)/.test(modelId)) return MOBILE_GPT_PRO_EFFORTS;
-  if (/^gpt-5\.[2-9](?:\.\d+)?(?:-|$)/.test(modelId)) return MOBILE_GPT_52_EFFORTS;
-  if (/^gpt-5\.1(?:-|$)/.test(modelId)) return MOBILE_GPT_51_EFFORTS;
-  if (/^gpt-5(?:-|$)/.test(modelId)) return MOBILE_GPT_5_EFFORTS;
-  return MOBILE_GENERIC_OPENAI_EFFORTS;
-}
-
-function mobileResolveAnthropicEfforts(modelId: string): readonly string[] {
-  if (!modelId.includes("claude")) return MOBILE_ANTHROPIC_LEGACY_EFFORTS;
-  if (/claude-(?:opus|sonnet)-4[-.]6(?:-|$)/.test(modelId)) {
-    return MOBILE_ANTHROPIC_46_EFFORTS;
-  }
-  if (/claude-(?:3|opus-4[-.][0-5]|sonnet-4[-.][0-5]|haiku-4[-.]5)(?:-|$)/.test(modelId)) {
-    return MOBILE_ANTHROPIC_LEGACY_EFFORTS;
-  }
-  return MOBILE_ANTHROPIC_MODERN_EFFORTS;
-}
-
-function mobileSupportedEfforts(
-  provider?: string | null,
-  model?: string | null
-): readonly string[] {
-  const providerId = (provider ?? "").trim().toLowerCase();
-  if (MOBILE_BINARY_THINKING_PROVIDERS.has(providerId)) {
-    return ["medium"];
-  }
-  const modelId = mobileNormalizeModelId(model);
-  if (providerId === "anthropic" || providerId === "anthropic_vertex") {
-    return mobileResolveAnthropicEfforts(modelId);
-  }
-  if (providerId === "google" || providerId === "google_vertex") {
-    if (/^gemini-3(?:\.1)?-.*pro/.test(modelId)) return MOBILE_GOOGLE_PRO_EFFORTS;
-    return MOBILE_GOOGLE_EFFORTS;
-  }
-  if (
-    providerId === "openai" ||
-    providerId === "openai-codex" ||
-    providerId === "openai-codex-responses" ||
-    providerId === "azure-openai" ||
-    !modelId
-  ) {
-    return mobileResolveOpenAIModelEfforts(modelId);
-  }
-  return MOBILE_GENERIC_OPENAI_EFFORTS;
-}
-
 export function mobileSupportsXHighReasoning(
   provider?: string | null,
   model?: string | null
 ): boolean {
-  return mobileSupportedEfforts(provider, model).includes("xhigh");
+  return supportsXHighReasoning(provider, model);
 }
 
 export function mobileSupportedReasoningEfforts(
   provider?: string | null,
   model?: string | null
 ): readonly { label: string; value: MobileReasoningEffort }[] {
-  const providerId = (provider ?? "").trim().toLowerCase();
-  if (
-    MOBILE_ADAPTIVE_THINKING_PROVIDERS.has(providerId) &&
-    /(?:^|\/)minimax-m3(?:[.-]|$)/i.test(model ?? "")
-  ) {
+  if (usesProviderAdaptiveReasoning(provider, model)) {
     return [{ label: "Adaptive", value: "" }];
   }
-  if (MOBILE_BINARY_THINKING_PROVIDERS.has(providerId)) {
+  if (usesBinaryReasoning(provider)) {
     return [
       { label: "Default", value: "" },
       { label: "Thinking", value: "medium" },
@@ -325,7 +233,7 @@ export function mobileSupportedReasoningEfforts(
   }
   return [
     { label: "Default", value: "" },
-    ...mobileSupportedEfforts(provider, model).map((level) => ({
+    ...supportedReasoningEfforts(provider, model).map((level) => ({
       label: MOBILE_EFFORT_LABELS[level] ?? level,
       value: level as MobileReasoningEffort,
     })),

--- a/apps/mobile/src/screens/dashboardSessionDetail.tsx
+++ b/apps/mobile/src/screens/dashboardSessionDetail.tsx
@@ -754,12 +754,20 @@ export function SessionDetailPanel({
     () =>
       mobileSupportedReasoningEfforts(
         selectedAgent?.provider_type ?? selectedAgent?.provider_id ?? selectedAgent?.provider,
-        selectedAgent?.model
+        selectedAgent?.model,
+        selectedAgent?.reasoning_mode,
+        selectedAgent?.reasoning_efforts
       ).map((option) => ({
         value: option.value === "" ? null : option.value,
         label: option.label,
       })),
-    [selectedAgent?.provider_id, selectedAgent?.provider, selectedAgent?.model]
+    [
+      selectedAgent?.provider_id,
+      selectedAgent?.provider,
+      selectedAgent?.model,
+      selectedAgent?.reasoning_mode,
+      selectedAgent?.reasoning_efforts,
+    ]
   );
   const reasoningLabel =
     reasoningOptions.find((option) => option.value === reasoningEffort)?.label ?? "Default";

--- a/scripts/build-sidecar.ts
+++ b/scripts/build-sidecar.ts
@@ -1,5 +1,4 @@
 #!/usr/bin/env bun
-import { $ } from "bun";
 import {
   cpSync,
   existsSync,
@@ -18,6 +17,7 @@ import {
   getCuaDriverTarget,
   installCuaDriverAt,
 } from "../src/core/cua-driver-runtime";
+import { buildStandaloneCli } from "./build-standalone-cli";
 
 const TAURI_BIN_DIR = join(import.meta.dirname, "..", "src-tauri", "bin");
 const RELEASE_DIR = join(import.meta.dirname, "..", "release");
@@ -626,8 +626,6 @@ export async function buildSidecar(): Promise<void> {
     process.env.GITHUB_SHA?.trim() ||
     (await readGitCommit(join(import.meta.dirname, "..")));
   if (buildCommit) process.env.CYBARA_BUILD_COMMIT = buildCommit;
-  const buildEnvironment = "--env=CYBARA_BUILD_*";
-
   console.log(`\n⚡ Building Cybara sidecar for ${target.tauriSuffix}\n`);
 
   for (const dir of [RELEASE_DIR, TAURI_BIN_DIR, tauriDebugDir]) {
@@ -705,7 +703,12 @@ export default instance.exports;
   }
 
   try {
-    await $`bun build src/index.ts --compile ${buildEnvironment} --target=${target.bunTarget} --outfile ${releasePath} --external electron --external @aws-sdk/client-s3 --external onnxruntime-node --external onnxruntime-web --external @huggingface/transformers --external kokoro-js --external playwright --external playwright-core`;
+    await buildStandaloneCli({
+      target: target.bunTarget,
+      outfile: releasePath,
+      entryModule: "src/index.ts",
+      externalPackages: ["playwright", "playwright-core"],
+    });
   } finally {
     // Restore original wasm_loader.js
     if (originalWasmLoader) {

--- a/scripts/build-standalone-cli.ts
+++ b/scripts/build-standalone-cli.ts
@@ -7,11 +7,14 @@ export interface StandaloneCliBuildOptions {
   outfile: string;
   cwd?: string;
   uiDir?: string;
+  entryModule?: string;
+  externalPackages?: readonly string[];
 }
 
 export interface StandaloneEntryOptions {
   cwd: string;
   uiDir: string;
+  entryModule?: string;
 }
 
 const EXTERNAL_PACKAGES = [
@@ -46,6 +49,10 @@ export function createStandaloneEntrySource(options: StandaloneEntryOptions): st
   const indexPath = resolve(options.uiDir, "index.html");
   const index = files.indexOf(indexPath);
   if (index < 0) throw new Error(`Standalone UI index not found at ${indexPath}`);
+  const entryModule = importPath(
+    options.cwd,
+    resolve(options.cwd, options.entryModule ?? "src/main.ts")
+  );
 
   const imports = files.map(
     (path, position) =>
@@ -75,14 +82,15 @@ ${assets.join("\n")}
   },
 };
 
-await import("./src/main.ts");
+await import(${JSON.stringify(entryModule)});
 `;
 }
 
 export function standaloneCliBuildArgs(
   target: string,
   outfile: string,
-  entrypoint = "src/main.ts"
+  entrypoint = "src/main.ts",
+  externalPackages: readonly string[] = EXTERNAL_PACKAGES
 ): string[] {
   return [
     process.execPath,
@@ -92,7 +100,10 @@ export function standaloneCliBuildArgs(
     "--env=CYBARA_BUILD_*",
     `--target=${target}`,
     `--outfile=${outfile}`,
-    ...EXTERNAL_PACKAGES.flatMap((packageName) => ["--external", packageName]),
+    ...[...new Set([...EXTERNAL_PACKAGES, ...externalPackages])].flatMap((packageName) => [
+      "--external",
+      packageName,
+    ]),
   ];
 }
 
@@ -105,9 +116,12 @@ export async function buildStandaloneCli(options: StandaloneCliBuildOptions): Pr
   const entrypoint = resolve(cwd, `.cybara-standalone-${process.pid}-${randomUUID()}.ts`);
 
   try {
-    await Bun.write(entrypoint, createStandaloneEntrySource({ cwd, uiDir }));
+    await Bun.write(
+      entrypoint,
+      createStandaloneEntrySource({ cwd, uiDir, entryModule: options.entryModule })
+    );
     const processHandle = Bun.spawn(
-      standaloneCliBuildArgs(options.target, options.outfile, entrypoint),
+      standaloneCliBuildArgs(options.target, options.outfile, entrypoint, options.externalPackages),
       {
         cwd,
         env: process.env,

--- a/scripts/package-native-macos.ts
+++ b/scripts/package-native-macos.ts
@@ -17,6 +17,7 @@ import {
 import { tmpdir } from "os";
 import { basename, dirname, join } from "path";
 import { buildSidecar } from "./build-sidecar";
+import { smokeSidecarUi } from "./smoke-tauri-sidecar-ui";
 
 const ROOT = join(import.meta.dirname, "..");
 const SWIFT_PRODUCT_NAME = "Cybara";
@@ -531,6 +532,8 @@ export async function packageNativeMacOSApp(): Promise<NativeMacOSPackageResult>
 
   console.log("⚡ Building sidecar...");
   await buildSidecar();
+  console.log("🩺 Verifying sidecar version...");
+  await smokeSidecarUi(SIDEcar_RELEASE_PATH, version);
 
   console.log("🧱 Building SwiftUI shell...");
   await $`cd ${ROOT} && swift build --package-path ${APP_PACKAGE_PATH} -c release`.quiet();

--- a/scripts/smoke-tauri-sidecar-ui.ts
+++ b/scripts/smoke-tauri-sidecar-ui.ts
@@ -1,0 +1,86 @@
+import { chmodSync, copyFileSync, mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { basename, join, resolve } from "path";
+
+function availablePort(): number {
+  const server = Bun.serve({ port: 0, fetch: () => new Response("reserved") });
+  const port = server.port;
+  server.stop(true);
+  return port;
+}
+
+async function waitForResponse(url: string): Promise<Response> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 120; attempt++) {
+    try {
+      const response = await fetch(url);
+      if (response.ok) return response;
+      lastError = new Error(`Gateway returned HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await Bun.sleep(250);
+  }
+  throw lastError instanceof Error ? lastError : new Error("Tauri sidecar did not start");
+}
+
+function firstAssetPath(html: string): string {
+  const match = html.match(/(?:src|href)="(\/assets\/[^"?#]+)["?#]/);
+  if (!match?.[1]) throw new Error("Embedded UI index does not reference a production asset");
+  return match[1];
+}
+
+export async function smokeTauriSidecarUi(sourceBinary: string): Promise<void> {
+  const directory = mkdtempSync(join(tmpdir(), "cybara-tauri-sidecar-ui-"));
+  const binary = join(directory, basename(sourceBinary));
+  const home = join(directory, "home");
+  const port = availablePort();
+  copyFileSync(sourceBinary, binary);
+  if (process.platform !== "win32") chmodSync(binary, 0o755);
+
+  const environment = { ...process.env };
+  delete environment.CYBARA_RESOURCE_DIR;
+  environment.CYBARA_HOME = home;
+  environment.HOME = home;
+  environment.USERPROFILE = home;
+  environment.PORT = String(port);
+  environment.CYBARA_REQUIRE_AUTH = "0";
+
+  const processHandle = Bun.spawn([binary, "start", "--port", String(port)], {
+    cwd: directory,
+    env: environment,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const stdoutPromise = new Response(processHandle.stdout).text();
+  const stderrPromise = new Response(processHandle.stderr).text();
+  let failure: unknown;
+  let output = "";
+
+  try {
+    const dashboard = await waitForResponse(`http://127.0.0.1:${port}/`);
+    const html = await dashboard.text();
+    if (html.includes("UI not built")) throw new Error("Tauri sidecar served the missing UI page");
+    const assetPath = firstAssetPath(html);
+    const asset = await fetch(`http://127.0.0.1:${port}${assetPath}`);
+    if (!asset.ok) throw new Error(`Embedded UI asset returned HTTP ${asset.status}: ${assetPath}`);
+  } catch (error) {
+    failure = error;
+  } finally {
+    processHandle.kill();
+    await processHandle.exited;
+    output = `${await stdoutPromise}\n${await stderrPromise}`;
+    rmSync(directory, { recursive: true, force: true });
+  }
+  if (output.includes("Failed to load UI index")) {
+    throw new Error("Tauri sidecar could not load its embedded UI");
+  }
+  if (failure) throw failure;
+}
+
+if (import.meta.main) {
+  const sourceBinary = process.argv[2]?.trim();
+  if (!sourceBinary) throw new Error("Usage: bun run scripts/smoke-tauri-sidecar-ui.ts <binary>");
+  await smokeTauriSidecarUi(resolve(sourceBinary));
+  console.log("Tauri sidecar embedded UI smoke passed");
+}

--- a/scripts/smoke-tauri-sidecar-ui.ts
+++ b/scripts/smoke-tauri-sidecar-ui.ts
@@ -30,7 +30,26 @@ function firstAssetPath(html: string): string {
   return match[1];
 }
 
-export async function smokeTauriSidecarUi(sourceBinary: string): Promise<void> {
+function readHealthVersion(value: unknown): string | null {
+  if (!value || typeof value !== "object" || !("version" in value)) return null;
+  const version = (value as { version?: unknown }).version;
+  return typeof version === "string" && version.trim() ? version.trim() : null;
+}
+
+export function assertSidecarVersion(value: unknown, expectedVersion?: string): void {
+  if (!expectedVersion) return;
+  const version = readHealthVersion(value);
+  if (version !== expectedVersion) {
+    throw new Error(
+      `Bundled gateway version ${version ?? "unknown"} does not match app version ${expectedVersion}`
+    );
+  }
+}
+
+export async function smokeSidecarUi(
+  sourceBinary: string,
+  expectedVersion?: string
+): Promise<void> {
   const directory = mkdtempSync(join(tmpdir(), "cybara-tauri-sidecar-ui-"));
   const binary = join(directory, basename(sourceBinary));
   const home = join(directory, "home");
@@ -64,6 +83,8 @@ export async function smokeTauriSidecarUi(sourceBinary: string): Promise<void> {
     const assetPath = firstAssetPath(html);
     const asset = await fetch(`http://127.0.0.1:${port}${assetPath}`);
     if (!asset.ok) throw new Error(`Embedded UI asset returned HTTP ${asset.status}: ${assetPath}`);
+    const health = await waitForResponse(`http://127.0.0.1:${port}/api/health`);
+    assertSidecarVersion(await health.json(), expectedVersion);
   } catch (error) {
     failure = error;
   } finally {
@@ -81,6 +102,6 @@ export async function smokeTauriSidecarUi(sourceBinary: string): Promise<void> {
 if (import.meta.main) {
   const sourceBinary = process.argv[2]?.trim();
   if (!sourceBinary) throw new Error("Usage: bun run scripts/smoke-tauri-sidecar-ui.ts <binary>");
-  await smokeTauriSidecarUi(resolve(sourceBinary));
-  console.log("Tauri sidecar embedded UI smoke passed");
+  await smokeSidecarUi(resolve(sourceBinary), process.argv[3]?.trim() || undefined);
+  console.log("Sidecar embedded UI smoke passed");
 }

--- a/shared/reasoning-capabilities.ts
+++ b/shared/reasoning-capabilities.ts
@@ -1,0 +1,214 @@
+export type ReasoningEffort = "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
+
+export type ReasoningMode = "adaptive" | "binary" | "effort";
+
+const VALID_REASONING_EFFORTS = new Set<ReasoningEffort>([
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+]);
+
+const BINARY_THINKING_PROVIDERS = new Set([
+  "z.ai",
+  "z.ai-coding",
+  "zai",
+  "z-ai",
+  "qwen-portal",
+  "alibaba",
+  "alibaba-coding-plan",
+  "qwen-token-plan",
+  "qwen-token-plan-cn",
+]);
+
+const ADAPTIVE_THINKING_PROVIDERS = new Set([
+  "minimax",
+  "minimax-cn",
+  "minimax-portal",
+  "minimax-portal-cn",
+]);
+
+const KIMI_CODE_PROVIDERS = new Set([
+  "kimi-code",
+  "kimi-code-oauth",
+  "kimi-coding",
+  "kimi-oauth",
+  "kimi-code-subscription",
+]);
+
+const ANTHROPIC_PROVIDERS = new Set([
+  "anthropic",
+  "anthropic-oauth",
+  "anthropic_vertex",
+  "claude-oauth",
+]);
+
+const GOOGLE_PROVIDERS = new Set([
+  "antigravity",
+  "gemini-cli",
+  "google",
+  "google-antigravity",
+  "google-gemini-cli",
+  "google_vertex",
+]);
+
+const GPT_5_EFFORTS: ReasoningEffort[] = ["minimal", "low", "medium", "high"];
+const GPT_51_EFFORTS: ReasoningEffort[] = ["low", "medium", "high"];
+const GPT_52_EFFORTS: ReasoningEffort[] = ["low", "medium", "high", "xhigh"];
+const GPT_56_EFFORTS: ReasoningEffort[] = ["low", "medium", "high", "xhigh", "max"];
+const GPT_CODEX_EFFORTS: ReasoningEffort[] = ["low", "medium", "high", "xhigh"];
+const GPT_CODEX_MINI_EFFORTS: ReasoningEffort[] = ["medium"];
+const GPT_CODEX_MAX_EFFORTS: ReasoningEffort[] = ["medium", "high", "xhigh"];
+const GPT_PRO_EFFORTS: ReasoningEffort[] = ["medium", "high", "xhigh"];
+const GPT_5_PRO_EFFORTS: ReasoningEffort[] = ["high"];
+const GENERIC_OPENAI_EFFORTS: ReasoningEffort[] = ["low", "medium", "high"];
+const ANTHROPIC_LEGACY_EFFORTS: ReasoningEffort[] = ["minimal", "low", "medium", "high"];
+const ANTHROPIC_46_EFFORTS: ReasoningEffort[] = ["low", "medium", "high", "max"];
+const ANTHROPIC_MODERN_EFFORTS: ReasoningEffort[] = ["low", "medium", "high", "xhigh", "max"];
+const GOOGLE_25_EFFORTS: ReasoningEffort[] = ["low", "medium", "high"];
+const GOOGLE_3_FLASH_EFFORTS: ReasoningEffort[] = ["minimal", "low", "medium", "high"];
+const GOOGLE_3_PRO_EFFORTS: ReasoningEffort[] = ["low", "high"];
+const KIMI_K3_EFFORTS: ReasoningEffort[] = ["low", "high", "max"];
+
+const EFFORT_RANK: Record<ReasoningEffort, number> = {
+  minimal: 0,
+  low: 1,
+  medium: 2,
+  high: 3,
+  xhigh: 4,
+  max: 5,
+};
+
+export function normalizeReasoningEffort(value: unknown): ReasoningEffort | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim().toLowerCase();
+  if (VALID_REASONING_EFFORTS.has(normalized as ReasoningEffort)) {
+    return normalized as ReasoningEffort;
+  }
+  const collapsed = normalized.replace(/[\s_-]+/g, "");
+  if (collapsed === "xhigh" || collapsed === "extrahigh") return "xhigh";
+  if (["max", "ultra", "ultrathink", "ultracode"].includes(collapsed)) return "max";
+  if (collapsed === "min") return "minimal";
+  return null;
+}
+
+export function normalizeReasoningModelId(id: string | null | undefined): string {
+  return (id ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/^(?:openai\/|anthropic\/|google\/)/, "")
+    .replace(/-\d{4}-\d{2}-\d{2}$/, "");
+}
+
+function resolveOpenAIModelEfforts(modelId: string): ReasoningEffort[] {
+  if (/^gpt-5\.6(?:-|$)/.test(modelId)) return GPT_56_EFFORTS;
+  if (modelId === "gpt-5.1-codex-mini") return GPT_CODEX_MINI_EFFORTS;
+  if (modelId === "gpt-5.1-codex-max") return GPT_CODEX_MAX_EFFORTS;
+  if (/^gpt-5(?:\.\d+)?-codex(?:-|$)/.test(modelId)) return GPT_CODEX_EFFORTS;
+  if (modelId === "gpt-5-pro") return GPT_5_PRO_EFFORTS;
+  if (/^gpt-5\.[2-9](?:\.\d+)?-pro(?:-|$)/.test(modelId)) return GPT_PRO_EFFORTS;
+  if (/^gpt-5\.[2-9](?:\.\d+)?(?:-|$)/.test(modelId)) return GPT_52_EFFORTS;
+  if (/^gpt-5\.1(?:-|$)/.test(modelId)) return GPT_51_EFFORTS;
+  if (/^gpt-5(?:-|$)/.test(modelId)) return GPT_5_EFFORTS;
+  return GENERIC_OPENAI_EFFORTS;
+}
+
+function resolveAnthropicModelEfforts(modelId: string): ReasoningEffort[] {
+  if (!modelId.includes("claude")) return [...ANTHROPIC_LEGACY_EFFORTS];
+  if (/claude-(?:opus|sonnet)-4[-.]6(?:-|$)/.test(modelId)) return [...ANTHROPIC_46_EFFORTS];
+  if (/claude-(?:3|opus-4[-.][0-5]|sonnet-4[-.][0-5]|haiku-4[-.]5)(?:-|$)/.test(modelId)) {
+    return [...ANTHROPIC_LEGACY_EFFORTS];
+  }
+  return [...ANTHROPIC_MODERN_EFFORTS];
+}
+
+function resolveGoogleModelEfforts(modelId: string): ReasoningEffort[] {
+  if (/^gemini-3(?:\.\d+)?-.*pro/.test(modelId)) return [...GOOGLE_3_PRO_EFFORTS];
+  if (/^gemini-3(?:\.\d+)?-.*flash/.test(modelId)) return [...GOOGLE_3_FLASH_EFFORTS];
+  return [...GOOGLE_25_EFFORTS];
+}
+
+function isKimiK3(provider: string, model: string | null | undefined): boolean {
+  return KIMI_CODE_PROVIDERS.has(provider) && /(?:^|\/)k3$/.test(normalizeReasoningModelId(model));
+}
+
+export function usesBinaryReasoning(providerId?: string | null): boolean {
+  return BINARY_THINKING_PROVIDERS.has((providerId ?? "").trim().toLowerCase());
+}
+
+export function usesProviderAdaptiveReasoning(
+  providerId?: string | null,
+  model?: string | null
+): boolean {
+  const provider = (providerId ?? "").trim().toLowerCase();
+  return (
+    ADAPTIVE_THINKING_PROVIDERS.has(provider) && /(?:^|\/)minimax-m3(?:[.-]|$)/i.test(model ?? "")
+  );
+}
+
+export function reasoningMode(providerId?: string | null, model?: string | null): ReasoningMode {
+  if (usesProviderAdaptiveReasoning(providerId, model)) return "adaptive";
+  return usesBinaryReasoning(providerId) ? "binary" : "effort";
+}
+
+export function supportedReasoningEfforts(
+  providerId?: string | null,
+  model?: string | null
+): ReasoningEffort[] {
+  const provider = (providerId ?? "").trim().toLowerCase();
+  if (usesBinaryReasoning(provider)) return ["medium"];
+  if (usesProviderAdaptiveReasoning(provider, model)) return [];
+  const modelId = normalizeReasoningModelId(model);
+  if (isKimiK3(provider, modelId)) {
+    return [...KIMI_K3_EFFORTS];
+  }
+  if (ANTHROPIC_PROVIDERS.has(provider)) {
+    return resolveAnthropicModelEfforts(modelId);
+  }
+  if (GOOGLE_PROVIDERS.has(provider)) {
+    return resolveGoogleModelEfforts(modelId);
+  }
+  if (
+    provider === "openai" ||
+    provider === "openai-codex" ||
+    provider === "openai-codex-responses" ||
+    provider === "azure-openai" ||
+    !modelId
+  ) {
+    return [...resolveOpenAIModelEfforts(modelId)];
+  }
+  return [...GENERIC_OPENAI_EFFORTS];
+}
+
+export function supportsXHighReasoning(providerId?: string | null, model?: string | null): boolean {
+  return supportedReasoningEfforts(providerId, model).includes("xhigh");
+}
+
+export function usesAnthropicAdaptiveThinking(model?: string | null): boolean {
+  const modelId = normalizeReasoningModelId(model);
+  if (!modelId.includes("claude")) return false;
+  return !/claude-(?:3|opus-4[-.][0-5]|sonnet-4[-.][0-5]|haiku-4[-.]5)(?:-|$)/.test(modelId);
+}
+
+export function coerceReasoningEffort(
+  effort: ReasoningEffort,
+  providerId?: string | null,
+  model?: string | null
+): ReasoningEffort {
+  const provider = (providerId ?? "").trim().toLowerCase();
+  if (isKimiK3(provider, model)) {
+    if (effort === "minimal" || effort === "low") return "low";
+    if (effort === "medium" || effort === "high") return "high";
+    return "max";
+  }
+  const supported = supportedReasoningEfforts(providerId, model);
+  if (supported.length === 0 || supported.includes(effort)) return effort;
+  const requestedRank = EFFORT_RANK[effort];
+  const lower = supported
+    .filter((candidate) => EFFORT_RANK[candidate] <= requestedRank)
+    .sort((left, right) => EFFORT_RANK[right] - EFFORT_RANK[left])[0];
+  if (lower) return lower;
+  return [...supported].sort((left, right) => EFFORT_RANK[left] - EFFORT_RANK[right])[0];
+}

--- a/site/downloadStats.ts
+++ b/site/downloadStats.ts
@@ -25,8 +25,12 @@ function assetDownloadCount(asset: GithubDownloadAsset): number {
   return Number.isFinite(asset.download_count) ? Math.max(0, asset.download_count ?? 0) : 0;
 }
 
+function normalizedAssetName(asset: GithubDownloadAsset): string {
+  return asset.name?.trim().toLowerCase() ?? "";
+}
+
 export function isDownloadMetadataAsset(asset: GithubDownloadAsset): boolean {
-  const name = asset.name?.trim().toLowerCase();
+  const name = normalizedAssetName(asset);
   return (
     !!name &&
     (EXCLUDED_DOWNLOAD_ASSETS.has(name) ||
@@ -36,7 +40,7 @@ export function isDownloadMetadataAsset(asset: GithubDownloadAsset): boolean {
 }
 
 export function isCountedDownloadAsset(asset: GithubDownloadAsset): boolean {
-  const name = asset.name?.trim().toLowerCase();
+  const name = normalizedAssetName(asset);
   return (
     !!name &&
     !isDownloadMetadataAsset(asset) &&
@@ -44,25 +48,47 @@ export function isCountedDownloadAsset(asset: GithubDownloadAsset): boolean {
   );
 }
 
-export function releaseAutomationBaseline(release: GithubDownloadRelease): number {
-  return (release.assets ?? []).reduce((baseline, asset) => {
-    const name = asset.name?.trim().toLowerCase();
-    if (!name || name === "latest.json" || !isDownloadMetadataAsset(asset)) return baseline;
-    return Math.max(baseline, assetDownloadCount(asset));
+function companionMetadataNames(name: string): Set<string> {
+  const names = new Set([`${name}.sig`, `${name}.sha256`, `${name}.sha512`, `${name}.md5`]);
+  if (name.endsWith(".zip")) names.add(name.replace(/\.zip$/i, ".sha256"));
+  if (/_aarch64\.dmg$/i.test(name)) names.add("cybara_aarch64.app.tar.gz.sig");
+  if (/_x64\.dmg$/i.test(name)) names.add("cybara_x64.app.tar.gz.sig");
+  return names;
+}
+
+function releaseChecksumManifestCount(assets: GithubDownloadAsset[]): number {
+  return assets.reduce((count, asset) => {
+    const name = normalizedAssetName(asset);
+    return CHECKSUM_MANIFEST_PATTERN.test(name) ? Math.max(count, assetDownloadCount(asset)) : count;
   }, 0);
+}
+
+function installerAutomationBaseline(
+  asset: GithubDownloadAsset,
+  assets: GithubDownloadAsset[]
+): number {
+  const companionNames = companionMetadataNames(normalizedAssetName(asset));
+  let companionCount = 0;
+  let hasCompanion = false;
+  for (const candidate of assets) {
+    if (!companionNames.has(normalizedAssetName(candidate))) continue;
+    hasCompanion = true;
+    companionCount = Math.max(companionCount, assetDownloadCount(candidate));
+  }
+  return hasCompanion ? companionCount : releaseChecksumManifestCount(assets);
 }
 
 export function sumReleaseDownloads(releases: GithubDownloadRelease[]): number {
   return releases.reduce(
     (releaseTotal, release) => {
-      const baseline = releaseAutomationBaseline(release);
+      const assets = release.assets ?? [];
       return (
         releaseTotal +
-        (release.assets ?? []).reduce(
+        assets.reduce(
           (assetTotal, asset) =>
             assetTotal +
             (isCountedDownloadAsset(asset)
-              ? Math.max(0, assetDownloadCount(asset) - baseline)
+              ? Math.max(0, assetDownloadCount(asset) - installerAutomationBaseline(asset, assets))
               : 0),
           0
         )

--- a/site/serve.ts
+++ b/site/serve.ts
@@ -120,7 +120,7 @@ async function respond(request: Request): Promise<Response> {
               "*native-macos*.zip",
               "*.apk",
             ],
-            estimation: "installer-assets-minus-release-automation-baseline",
+            estimation: "installer-assets-minus-companion-metadata-downloads",
             updatedAt: new Date(downloadCache.at).toISOString(),
           };
     return Response.json(body, {

--- a/site/src/hooks/useLatestRelease.ts
+++ b/site/src/hooks/useLatestRelease.ts
@@ -134,7 +134,7 @@ export function shortSha(sha256?: string): string {
 
 const DOWNLOAD_TOTAL_API = "/api/downloads";
 const ALL_RELEASES_API = "https://api.github.com/repos/metaspartan/cybara/releases?per_page=100";
-const DOWNLOAD_TOTAL_CACHE_KEY = "cybara.site.downloadTotal.v5";
+const DOWNLOAD_TOTAL_CACHE_KEY = "cybara.site.downloadTotal.v6";
 const DOWNLOAD_TOTAL_CACHE_TTL_MS = 30 * 60 * 1000;
 
 interface DownloadTotalResponse {

--- a/src/api/agent-routes.ts
+++ b/src/api/agent-routes.ts
@@ -8,12 +8,26 @@ import {
   readAgentReasoningSetting,
   withAgentReasoningSetting,
 } from "../core/agent-reasoning";
+import {
+  coerceReasoningEffort,
+  reasoningMode,
+  supportedReasoningEfforts,
+} from "../../shared/reasoning-capabilities";
 import { type RouteHandler } from "./routes/_shared";
 
 function agentId(params: Record<string, string> | undefined): string {
   const value = params?.id?.trim();
   if (!value) throw new Error("Validation error: Agent id is required");
   return value;
+}
+
+function effectiveReasoningEffort(
+  effort: ReturnType<typeof readAgentReasoningSetting>,
+  provider: string | undefined,
+  model: string | undefined
+): ReturnType<typeof readAgentReasoningSetting> {
+  if (!effort || reasoningMode(provider, model) === "adaptive") return null;
+  return coerceReasoningEffort(effort, provider, model);
 }
 
 export const agentRoutes: Record<string, RouteHandler> = {
@@ -23,6 +37,8 @@ export const agentRoutes: Record<string, RouteHandler> = {
     const imageSupport = agentImageSupportById(agents);
     return agents.map((agent) => {
       const toolProfile = parseAgentConfig(agent.config).tool_profile;
+      const provider = agent.provider_type;
+      const mode = reasoningMode(provider, agent.model);
       return {
         id: agent.id,
         name: agent.name,
@@ -36,7 +52,13 @@ export const agentRoutes: Record<string, RouteHandler> = {
         fallback_provider_id: agent.fallback_provider_id,
         status: agent.status,
         created_at: agent.created_at,
-        reasoning_effort: readAgentReasoningSetting(agent.config),
+        reasoning_effort: effectiveReasoningEffort(
+          readAgentReasoningSetting(agent.config),
+          provider,
+          agent.model
+        ),
+        reasoning_mode: mode,
+        reasoning_efforts: supportedReasoningEfforts(provider, agent.model),
         tool_profile: typeof toolProfile === "string" ? toolProfile : "full",
         supports_images: imageSupport.get(agent.id) ?? false,
       };
@@ -69,13 +91,24 @@ export const agentRoutes: Record<string, RouteHandler> = {
       (body as { reasoning_effort?: unknown } | undefined)?.reasoning_effort
     );
     if (!parsed.valid) return { success: false, error: "Invalid reasoning effort" };
+    const mode = reasoningMode(agent.provider_type, agent.model);
+    const effort =
+      parsed.effort && mode !== "adaptive"
+        ? coerceReasoningEffort(parsed.effort, agent.provider_type, agent.model)
+        : null;
     const updated = agentManager.update(id, {
-      config: withAgentReasoningSetting(agent.config, parsed.effort),
+      config: withAgentReasoningSetting(agent.config, effort),
     });
     if (!updated) return { success: false, error: "Agent not found" };
     return {
       success: true,
-      reasoning_effort: readAgentReasoningSetting(updated.config),
+      reasoning_effort: effectiveReasoningEffort(
+        readAgentReasoningSetting(updated.config),
+        agent.provider_type,
+        agent.model
+      ),
+      reasoning_mode: mode,
+      reasoning_efforts: supportedReasoningEfforts(agent.provider_type, agent.model),
     };
   },
   "POST /api/agents/:id/start": async (_body, params) => ({

--- a/src/cli/tui/components/interactive-chat.tsx
+++ b/src/cli/tui/components/interactive-chat.tsx
@@ -827,7 +827,13 @@ export function InteractiveChatTUI({
           return true;
         }
         await loadControlPlane();
-        setNotice(`Reasoning effort set to ${value}.`);
+        const savedEffort =
+          isRecord(response) && typeof response.reasoning_effort === "string"
+            ? response.reasoning_effort
+            : isRecord(response) && response.reasoning_effort === null
+              ? "default"
+              : value;
+        setNotice(`Reasoning effort set to ${savedEffort}.`);
         return true;
       }
       if (normalizedCommand === "title" || normalizedCommand === "rename") {

--- a/src/cli/tui/interactive-chat-data.ts
+++ b/src/cli/tui/interactive-chat-data.ts
@@ -15,6 +15,8 @@ export interface AgentSummary {
   providerId?: string;
   status?: string;
   reasoning_effort?: string | null;
+  reasoning_mode?: "adaptive" | "binary" | "effort";
+  reasoning_efforts?: string[];
   tool_profile?: string;
   config?: unknown;
 }

--- a/src/core/llm/reasoning.ts
+++ b/src/core/llm/reasoning.ts
@@ -1,196 +1,24 @@
-export type ReasoningEffort = "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
+import {
+  coerceReasoningEffort,
+  normalizeReasoningEffort,
+  normalizeReasoningModelId,
+  supportedReasoningEfforts,
+  supportsXHighReasoning,
+  usesAnthropicAdaptiveThinking,
+  usesProviderAdaptiveReasoning,
+  type ReasoningEffort,
+} from "../../../shared/reasoning-capabilities";
 
-const VALID = new Set<ReasoningEffort>(["minimal", "low", "medium", "high", "xhigh", "max"]);
-
-export function normalizeReasoningEffort(value: unknown): ReasoningEffort | null {
-  if (typeof value !== "string") return null;
-  const v = value.trim().toLowerCase();
-  if (VALID.has(v as ReasoningEffort)) return v as ReasoningEffort;
-  const collapsed = v.replace(/[\s_-]+/g, "");
-  if (collapsed === "xhigh" || collapsed === "extrahigh") {
-    return "xhigh";
-  }
-  if (
-    collapsed === "max" ||
-    collapsed === "ultra" ||
-    collapsed === "ultrathink" ||
-    collapsed === "ultracode"
-  ) {
-    return "max";
-  }
-  if (collapsed === "min") return "minimal";
-  if (v === "none" || v === "off" || v === "false") return null;
-  return null;
-}
-
-const BINARY_THINKING_PROVIDERS = new Set([
-  "z.ai",
-  "z.ai-coding",
-  "zai",
-  "z-ai",
-  "qwen-portal",
-  "alibaba",
-  "alibaba-coding-plan",
-  "qwen-token-plan",
-  "qwen-token-plan-cn",
-]);
-const ADAPTIVE_THINKING_PROVIDERS = new Set([
-  "minimax",
-  "minimax-cn",
-  "minimax-portal",
-  "minimax-portal-cn",
-]);
-const KIMI_CODE_PROVIDERS = new Set([
-  "kimi-code",
-  "kimi-code-oauth",
-  "kimi-coding",
-  "kimi-oauth",
-  "kimi-code-subscription",
-]);
-
-const GPT_5_EFFORTS: ReasoningEffort[] = ["minimal", "low", "medium", "high"];
-const GPT_51_EFFORTS: ReasoningEffort[] = ["low", "medium", "high"];
-const GPT_52_EFFORTS: ReasoningEffort[] = ["low", "medium", "high", "xhigh"];
-const GPT_56_EFFORTS: ReasoningEffort[] = ["low", "medium", "high", "xhigh", "max"];
-const GPT_CODEX_EFFORTS: ReasoningEffort[] = ["low", "medium", "high", "xhigh"];
-const GPT_CODEX_MINI_EFFORTS: ReasoningEffort[] = ["medium"];
-const GPT_CODEX_MAX_EFFORTS: ReasoningEffort[] = ["medium", "high", "xhigh"];
-const GPT_PRO_EFFORTS: ReasoningEffort[] = ["medium", "high", "xhigh"];
-const GPT_5_PRO_EFFORTS: ReasoningEffort[] = ["high"];
-const GENERIC_OPENAI_EFFORTS: ReasoningEffort[] = ["low", "medium", "high"];
-
-function normalizeModelId(id: string | null | undefined): string {
-  return (id ?? "")
-    .trim()
-    .toLowerCase()
-    .replace(/^(?:openai\/|anthropic\/|google\/)?/, "")
-    .replace(/-\d{4}-\d{2}-\d{2}$/, "");
-}
-
-function resolveOpenAIModelEfforts(modelId: string): ReasoningEffort[] {
-  if (/^gpt-5\.6(?:-|$)/.test(modelId)) return GPT_56_EFFORTS;
-  if (modelId === "gpt-5.1-codex-mini") return GPT_CODEX_MINI_EFFORTS;
-  if (modelId === "gpt-5.1-codex-max") return GPT_CODEX_MAX_EFFORTS;
-  if (/^gpt-5(?:\.\d+)?-codex(?:-|$)/.test(modelId)) return GPT_CODEX_EFFORTS;
-  if (modelId === "gpt-5-pro") return GPT_5_PRO_EFFORTS;
-  if (/^gpt-5\.[2-9](?:\.\d+)?-pro(?:-|$)/.test(modelId)) return GPT_PRO_EFFORTS;
-  if (/^gpt-5\.[2-9](?:\.\d+)?(?:-|$)/.test(modelId)) return GPT_52_EFFORTS;
-  if (/^gpt-5\.1(?:-|$)/.test(modelId)) return GPT_51_EFFORTS;
-  if (/^gpt-5(?:-|$)/.test(modelId)) return GPT_5_EFFORTS;
-  return GENERIC_OPENAI_EFFORTS;
-}
-
-const ANTHROPIC_LEGACY_EFFORTS: ReasoningEffort[] = ["minimal", "low", "medium", "high"];
-const ANTHROPIC_46_EFFORTS: ReasoningEffort[] = ["low", "medium", "high", "max"];
-const ANTHROPIC_MODERN_EFFORTS: ReasoningEffort[] = ["low", "medium", "high", "xhigh", "max"];
-const GOOGLE_25_EFFORTS: ReasoningEffort[] = ["low", "medium", "high"];
-const GOOGLE_3_FLASH_EFFORTS: ReasoningEffort[] = ["low", "medium", "high"];
-const GOOGLE_3_PRO_EFFORTS: ReasoningEffort[] = ["low", "high"];
-
-const EFFORT_RANK: Record<ReasoningEffort, number> = {
-  minimal: 0,
-  low: 1,
-  medium: 2,
-  high: 3,
-  xhigh: 4,
-  max: 5,
+export {
+  coerceReasoningEffort,
+  normalizeReasoningEffort,
+  normalizeReasoningModelId,
+  supportedReasoningEfforts,
+  supportsXHighReasoning,
+  usesAnthropicAdaptiveThinking,
+  usesProviderAdaptiveReasoning,
+  type ReasoningEffort,
 };
-
-function resolveAnthropicModelEfforts(modelId: string): ReasoningEffort[] {
-  if (!modelId.includes("claude")) return [...ANTHROPIC_LEGACY_EFFORTS];
-  if (/claude-(?:opus|sonnet)-4[-.]6(?:-|$)/.test(modelId)) return [...ANTHROPIC_46_EFFORTS];
-  if (/claude-(?:3|opus-4[-.][0-5]|sonnet-4[-.][0-5]|haiku-4[-.]5)(?:-|$)/.test(modelId)) {
-    return [...ANTHROPIC_LEGACY_EFFORTS];
-  }
-  return [...ANTHROPIC_MODERN_EFFORTS];
-}
-
-function resolveGoogleModelEfforts(modelId: string): ReasoningEffort[] {
-  if (/^gemini-3(?:\.1)?-.*pro/.test(modelId)) return [...GOOGLE_3_PRO_EFFORTS];
-  if (/^gemini-3(?:\.1)?-.*flash/.test(modelId)) return [...GOOGLE_3_FLASH_EFFORTS];
-  return [...GOOGLE_25_EFFORTS];
-}
-
-export function usesProviderAdaptiveReasoning(
-  providerId?: string | null,
-  model?: string | null
-): boolean {
-  const provider = (providerId || "").trim().toLowerCase();
-  return (
-    ADAPTIVE_THINKING_PROVIDERS.has(provider) && /(?:^|\/)minimax-m3(?:[.-]|$)/i.test(model ?? "")
-  );
-}
-
-export function supportedReasoningEfforts(
-  providerId?: string | null,
-  model?: string | null
-): ReasoningEffort[] {
-  const provider = (providerId || "").trim().toLowerCase();
-  if (BINARY_THINKING_PROVIDERS.has(provider)) {
-    return ["medium"];
-  }
-  if (usesProviderAdaptiveReasoning(provider, model)) {
-    return [];
-  }
-  const modelId = normalizeModelId(model);
-  if (KIMI_CODE_PROVIDERS.has(provider) && modelId === "k3") {
-    return ["max"];
-  }
-  if (provider === "anthropic" || provider === "anthropic_vertex") {
-    return resolveAnthropicModelEfforts(modelId);
-  }
-  if (provider === "google" || provider === "google_vertex") {
-    return resolveGoogleModelEfforts(modelId);
-  }
-  if (
-    provider === "openai" ||
-    provider === "openai-codex" ||
-    provider === "openai-codex-responses" ||
-    provider === "azure-openai" ||
-    !modelId
-  ) {
-    return resolveOpenAIModelEfforts(modelId);
-  }
-  return [...GENERIC_OPENAI_EFFORTS];
-}
-
-export function supportsXHighReasoning(providerId?: string | null, model?: string | null): boolean {
-  return supportedReasoningEfforts(providerId, model).includes("xhigh");
-}
-
-export function usesAnthropicAdaptiveThinking(model?: string | null): boolean {
-  const modelId = normalizeModelId(model);
-  if (!modelId.includes("claude")) return false;
-  return !/claude-(?:3|opus-4[-.][0-5]|sonnet-4[-.][0-5]|haiku-4[-.]5)(?:-|$)/.test(modelId);
-}
-
-export function coerceReasoningEffort(
-  effort: ReasoningEffort,
-  providerId?: string | null,
-  model?: string | null
-): ReasoningEffort {
-  const supported = supportedReasoningEfforts(providerId, model);
-  if (supported.length === 0) return effort;
-  if (supported.includes(effort)) return effort;
-  const requestedRank = EFFORT_RANK[effort];
-  let downgraded: ReasoningEffort | null = null;
-  let downgradedRank = -1;
-  let upgraded: ReasoningEffort | null = null;
-  let upgradedRank = Number.MAX_SAFE_INTEGER;
-  for (const candidate of supported) {
-    const candidateRank = EFFORT_RANK[candidate];
-    if (candidateRank <= requestedRank && candidateRank > downgradedRank) {
-      downgraded = candidate;
-      downgradedRank = candidateRank;
-    }
-    if (candidateRank >= requestedRank && candidateRank < upgradedRank) {
-      upgraded = candidate;
-      upgradedRank = candidateRank;
-    }
-  }
-  if (downgraded) return downgraded;
-  return upgraded ?? supported[0];
-}
 
 type ThinkingFormat = "openai" | "zai" | "qwen" | "deepseek" | "openrouter" | "together";
 
@@ -255,9 +83,9 @@ export function googleThinkingConfig(
   effort: ReasoningEffort,
   model?: string | null
 ): Record<string, unknown> {
-  const modelId = normalizeModelId(model);
+  const modelId = normalizeReasoningModelId(model);
   const resolved = coerceReasoningEffort(effort, "google", modelId);
-  if (/^gemini-3(?:\.1)?-/.test(modelId)) {
+  if (/^gemini-3(?:\.\d+)?-/.test(modelId)) {
     return { includeThoughts: true, thinkingLevel: resolved };
   }
   return { includeThoughts: true };

--- a/src/core/runtime/ui-path.ts
+++ b/src/core/runtime/ui-path.ts
@@ -25,8 +25,11 @@ export function resolveUiPath(options: ResolveUiPathOptions): string {
     const releaseUi = join(execDir, "ui", "dist");
     if (existsSyncFn(releaseUi)) return releaseUi;
 
-    const tauriMacUi = join(execDir, "..", "Resources", "_up_", "ui", "dist");
+    const tauriMacUi = join(execDir, "..", "Resources", "ui", "dist");
     if (existsSyncFn(tauriMacUi)) return tauriMacUi;
+
+    const legacyTauriMacUi = join(execDir, "..", "Resources", "_up_", "ui", "dist");
+    if (existsSyncFn(legacyTauriMacUi)) return legacyTauriMacUi;
 
     const tauriLinuxLib = join(execDir, "..", "lib", appName, "ui", "dist");
     if (existsSyncFn(tauriLinuxLib)) return tauriLinuxLib;

--- a/tests/api/routes.test.ts
+++ b/tests/api/routes.test.ts
@@ -463,6 +463,8 @@ describe("Agents API", () => {
       expect(first.config).toBeUndefined();
       expect(first.tools).toBeUndefined();
       expect(typeof first.tool_profile).toBe("string");
+      expect(["adaptive", "binary", "effort"]).toContain(first.reasoning_mode);
+      expect(Array.isArray(first.reasoning_efforts)).toBe(true);
     }
   });
 
@@ -565,7 +567,12 @@ describe("Agents API", () => {
     const update = await fixture.api("PUT", `/api/agents/${agentId}/reasoning`, {
       reasoning_effort: "high",
     });
-    expect(update.data).toEqual({ success: true, reasoning_effort: "high" });
+    expect(update.data).toEqual({
+      success: true,
+      reasoning_effort: "high",
+      reasoning_mode: "effort",
+      reasoning_efforts: ["low", "medium", "high"],
+    });
 
     const fetched = await fixture.api("GET", `/api/agents/${agentId}`);
     const fetchedConfig =
@@ -587,7 +594,12 @@ describe("Agents API", () => {
     const reset = await fixture.api("PUT", `/api/agents/${agentId}/reasoning`, {
       reasoning_effort: null,
     });
-    expect(reset.data).toEqual({ success: true, reasoning_effort: null });
+    expect(reset.data).toEqual({
+      success: true,
+      reasoning_effort: null,
+      reasoning_mode: "effort",
+      reasoning_efforts: ["low", "medium", "high"],
+    });
 
     const invalid = await fixture.api("PUT", `/api/agents/${agentId}/reasoning`, {
       reasoning_effort: "extreme",
@@ -598,6 +610,41 @@ describe("Agents API", () => {
     });
 
     await fixture.api("DELETE", `/api/agents/${agentId}`);
+  });
+
+  test("PUT /api/agents/:id/reasoning stores the provider-supported effective effort", async () => {
+    const provider = await fixture.api("POST", "/api/providers", {
+      provider: "kimi-code",
+      name: `reasoning-kimi-${Date.now()}`,
+      api_key: `kimi-test-${Date.now()}`,
+    });
+    expect(provider.status).toBe(200);
+    const created = await fixture.api("POST", "/api/agents", {
+      name: `reasoning-kimi-agent-${Date.now()}`,
+      type: "main",
+      model: "kimi-code/k3",
+      provider_id: provider.data.id,
+    });
+
+    const update = await fixture.api("PUT", `/api/agents/${created.data.id}/reasoning`, {
+      reasoning_effort: "medium",
+    });
+    expect(update.data).toEqual({
+      success: true,
+      reasoning_effort: "high",
+      reasoning_mode: "effort",
+      reasoning_efforts: ["low", "high", "max"],
+    });
+
+    const summary = await fixture.api("GET", "/api/agents/summary");
+    const agent = (summary.data as Array<Record<string, unknown>>).find(
+      (entry) => entry.id === created.data.id
+    );
+    expect(agent?.reasoning_effort).toBe("high");
+    expect(agent?.reasoning_efforts).toEqual(["low", "high", "max"]);
+
+    await fixture.api("DELETE", `/api/agents/${created.data.id}`);
+    await fixture.api("DELETE", `/api/providers/${provider.data.id}`);
   });
 
   test("POST /api/agents/:id/start tolerates malformed persisted config JSON", async () => {

--- a/tests/core/reasoning-levels.test.ts
+++ b/tests/core/reasoning-levels.test.ts
@@ -112,11 +112,55 @@ describe("reasoning level support matrix", () => {
     expect(supportedReasoningEfforts("minimax-portal", "minimax-m3")).toEqual([]);
   });
 
-  test("Kimi K3 uses the current max-only reasoning contract", () => {
-    expect(supportedReasoningEfforts("kimi-code", "k3")).toEqual(["max"]);
-    expect(supportedReasoningEfforts("kimi-code-oauth", "k3")).toEqual(["max"]);
-    expect(supportedReasoningEfforts("kimi-code-subscription", "k3")).toEqual(["max"]);
-    expect(coerceReasoningEffort("high", "kimi-code-oauth", "k3")).toBe("max");
+  test("Kimi K3 uses its current low, high, and max reasoning contract", () => {
+    expect(supportedReasoningEfforts("kimi-code", "k3")).toEqual(["low", "high", "max"]);
+    expect(supportedReasoningEfforts("kimi-code-oauth", "kimi-code/k3")).toEqual([
+      "low",
+      "high",
+      "max",
+    ]);
+    expect(supportedReasoningEfforts("kimi-code-subscription", "k3")).toEqual([
+      "low",
+      "high",
+      "max",
+    ]);
+    expect(coerceReasoningEffort("medium", "kimi-code-oauth", "k3")).toBe("high");
+    expect(coerceReasoningEffort("xhigh", "kimi-code-oauth", "k3")).toBe("max");
+  });
+
+  test("Gemini 3 Flash exposes the current four-level thinking ladder", () => {
+    expect(supportedReasoningEfforts("google", "gemini-3.5-flash")).toEqual([
+      "minimal",
+      "low",
+      "medium",
+      "high",
+    ]);
+    expect(supportedReasoningEfforts("google-gemini-cli", "gemini-3.5-flash")).toEqual([
+      "minimal",
+      "low",
+      "medium",
+      "high",
+    ]);
+    expect(supportedReasoningEfforts("antigravity", "gemini-3.1-pro-preview")).toEqual([
+      "low",
+      "high",
+    ]);
+  });
+
+  test("keeps OAuth provider capabilities aligned with API-key providers", () => {
+    expect(supportedReasoningEfforts("anthropic-oauth", "claude-opus-4-8")).toEqual([
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+      "max",
+    ]);
+    expect(supportedReasoningEfforts("claude-oauth", "claude-sonnet-4-6")).toEqual([
+      "low",
+      "medium",
+      "high",
+      "max",
+    ]);
   });
 
   test("unknown openai model gets low/medium/high", () => {

--- a/tests/core/reasoning.test.ts
+++ b/tests/core/reasoning.test.ts
@@ -98,6 +98,10 @@ describe("thinking budgets", () => {
       includeThoughts: true,
       thinkingLevel: "low",
     });
+    expect(googleThinkingConfig("minimal", "gemini-3.5-flash")).toEqual({
+      includeThoughts: true,
+      thinkingLevel: "minimal",
+    });
     expect(googleThinkingConfig("high", "gemini-2.5-pro")).toEqual({ includeThoughts: true });
   });
 

--- a/tests/mobile/api-normalizers.test.ts
+++ b/tests/mobile/api-normalizers.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import { normalizeAgent } from "../../apps/mobile/src/lib/api-normalizers";
+
+describe("mobile API normalizers", () => {
+  test("preserves gateway reasoning capabilities for agent controls", () => {
+    const agent = normalizeAgent({
+      id: "agent-1",
+      name: "Research",
+      reasoning_mode: "effort",
+      reasoning_efforts: ["low", "high", "max"],
+    });
+
+    expect(agent.reasoning_mode).toBe("effort");
+    expect(agent.reasoning_efforts).toEqual(["low", "high", "max"]);
+  });
+
+  test("filters malformed gateway reasoning capabilities", () => {
+    const agent = normalizeAgent({
+      id: "agent-2",
+      reasoning_mode: "unsupported",
+      reasoning_efforts: ["low", "unsupported", null, "xhigh"],
+    });
+
+    expect(agent.reasoning_mode).toBeUndefined();
+    expect(agent.reasoning_efforts).toEqual(["low", "xhigh"]);
+  });
+});

--- a/tests/mobile/dashboard.test.ts
+++ b/tests/mobile/dashboard.test.ts
@@ -3,11 +3,21 @@ import { readFileSync } from "node:fs";
 import type { FeatureSummary } from "../../apps/mobile/src/lib/api";
 import type { GatewayProfile } from "../../apps/mobile/src/lib/connection";
 import {
-  MOBILE_FEATURE_SECTIONS,
+  boundedMobileComposerHeight,
+  buildGatewayPanelMeta,
+  buildMobileChatSettingsLines,
+  buildMobileHeaderCopy,
+  compactLastUpdatedLabel,
+  createMobileSessionId,
+  formatMobileValue,
+  formatUptime,
+  isMobileSettingsDetailFieldVisible,
+  lastUpdatedLabel,
   MOBILE_ACCENT_KEYS,
+  MOBILE_CHAT_CHROME,
   MOBILE_CHAT_COMPOSER,
   MOBILE_CHAT_DETAIL_CHROME,
-  MOBILE_CHAT_CHROME,
+  MOBILE_FEATURE_SECTIONS,
   MOBILE_GATEWAY_PANEL_CHROME,
   MOBILE_HOME_CHROME,
   MOBILE_LOGS_CHROME,
@@ -15,46 +25,36 @@ import {
   MOBILE_METRICS_CHROME,
   MOBILE_NAV_CHROME,
   MOBILE_NEW_CHAT_CHROME,
-  MOBILE_RECENT_ACTIVITY_CHROME,
+  MOBILE_PLATFORM_SETTING_KEYS,
   MOBILE_REASONING_EFFORT_OPTIONS,
+  MOBILE_RECENT_ACTIVITY_CHROME,
   MOBILE_ROUTER_STRATEGY_OPTIONS,
   MOBILE_SETTINGS_DETAIL_CHROME,
   MOBILE_SETTINGS_ROOT_CHROME,
   MOBILE_SETTINGS_SURFACES,
   MOBILE_SETTINGS_TABS,
-  MOBILE_PLATFORM_SETTING_KEYS,
-  MOBILE_SYSTEM_PROMPT_FEATURE_KEYS,
   MOBILE_SURFACES,
+  MOBILE_SYSTEM_PROMPT_FEATURE_KEYS,
   MOBILE_TABS,
-  boundedMobileComposerHeight,
-  buildGatewayPanelMeta,
-  buildMobileChatSettingsLines,
-  buildMobileHeaderCopy,
-  compactLastUpdatedLabel,
-  createMobileSessionId,
-  sessionProviderModelLabel,
-  formatMobileValue,
-  formatUptime,
-  isMobileSettingsDetailFieldVisible,
-  lastUpdatedLabel,
-  mobileComposerHeightForDraft,
   mobileBackRouteForDetail,
+  mobileComposerHeightForDraft,
   mobileFirstNonEmptyString,
   mobileGatewayAuthStatus,
   mobileProviderAuthMode,
+  mobileReasoningLabel,
   mobileSessionTitle,
+  mobileSupportedReasoningEfforts,
+  mobileSupportsXHighReasoning,
   mobileThemeConfigPayload,
-  recentSessionStateLabel,
+  readMobileAccent,
   readMobileDangerousToolPolicy,
   readMobileFollowUpBehaviorEnabled,
   readMobileReasoningEffort,
   readMobileRouterStrategy,
   readMobileSandboxRuntime,
-  readMobileAccent,
   readMobileToolApprovalMode,
-  mobileSupportsXHighReasoning,
-  mobileSupportedReasoningEfforts,
-  mobileReasoningLabel,
+  recentSessionStateLabel,
+  sessionProviderModelLabel,
   summarizeFeatureCounts,
 } from "../../apps/mobile/src/lib/dashboard";
 import { readMobileTokenOptimizationSettings } from "../../apps/mobile/src/screens/dashboardHelpers";
@@ -968,6 +968,29 @@ describe("mobile provider-aware reasoning gating", () => {
     expect(mobileReasoningLabel("high", "google", "gemini-2.5-pro")).toBe("High");
     expect(mobileReasoningLabel("xhigh", "openai", "gpt-5.2")).toBe("Extra High");
     expect(mobileReasoningLabel("medium", "z.ai", "glm-5.2")).toBe("Thinking");
+  });
+
+  test("gateway reasoning capabilities override provider inference", () => {
+    expect(mobileSupportedReasoningEfforts("custom", "custom", "adaptive", [])).toEqual([
+      { label: "Adaptive", value: "" },
+    ]);
+    expect(
+      mobileSupportedReasoningEfforts("z.ai", "glm-5.2", "effort", ["low", "high", "max"])
+    ).toEqual([
+      { label: "Default", value: "" },
+      { label: "Low", value: "low" },
+      { label: "High", value: "high" },
+      { label: "Max", value: "max" },
+    ]);
+    expect(mobileReasoningLabel(null, "custom", "custom", "adaptive", [])).toBe("Adaptive");
+  });
+
+  test("empty gateway effort lists retain provider fallback", () => {
+    expect(
+      mobileSupportedReasoningEfforts("openai", "gpt-5.3-codex", "effort", []).map(
+        (option) => option.value
+      )
+    ).toEqual(["", "low", "medium", "high", "xhigh"]);
   });
 });
 

--- a/tests/mobile/dashboard.test.ts
+++ b/tests/mobile/dashboard.test.ts
@@ -902,9 +902,24 @@ describe("mobile provider-aware reasoning gating", () => {
     expect(mobileReasoningLabel(null, "minimax-portal", "MiniMax-M3")).toBe("Adaptive");
   });
 
+  test("Kimi K3 uses the shared low, high, and max matrix", () => {
+    expect(mobileSupportedReasoningEfforts("kimi-code-oauth", "kimi-code/k3")).toEqual([
+      { label: "Default", value: "" },
+      { label: "Low", value: "low" },
+      { label: "High", value: "high" },
+      { label: "Max", value: "max" },
+    ]);
+  });
+
   test("google yields documented model effort levels plus default", () => {
     const options = mobileSupportedReasoningEfforts("google", "gemini-2.5-pro");
     expect(options.map((o) => o.value)).toEqual(["", "low", "medium", "high"]);
+  });
+
+  test("Gemini 3 Flash includes Minimal through High", () => {
+    expect(
+      mobileSupportedReasoningEfforts("google", "gemini-3.5-flash").map((o) => o.value)
+    ).toEqual(["", "minimal", "low", "medium", "high"]);
   });
 
   test("codex models exclude Minimal and add Max", () => {

--- a/tests/mobile/sessions.test.ts
+++ b/tests/mobile/sessions.test.ts
@@ -189,10 +189,14 @@ describe("mobile: chat management", () => {
     expect(newChat).toContain(".routerConfig()");
     expect(newChat).toContain("useModelRouter");
     expect(newChat).toContain("mobileSupportedReasoningEfforts(");
+    expect(newChat).toContain("selectedAgent?.reasoning_mode");
+    expect(newChat).toContain("selectedAgent?.reasoning_efforts");
     expect(newChat).toContain("api.updateAgentReasoning(selectedAgent.id, effort)");
     expect(newChat).toContain("Reasoning effort:");
     expect(newChat).toContain("ActionSheetIOS.showActionSheetWithOptions(");
     expect(screen).toContain("const changeSessionAgent");
+    expect(screen).toContain("selectedAgent?.reasoning_mode");
+    expect(screen).toContain("selectedAgent?.reasoning_efforts");
     expect(screen).toContain("const openAgentSelector");
     expect(screen).toContain("MOBILE_MODEL_ROUTER_SELECTOR_VALUE");
     expect(screen).toContain("setUseModelRouter(true)");

--- a/tests/runtime/package-scripts.test.ts
+++ b/tests/runtime/package-scripts.test.ts
@@ -9,6 +9,7 @@ const CI_INSTALL_SCRIPT = join(ROOT_DIR, "scripts", "ci-install.sh");
 const PACKAGE_SCRIPT = join(ROOT_DIR, "scripts", "package.ts");
 const REACT_DOCTOR_SCRIPT = join(ROOT_DIR, "scripts", "react-doctor.ts");
 const SMOKE_TEST_SCRIPT = join(ROOT_DIR, "scripts", "run-smoke-tests.ts");
+const TAURI_SIDECAR_SMOKE_SCRIPT = join(ROOT_DIR, "scripts", "smoke-tauri-sidecar-ui.ts");
 const KNIP_CONFIG = join(ROOT_DIR, "knip.json");
 
 describe("package.json script wiring", () => {
@@ -105,7 +106,14 @@ describe("package.json script wiring", () => {
     expect((pkg as Record<string, unknown>)["build"]).toBeUndefined();
     expect((pkg as Record<string, unknown>)["build:cli"]).toBeUndefined();
     expect((pkg as Record<string, unknown>)["build:main"]).toBeUndefined();
-    expect(readFileSync(SIDECAR_SCRIPT, "utf8")).toContain("--external @aws-sdk/client-s3");
+    const sidecarScript = readFileSync(SIDECAR_SCRIPT, "utf8");
+    expect(sidecarScript).toContain("buildStandaloneCli");
+    expect(sidecarScript).toContain('entryModule: "src/index.ts"');
+    expect(sidecarScript).toContain('externalPackages: ["playwright", "playwright-core"]');
+    const sidecarSmokeScript = readFileSync(TAURI_SIDECAR_SMOKE_SCRIPT, "utf8");
+    expect(sidecarSmokeScript).toContain("delete environment.CYBARA_RESOURCE_DIR");
+    expect(sidecarSmokeScript).toContain('html.includes("UI not built")');
+    expect(sidecarSmokeScript).toContain("firstAssetPath(html)");
     const packageScript = readFileSync(PACKAGE_SCRIPT, "utf8");
     expect(packageScript).toContain("--external tiny-secp256k1");
     expect(packageScript).toContain("--external @aws-sdk/client-s3");

--- a/tests/runtime/ui-path.test.ts
+++ b/tests/runtime/ui-path.test.ts
@@ -38,6 +38,21 @@ describe("resolveUiPath", () => {
   test("uses Tauri macOS resource path when present", () => {
     const execPath = "/Applications/Cybara.app/Contents/MacOS/cybara";
     const execDir = dirname(execPath);
+    const tauriMacUi = join(execDir, "..", "Resources", "ui", "dist");
+
+    const result = resolveUiPath({
+      isCompiledBinary: true,
+      execPath,
+      moduleDir: "/virtual/bundle",
+      existsSyncFn: existsFrom([tauriMacUi]),
+    });
+
+    expect(result).toBe(tauriMacUi);
+  });
+
+  test("supports the legacy Tauri macOS resource path", () => {
+    const execPath = "/Applications/Cybara.app/Contents/MacOS/cybara";
+    const execDir = dirname(execPath);
     const tauriMacUi = join(execDir, "..", "Resources", "_up_", "ui", "dist");
 
     const result = resolveUiPath({

--- a/tests/scripts/build-standalone-cli.test.ts
+++ b/tests/scripts/build-standalone-cli.test.ts
@@ -44,6 +44,13 @@ describe("standalone CLI build", () => {
       expect(source).toContain('"/assets/app.js"');
       expect(source).toContain("__CYBARA_EMBEDDED_UI__");
       expect(source).toContain('await import("./src/main.ts")');
+
+      const sidecarSource = createStandaloneEntrySource({
+        cwd: directory,
+        uiDir,
+        entryModule: "src/index.ts",
+      });
+      expect(sidecarSource).toContain('await import("./src/index.ts")');
     } finally {
       rmSync(directory, { recursive: true, force: true });
     }

--- a/tests/scripts/package-native-macos.test.ts
+++ b/tests/scripts/package-native-macos.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import {
@@ -62,6 +62,14 @@ describe("native macOS packaging helpers", () => {
     );
     expect(layout.uiDistDir).toBe("/bundle/Cybara.app/Contents/Resources/sidecar/ui/dist");
     expect(layout.wasmPath).toBe("/bundle/Cybara.app/Contents/Resources/sidecar/secp256k1.wasm");
+  });
+
+  test("verifies the bundled gateway version before packaging", () => {
+    const source = readFileSync(
+      join(import.meta.dirname, "..", "..", "scripts", "package-native-macos.ts"),
+      "utf8"
+    );
+    expect(source).toContain("await smokeSidecarUi(SIDEcar_RELEASE_PATH, version)");
   });
 
   test("detects extensionless Mach-O helper executables for nested signing", () => {

--- a/tests/scripts/smoke-tauri-sidecar-ui.test.ts
+++ b/tests/scripts/smoke-tauri-sidecar-ui.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+import { assertSidecarVersion } from "../../scripts/smoke-tauri-sidecar-ui";
+
+describe("sidecar release smoke", () => {
+  test("accepts a gateway matching the app version", () => {
+    expect(() => assertSidecarVersion({ version: "1.0.1798" }, "1.0.1798")).not.toThrow();
+  });
+
+  test("rejects a gateway older than the app", () => {
+    expect(() => assertSidecarVersion({ version: "1.0.1719" }, "1.0.1798")).toThrow(
+      "Bundled gateway version 1.0.1719 does not match app version 1.0.1798"
+    );
+  });
+
+  test("rejects missing or malformed gateway versions", () => {
+    expect(() => assertSidecarVersion({}, "1.0.1798")).toThrow("Bundled gateway version unknown");
+    expect(() => assertSidecarVersion({ version: 1798 }, "1.0.1798")).toThrow(
+      "Bundled gateway version unknown"
+    );
+  });
+});

--- a/tests/site/download-stats.test.ts
+++ b/tests/site/download-stats.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, test } from "bun:test";
 import {
   formatDownloadTotal,
   isCountedDownloadAsset,
-  releaseAutomationBaseline,
   sumReleaseDownloads,
 } from "../../site/downloadStats";
 
@@ -40,8 +39,56 @@ describe("site release download totals", () => {
         { name: "cybara-windows.exe", download_count: 80 },
       ],
     };
-    expect(releaseAutomationBaseline(release)).toBe(100);
     expect(sumReleaseDownloads([release])).toBe(20);
+  });
+
+  test("does not erase installer downloads with unrelated CLI checksum traffic", () => {
+    const release = {
+      assets: [
+        { name: "cybara-v1.0.1798-linux-x64-cli.sha256", download_count: 14 },
+        { name: "Cybara_1.0.1798_x64_en-US.msi", download_count: 2 },
+        { name: "Cybara_1.0.1798_x64_en-US.msi.sig", download_count: 1 },
+        { name: "Cybara_1.0.1798_x64-setup.exe", download_count: 3 },
+        { name: "Cybara_1.0.1798_x64-setup.exe.sig", download_count: 1 },
+        { name: "cybara-v1.0.1798-android.apk", download_count: 1 },
+        { name: "checksums.txt", download_count: 0 },
+      ],
+    };
+    expect(sumReleaseDownloads([release])).toBe(4);
+  });
+
+  test("subtracts matching metadata traffic without counting updater checks", () => {
+    const release = {
+      assets: [
+        { name: "latest.json", download_count: 2_242 },
+        { name: "Cybara_1.0.1798_aarch64.dmg", download_count: 3 },
+        { name: "Cybara_aarch64.app.tar.gz.sig", download_count: 1 },
+        { name: "CybaraNative-v1.0.1798-arm64.zip", download_count: 2 },
+        { name: "CybaraNative-v1.0.1798-arm64.sha256", download_count: 1 },
+      ],
+    };
+    expect(sumReleaseDownloads([release])).toBe(3);
+  });
+
+  test("uses the checksum manifest for installer assets without companion metadata", () => {
+    const release = {
+      assets: [
+        { name: "checksums.txt", download_count: 57 },
+        { name: "cybara-v1.0.593-android.apk", download_count: 56 },
+      ],
+    };
+    expect(sumReleaseDownloads([release])).toBe(0);
+  });
+
+  test("prefers a present zero-count companion over unrelated manifest traffic", () => {
+    const release = {
+      assets: [
+        { name: "checksums.txt", download_count: 57 },
+        { name: "Cybara_1.0.1798_x64_en-US.msi", download_count: 2 },
+        { name: "Cybara_1.0.1798_x64_en-US.msi.sig", download_count: 0 },
+      ],
+    };
+    expect(sumReleaseDownloads([release])).toBe(2);
   });
 
   test("ignores malformed and negative counts", () => {

--- a/tests/tauri/wiring.test.ts
+++ b/tests/tauri/wiring.test.ts
@@ -64,6 +64,17 @@ describe("Tauri wiring", () => {
     }
   });
 
+  test("release workflow verifies the sidecar without adjacent UI resources", () => {
+    const releaseWorkflow = readFileSync(
+      join(ROOT_DIR, ".github", "workflows", "release.yml"),
+      "utf8"
+    );
+    expect(releaseWorkflow).toContain("Smoke Tauri sidecar embedded UI");
+    expect(releaseWorkflow).toContain(
+      'bun run scripts/smoke-tauri-sidecar-ui.ts "${{ matrix.sidecar }}"'
+    );
+  });
+
   test("main.rs starts and stops the cybara sidecar process", () => {
     const mainRsPath = join(ROOT_DIR, "src-tauri", "src", "main.rs");
     const mainRs = readFileSync(mainRsPath, "utf8");

--- a/tests/ui/chat-reasoning-options.test.ts
+++ b/tests/ui/chat-reasoning-options.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { resolveChatReasoningOptions } from "../../ui/src/pages/chat/chatReasoningOptions";
+
+describe("chat reasoning options", () => {
+  test("falls back to provider capabilities when gateway efforts are empty", () => {
+    expect(resolveChatReasoningOptions("openai-codex", "gpt-5.6-sol", "effort", [])).toEqual([
+      { value: null, label: "Default" },
+      { value: "low", label: "Low" },
+      { value: "medium", label: "Medium" },
+      { value: "high", label: "High" },
+      { value: "xhigh", label: "Extra High" },
+      { value: "max", label: "Max" },
+    ]);
+  });
+
+  test("prefers explicit gateway modes and nonempty efforts", () => {
+    expect(resolveChatReasoningOptions("custom", "custom", "adaptive", [])).toEqual([
+      { value: null, label: "Adaptive" },
+    ]);
+    expect(resolveChatReasoningOptions("custom", "custom", "effort", ["low", "max"])).toEqual([
+      { value: null, label: "Default" },
+      { value: "low", label: "Low" },
+      { value: "max", label: "Max" },
+    ]);
+  });
+});

--- a/tests/ui/chat-session-sidebar-layout.test.ts
+++ b/tests/ui/chat-session-sidebar-layout.test.ts
@@ -221,4 +221,13 @@ describe("chat session sidebar layout", () => {
     expect(source).toContain("aria-label={`Rename ${displayTitle}`}");
     expect(source.match(/type="button"/g)?.length ?? 0).toBeGreaterThan(10);
   });
+
+  test("exposes chat rows as multi-chat drag sources", () => {
+    const source = sessionSidebarSource();
+
+    expect(source).toContain("MULTI_CHAT_DRAG_TYPE");
+    expect(source).toContain('event.dataTransfer.effectAllowed = "copyMove"');
+    expect(source).toContain("event.dataTransfer.setData(MULTI_CHAT_DRAG_TYPE, session.id)");
+    expect(source).toContain("draggable");
+  });
 });

--- a/tests/ui/multi-chat-layout.test.ts
+++ b/tests/ui/multi-chat-layout.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import {
+  addMultiChatSession,
+  buildMultiChatPath,
+  isMultiChatSearch,
+  normalizeMultiChatSessionIds,
+  parseMultiChatSessionIds,
+  readPersistedMultiChatSessionIds,
+  reorderMultiChatSessions,
+  replaceMultiChatSession,
+  resolveActiveMultiChatDropIndex,
+} from "../../ui/src/pages/chat/multiChatLayout";
+
+describe("multi-chat layout", () => {
+  test("normalizes unique bounded pane session ids", () => {
+    expect(normalizeMultiChatSessionIds(["a", " a ", "", "b", "c", "d", "e"])).toEqual([
+      "a",
+      "b",
+      "c",
+      "d",
+    ]);
+  });
+
+  test("round trips pane ids through the chat URL", () => {
+    const path = buildMultiChatPath(["session a", "session/b"]);
+    const search = path.slice(path.indexOf("?"));
+    expect(isMultiChatSearch(search)).toBe(true);
+    expect(parseMultiChatSessionIds(search)).toEqual(["session a", "session/b"]);
+  });
+
+  test("adds, replaces, and reorders panes without duplicates", () => {
+    expect(addMultiChatSession(["a", "b"], "c")).toEqual(["a", "b", "c"]);
+    expect(addMultiChatSession(["a", "b"], "a")).toEqual(["a", "b"]);
+    expect(replaceMultiChatSession(["a", "b", "c"], 1, "c")).toEqual(["a", "c"]);
+    expect(reorderMultiChatSessions(["a", "b", "c"], "c", 0)).toEqual(["c", "a", "b"]);
+  });
+
+  test("fails closed when persisted state is malformed", () => {
+    const storage = {
+      getItem: () => "not-json",
+    } as Storage;
+    expect(readPersistedMultiChatSessionIds(storage)).toEqual([]);
+  });
+
+  test("keeps only the newest drag target active across delayed leave events", () => {
+    expect(resolveActiveMultiChatDropIndex(null, 2, true)).toBe(2);
+    expect(resolveActiveMultiChatDropIndex(2, 3, true)).toBe(3);
+    expect(resolveActiveMultiChatDropIndex(3, 2, false)).toBe(3);
+    expect(resolveActiveMultiChatDropIndex(3, 3, false)).toBeNull();
+  });
+});

--- a/tests/ui/multi-chat-wiring.test.ts
+++ b/tests/ui/multi-chat-wiring.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+function readSource(path: string): string {
+  return readFileSync(join(process.cwd(), path), "utf8");
+}
+
+describe("multi-chat workspace wiring", () => {
+  test("routes multi-chat URLs to a lazy workspace", () => {
+    const source = readSource("ui/src/App.tsx");
+
+    expect(source).toContain("const MultiChatWorkspace = lazy");
+    expect(source).toContain("isMultiChatSearch(location.search)");
+    expect(source).toContain('return <MultiChatWorkspace key="multi-chat" />');
+  });
+
+  test("opens multi-chat from the chat header and main sidebar", () => {
+    const chat = readSource("ui/src/pages/Chat.tsx");
+    const header = readSource("ui/src/pages/chat/ChatPageHeader.tsx");
+    const sidebar = readSource("ui/src/components/layout/Sidebar.tsx");
+
+    expect(chat).toContain("navigate(buildMultiChatPath([sessionId]))");
+    expect(header).toContain('aria-label="Open multi-chat"');
+    expect(sidebar).toContain("buildMultiChatPath(currentSessionId ? [currentSessionId] : [])");
+    expect(sidebar).toContain("multiChatActive");
+  });
+
+  test("supports searchable selection and sidebar drag and drop", () => {
+    const workspace = readSource("ui/src/pages/chat/MultiChatWorkspace.tsx");
+    const dropTarget = readSource("ui/src/pages/chat/useMultiChatDropTarget.ts");
+    const sidebar = readSource("ui/src/pages/chat/SessionSidebar.tsx");
+
+    expect(workspace).toContain('aria-label="Search chats to add"');
+    expect(workspace).toContain('data-testid="multi-chat-picker"');
+    expect(workspace).toContain("onTargetChange: onDropTargetChange");
+    expect(workspace).toContain("Drop chat here");
+    expect(workspace).toContain("data-drop-active={dropTarget.active}");
+    expect(workspace).toContain("activeDropIndex === index");
+    expect(workspace).toContain('window.addEventListener("dragend", clearDropTarget, true)');
+    expect(dropTarget).toContain("event.dataTransfer.getData(MULTI_CHAT_DRAG_TYPE)");
+    expect(dropTarget).toContain("onTargetChange(index, true)");
+    expect(dropTarget).toContain("event.currentTarget.contains(nextTarget)");
+    expect(dropTarget).toContain('event.dataTransfer.dropEffect = "move"');
+    expect(sidebar).toContain("event.dataTransfer.setData(MULTI_CHAT_DRAG_TYPE, session.id)");
+    expect(sidebar).toContain("draggable");
+  });
+
+  test("shares status streaming, bounds rendering, and queues active follow-ups", () => {
+    const workspace = readSource("ui/src/pages/chat/MultiChatWorkspace.tsx");
+
+    expect(workspace).toContain("const disconnect = connectStatusStream");
+    expect(workspace.match(/connectStatusStream\(/g)).toHaveLength(1);
+    expect(workspace).toContain("MULTI_CHAT_RENDERED_MESSAGE_LIMIT = 80");
+    expect(workspace).toContain("MULTI_CHAT_REFRESH_THROTTLE_MS = 750");
+    expect(workspace).toContain('queueMode: isActive ? "queue" : undefined');
+    expect(workspace).toContain("useSessionDetail(sessionId, !isDraft)");
+    expect(workspace).toContain("if (existing) return");
+    expect(workspace).toContain(
+      "existing?.status === next.status && existing.detail === next.detail"
+    );
+  });
+
+  test("uses true desktop quadrants and stacked responsive panes", () => {
+    const workspace = readSource("ui/src/pages/chat/MultiChatWorkspace.tsx");
+
+    expect(workspace).toContain("grid-cols-1 lg:grid-cols-2");
+    expect(workspace).toContain("lg:grid-rows-[minmax(0,1fr)_minmax(0,1fr)]");
+    expect(workspace).toContain("lg:min-h-0");
+    expect(workspace).toContain("lg:overflow-hidden");
+  });
+
+  test("uses the shared composer controls and persists new draft chats", () => {
+    const workspace = readSource("ui/src/pages/chat/MultiChatWorkspace.tsx");
+    const agentControls = readSource("ui/src/pages/chat/ChatAgentControls.tsx");
+    const attachments = readSource("ui/src/pages/chat/ChatComposerAttachments.tsx");
+
+    expect(workspace).toContain("<ChatAgentControls");
+    expect(workspace).toContain("<ChatReasoningControl");
+    expect(workspace).toMatch(/selectedAgent\?\.provider_type\s*\?\?\s*selectedAgent\?\.provider/);
+    expect(workspace).toContain("mode={selectedAgent?.reasoning_mode}");
+    expect(workspace).toContain("supportedEfforts={selectedAgent?.reasoning_efforts}");
+    expect(workspace).toContain("createMultiChatDraftId()");
+    expect(workspace).toContain("onReplaceSession(sessionId, resolvedSessionId)");
+    expect(workspace).toContain("controlId={`multi-chat-agent-selector-${index}`}");
+    expect(workspace).toContain("<ChatApprovalControls");
+    expect(workspace).toContain("<ChatComposerAttachments");
+    expect(workspace).toContain("useChatAttachments()");
+    expect(workspace).toContain("useChatDictation(setDraft)");
+    expect(workspace).toContain("images: attachments.images");
+    expect(workspace).toContain('data-chat-composer-input="true"');
+    expect(attachments).toContain("onAddAttachmentFiles");
+    expect(agentControls).toContain('controlId = "chat-agent-selector"');
+    expect(agentControls).toContain("id={controlId}");
+  });
+
+  test("opens environment panels independently or together without shadows", () => {
+    const workspace = readSource("ui/src/pages/chat/MultiChatWorkspace.tsx");
+    const paneEnvironment = readSource("ui/src/pages/chat/MultiChatPaneEnvironment.tsx");
+    const environment = readSource("ui/src/pages/chat/ChatEnvironmentOverview.tsx");
+
+    expect(workspace).toContain("openEnvironmentIds");
+    expect(workspace).toContain("toggleAllEnvironments");
+    expect(workspace).toContain("<MultiChatPaneEnvironment");
+    expect(workspace).toContain("aria-expanded={environmentOpen}");
+    expect(paneEnvironment).not.toContain("shadow-");
+    expect(paneEnvironment).toContain('label="Provider"');
+    expect(paneEnvironment).toContain('label="TTFT"');
+    expect(paneEnvironment).toContain('label="Speed"');
+    expect(paneEnvironment).toContain("multiline");
+    expect(environment).not.toContain("shadow-[0_28px_90px");
+  });
+
+  test("keeps the workspace header actions compact and accessible", () => {
+    const workspace = readSource("ui/src/pages/chat/MultiChatWorkspace.tsx");
+
+    expect(workspace).toContain('aria-label="New chat"');
+    expect(workspace).toContain('aria-label="Add existing chat"');
+    expect(workspace).toContain('aria-label="Open single chat"');
+    expect(workspace).not.toContain('<span className="hidden sm:inline">Add chat</span>');
+    expect(workspace).not.toContain('<span className="hidden md:inline">Environments</span>');
+  });
+
+  test("hides transcript scrollbars while preserving scroll behavior", () => {
+    const workspace = readSource("ui/src/pages/chat/MultiChatWorkspace.tsx");
+    const chat = readSource("ui/src/pages/Chat.tsx");
+    const ideChat = readSource("ui/src/pages/ide/IDEChatPanel.tsx");
+    const foundation = readSource("ui/src/styles/index-foundation.css");
+
+    expect(workspace).toContain("chat-scroll-region min-h-0 flex-1 overflow-y-auto");
+    expect(chat).toContain("chat-scroll-region flex-1 overflow-y-auto");
+    expect(ideChat).toContain("chat-scroll-region flex-1 overflow-y-auto");
+    expect(foundation).toContain(".chat-scroll-region::-webkit-scrollbar");
+    expect(foundation).toContain("scrollbar-width: none");
+  });
+});

--- a/tests/ui/multi-chat-wiring.test.ts
+++ b/tests/ui/multi-chat-wiring.test.ts
@@ -54,6 +54,7 @@ describe("multi-chat workspace wiring", () => {
     expect(workspace).toContain("MULTI_CHAT_RENDERED_MESSAGE_LIMIT = 80");
     expect(workspace).toContain("MULTI_CHAT_REFRESH_THROTTLE_MS = 750");
     expect(workspace).toContain('queueMode: isActive ? "queue" : undefined');
+    expect(workspace).toContain("(!isActive && responsePending)");
     expect(workspace).toContain("useSessionDetail(sessionId, !isDraft)");
     expect(workspace).toContain("if (existing) return");
     expect(workspace).toContain(

--- a/tests/ui/status-stream-wiring.test.ts
+++ b/tests/ui/status-stream-wiring.test.ts
@@ -98,8 +98,9 @@ describe("status stream websocket wiring", () => {
     expect(source).toContain("context-usage-tooltip");
     expect(source).toContain("context-usage-tooltip-title");
     expect(contextUsageRingSource).toContain("aria-expanded={open}");
-    expect(contextUsageRingSource).toContain("onClick={() => setOpen(true)}");
-    expect(contextUsageRingSource).not.toContain("onClick={() => setOpen((value) => !value)}");
+    expect(contextUsageRingSource).toContain("onClick={() => setOpen((current) => !current)}");
+    expect(contextUsageRingSource).toContain("createPortal(tooltipContent, document.body)");
+    expect(contextUsageRingSource).toContain("fixed z-[200]");
     expect(source).not.toContain("bg-[#2b2b2f]");
     expect(source).not.toContain("bg-[#171820]");
     expect(source).not.toContain("rgba(255,255,255,0.18)");
@@ -124,7 +125,8 @@ describe("status stream websocket wiring", () => {
     expect(source).toMatch(
       /settingsApi\.updateConfig\(\{\s*tool_approval_mode:\s*nextMode,?\s*\}\)/
     );
-    expect(source).toContain('id="chat-agent-selector"');
+    expect(source).toContain('controlId = "chat-agent-selector"');
+    expect(source).toContain("id={controlId}");
     expect(source).toContain("chat-composer-responsive");
     expect(source).toContain("chat-approval-toggle");
     expect(source).toContain("chat-agent-selector-compact-label");

--- a/tests/ui/update-settings.test.ts
+++ b/tests/ui/update-settings.test.ts
@@ -30,8 +30,8 @@ describe("desktop update settings", () => {
 
   test("stamps release sidecars with the source commit", () => {
     expect(buildScript).toContain("process.env.CYBARA_BUILD_COMMIT = buildCommit");
-    expect(buildScript).toContain('const buildEnvironment = "--env=CYBARA_BUILD_*"');
-    expect(buildScript).toContain("${buildEnvironment}");
+    expect(buildScript).toContain("buildStandaloneCli");
+    expect(buildScript).toContain('entryModule: "src/index.ts"');
     expect(packageScript).toContain("process.env.CYBARA_BUILD_COMMIT = buildCommit");
     expect(packageScript).toContain("buildStandaloneCli");
     expect(standaloneBuildScript).toContain('"--env=CYBARA_BUILD_*"');

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -23,6 +23,7 @@ import { readSetupComplete, resolveSetupGate, writeSetupComplete } from "@/lib/s
 import { isPetWindow } from "@/lib/tauriPet";
 import { cn } from "@/lib/utils";
 import { PetOverlay } from "@/pages/PetOverlay";
+import { isMultiChatSearch } from "@/pages/chat/multiChatLayout";
 import {
   readCustomThemeCollectionFromConfig,
   readThemeAccentFromConfig,
@@ -42,6 +43,11 @@ const Settings = lazy(() =>
   import("@/pages/Settings").then((module) => ({ default: module.Settings }))
 );
 const Chat = lazy(() => import("@/pages/Chat").then((module) => ({ default: module.Chat })));
+const MultiChatWorkspace = lazy(() =>
+  import("@/pages/chat/MultiChatWorkspace").then((module) => ({
+    default: module.MultiChatWorkspace,
+  }))
+);
 const Sessions = lazy(() =>
   import("@/pages/Sessions").then((module) => ({ default: module.Sessions }))
 );
@@ -74,6 +80,9 @@ function PageLoader() {
 
 function ChatRoute() {
   const location = useLocation();
+  if (isMultiChatSearch(location.search)) {
+    return <MultiChatWorkspace key="multi-chat" />;
+  }
   return <Chat key={location.search} />;
 }
 

--- a/ui/src/components/layout/Sidebar.tsx
+++ b/ui/src/components/layout/Sidebar.tsx
@@ -40,6 +40,7 @@ import { connectStatusStream } from "@/lib/status-stream";
 import { cn } from "@/lib/utils";
 import { SessionsPanel } from "@/pages/chat/SessionSidebar";
 import { buildFreshChatPath } from "@/pages/chat/chatRoute";
+import { buildMultiChatPath, isMultiChatSearch } from "@/pages/chat/multiChatLayout";
 import type { TranslationKey } from "../../../../shared/i18n/catalog";
 import {
   clampMainSidebarChatHeight,
@@ -293,6 +294,7 @@ export function Sidebar() {
   }, [location.pathname, setMobileOpen]);
 
   const currentSessionId = onChatPage ? new URLSearchParams(location.search).get("session") : null;
+  const multiChatActive = onChatPage && isMultiChatSearch(location.search);
   const activeSettingsSection =
     resolveSettingsSectionId(new URLSearchParams(location.search).get("section")) ?? "general";
 
@@ -515,6 +517,20 @@ export function Sidebar() {
                 {!collapsed && (
                   <div className="flex min-w-0 flex-1 items-center gap-2">
                     <h1 className="min-w-0 flex-1 truncate text-lg font-bold text-white">Cybara</h1>
+                    <button
+                      type="button"
+                      onClick={() =>
+                        navigate(buildMultiChatPath(currentSessionId ? [currentSessionId] : []))
+                      }
+                      className={cn(
+                        "theme-muted-icon-button flex h-8 w-8 shrink-0 items-center justify-center rounded-lg",
+                        multiChatActive && "bg-[var(--surface-hover)] text-[var(--text-primary)]"
+                      )}
+                      aria-label="Open multi-chat"
+                      title="Open multi-chat"
+                    >
+                      <MessagesSquare className="h-4 w-4" />
+                    </button>
                     <button
                       type="button"
                       onClick={() => setSessionSearchOpen(true)}

--- a/ui/src/hooks/useChat.ts
+++ b/ui/src/hooks/useChat.ts
@@ -1,7 +1,12 @@
 import { useState, useCallback, useRef } from "react";
 import { useQuery, useMutation, useQueryClient, type QueryClient } from "@tanstack/react-query";
 import { chatApi, agentsApi, extractApiError } from "@/lib/api";
-import type { ChatMessage, ChatImageAttachment } from "@/types";
+import type {
+  ChatImageAttachment,
+  ChatMessage,
+  SessionContextUsage,
+  SessionTokenUsage,
+} from "@/types";
 import { enrichReloadedMessages, readCachedSessionMessages } from "@/pages/chat/messageCache";
 
 interface ChatState {
@@ -35,8 +40,8 @@ export interface LoadedChatSession {
   created_at: string;
   updated_at: string;
   workspace_dir?: string | null;
-  contextUsage?: unknown;
-  tokenUsage?: unknown;
+  contextUsage?: SessionContextUsage | null;
+  tokenUsage?: SessionTokenUsage | null;
   plan?: unknown;
   messagesList: ChatMessage[];
 }
@@ -44,6 +49,29 @@ export interface LoadedChatSession {
 function sessionDetailQueryKey(sessionId: string) {
   return [SESSION_DETAIL_QUERY_KEY, sessionId, "compact"] as const;
 }
+
+const loadSessionDetail = async (
+  sessionId: string,
+  querySignal?: AbortSignal
+): Promise<LoadedChatSession> => {
+  const controller = new AbortController();
+  const abortFromQuery = () => controller.abort(querySignal?.reason);
+  querySignal?.addEventListener("abort", abortFromQuery, { once: true });
+  const timeoutId = globalThis.setTimeout(
+    () => controller.abort(new DOMException("Session load timed out", "TimeoutError")),
+    SESSION_DETAIL_TIMEOUT_MS
+  );
+  try {
+    const response = await chatApi.getSession(sessionId, { signal: controller.signal });
+    if (response.success && response.data) {
+      return response.data as LoadedChatSession;
+    }
+    throw new Error(response.error || "Failed to load session");
+  } finally {
+    globalThis.clearTimeout(timeoutId);
+    querySignal?.removeEventListener("abort", abortFromQuery);
+  }
+};
 
 function invalidateSessionDetail(queryClient: QueryClient, sessionId?: string | null) {
   return queryClient.invalidateQueries({
@@ -384,6 +412,17 @@ export function useSessions(options?: { limit?: number }) {
   });
 }
 
+export function useSessionDetail(sessionId: string, enabled = true) {
+  return useQuery({
+    queryKey: sessionDetailQueryKey(sessionId),
+    queryFn: ({ signal }) => loadSessionDetail(sessionId, signal),
+    enabled: enabled && !!sessionId,
+    staleTime: SESSION_DETAIL_STALE_MS,
+    gcTime: SESSION_DETAIL_GC_MS,
+    refetchOnWindowFocus: false,
+  });
+}
+
 export function useDeleteSession() {
   const queryClient = useQueryClient();
 
@@ -466,28 +505,6 @@ export function useUpdateSessionAgent() {
 
 export function useLoadSession() {
   const queryClient = useQueryClient();
-  const loadSessionDetail = useCallback(
-    async (sessionId: string, querySignal?: AbortSignal): Promise<LoadedChatSession> => {
-      const controller = new AbortController();
-      const abortFromQuery = () => controller.abort(querySignal?.reason);
-      querySignal?.addEventListener("abort", abortFromQuery, { once: true });
-      const timeoutId = globalThis.setTimeout(
-        () => controller.abort(new DOMException("Session load timed out", "TimeoutError")),
-        SESSION_DETAIL_TIMEOUT_MS
-      );
-      try {
-        const response = await chatApi.getSession(sessionId, { signal: controller.signal });
-        if (response.success && response.data) {
-          return response.data as LoadedChatSession;
-        }
-        throw new Error(response.error || "Failed to load session");
-      } finally {
-        globalThis.clearTimeout(timeoutId);
-        querySignal?.removeEventListener("abort", abortFromQuery);
-      }
-    },
-    []
-  );
   const loadFresh = useCallback(
     (sessionId: string): Promise<LoadedChatSession> =>
       queryClient.fetchQuery({
@@ -496,7 +513,7 @@ export function useLoadSession() {
         gcTime: SESSION_DETAIL_GC_MS,
         queryFn: ({ signal }) => loadSessionDetail(sessionId, signal),
       }),
-    [loadSessionDetail, queryClient]
+    [queryClient]
   );
 
   const mutation = useMutation({

--- a/ui/src/lib/reasoning.test.ts
+++ b/ui/src/lib/reasoning.test.ts
@@ -63,7 +63,7 @@ describe("supportedReasoningOptions per-model matrix", () => {
     expect(reasoningEffortLabel(null, "minimax-portal", "MiniMax-M3")).toBe("Adaptive");
   });
 
-  test("Kimi K3 exposes its max-only coding-plan reasoning contract", () => {
+  test("Kimi K3 exposes its current coding-plan reasoning contract", () => {
     for (const provider of [
       "kimi-code",
       "kimi-code-oauth",
@@ -73,11 +73,23 @@ describe("supportedReasoningOptions per-model matrix", () => {
     ]) {
       expect(supportedReasoningOptions(provider, "k3")).toEqual([
         { value: "", label: "Default" },
+        { value: "low", label: "Low" },
+        { value: "high", label: "High" },
         { value: "max", label: "Max" },
       ]);
     }
     expect(supportsXHighReasoning("kimi-code-oauth", "k3")).toBe(false);
     expect(reasoningEffortLabel("max", "kimi-code-oauth", "k3")).toBe("Max");
+  });
+
+  test("Gemini 3 Flash exposes Minimal through High", () => {
+    expect(supportedReasoningOptions("google", "gemini-3.5-flash").map((o) => o.value)).toEqual([
+      "",
+      "minimal",
+      "low",
+      "medium",
+      "high",
+    ]);
   });
 
   test("codex models expose Low..Max and exclude Minimal", () => {

--- a/ui/src/lib/reasoning.ts
+++ b/ui/src/lib/reasoning.ts
@@ -1,34 +1,17 @@
-export type ReasoningEffort = "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
+import {
+  supportedReasoningEfforts,
+  supportsXHighReasoning,
+  usesBinaryReasoning,
+  usesProviderAdaptiveReasoning,
+  type ReasoningEffort,
+} from "../../../shared/reasoning-capabilities";
+
+export { supportsXHighReasoning, type ReasoningEffort };
 
 export interface ReasoningOption {
   value: ReasoningEffort | "";
   label: string;
 }
-
-const BINARY_THINKING_PROVIDERS = new Set([
-  "z.ai",
-  "z.ai-coding",
-  "zai",
-  "z-ai",
-  "qwen-portal",
-  "alibaba",
-  "alibaba-coding-plan",
-  "qwen-token-plan",
-  "qwen-token-plan-cn",
-]);
-const ADAPTIVE_THINKING_PROVIDERS = new Set([
-  "minimax",
-  "minimax-cn",
-  "minimax-portal",
-  "minimax-portal-cn",
-]);
-const KIMI_CODE_PROVIDERS = new Set([
-  "kimi-code",
-  "kimi-code-oauth",
-  "kimi-coding",
-  "kimi-oauth",
-  "kimi-code-subscription",
-]);
 
 const LEVEL_LABELS: Record<ReasoningEffort, string> = {
   minimal: "Minimal",
@@ -39,104 +22,14 @@ const LEVEL_LABELS: Record<ReasoningEffort, string> = {
   max: "Max",
 };
 
-const GPT_5_EFFORTS: ReasoningEffort[] = ["minimal", "low", "medium", "high"];
-const GPT_51_EFFORTS: ReasoningEffort[] = ["low", "medium", "high"];
-const GPT_52_EFFORTS: ReasoningEffort[] = ["low", "medium", "high", "xhigh"];
-const GPT_56_EFFORTS: ReasoningEffort[] = ["low", "medium", "high", "xhigh", "max"];
-const GPT_CODEX_EFFORTS: ReasoningEffort[] = ["low", "medium", "high", "xhigh"];
-const GPT_CODEX_MINI_EFFORTS: ReasoningEffort[] = ["medium"];
-const GPT_CODEX_MAX_EFFORTS: ReasoningEffort[] = ["medium", "high", "xhigh"];
-const GPT_PRO_EFFORTS: ReasoningEffort[] = ["medium", "high", "xhigh"];
-const GPT_5_PRO_EFFORTS: ReasoningEffort[] = ["high"];
-const GENERIC_OPENAI_EFFORTS: ReasoningEffort[] = ["low", "medium", "high"];
-
-function normalizeModelId(id: string | null | undefined): string {
-  return (id ?? "")
-    .trim()
-    .toLowerCase()
-    .replace(/^(?:openai\/|anthropic\/|google\/)?/, "")
-    .replace(/-\d{4}-\d{2}-\d{2}$/, "");
-}
-
-function resolveOpenAIModelEfforts(modelId: string): ReasoningEffort[] {
-  if (/^gpt-5\.6(?:-|$)/.test(modelId)) return GPT_56_EFFORTS;
-  if (modelId === "gpt-5.1-codex-mini") return GPT_CODEX_MINI_EFFORTS;
-  if (modelId === "gpt-5.1-codex-max") return GPT_CODEX_MAX_EFFORTS;
-  if (/^gpt-5(?:\.\d+)?-codex(?:-|$)/.test(modelId)) return GPT_CODEX_EFFORTS;
-  if (modelId === "gpt-5-pro") return GPT_5_PRO_EFFORTS;
-  if (/^gpt-5\.[2-9](?:\.\d+)?-pro(?:-|$)/.test(modelId)) return GPT_PRO_EFFORTS;
-  if (/^gpt-5\.[2-9](?:\.\d+)?(?:-|$)/.test(modelId)) return GPT_52_EFFORTS;
-  if (/^gpt-5\.1(?:-|$)/.test(modelId)) return GPT_51_EFFORTS;
-  if (/^gpt-5(?:-|$)/.test(modelId)) return GPT_5_EFFORTS;
-  return GENERIC_OPENAI_EFFORTS;
-}
-
-const ANTHROPIC_LEGACY_EFFORTS: ReasoningEffort[] = ["minimal", "low", "medium", "high"];
-const ANTHROPIC_46_EFFORTS: ReasoningEffort[] = ["low", "medium", "high", "max"];
-const ANTHROPIC_MODERN_EFFORTS: ReasoningEffort[] = ["low", "medium", "high", "xhigh", "max"];
-const GOOGLE_3_PRO_EFFORTS: ReasoningEffort[] = ["low", "high"];
-const GOOGLE_EFFORTS: ReasoningEffort[] = ["low", "medium", "high"];
-
-function resolveAnthropicModelEfforts(modelId: string): ReasoningEffort[] {
-  if (!modelId.includes("claude")) return [...ANTHROPIC_LEGACY_EFFORTS];
-  if (/claude-(?:opus|sonnet)-4[-.]6(?:-|$)/.test(modelId)) return [...ANTHROPIC_46_EFFORTS];
-  if (/claude-(?:3|opus-4[-.][0-5]|sonnet-4[-.][0-5]|haiku-4[-.]5)(?:-|$)/.test(modelId)) {
-    return [...ANTHROPIC_LEGACY_EFFORTS];
-  }
-  return [...ANTHROPIC_MODERN_EFFORTS];
-}
-
-function supportedEfforts(provider?: string | null, model?: string | null): ReasoningEffort[] {
-  const providerId = (provider || "").trim().toLowerCase();
-  if (BINARY_THINKING_PROVIDERS.has(providerId)) {
-    return ["medium"];
-  }
-  const modelId = normalizeModelId(model);
-  if (KIMI_CODE_PROVIDERS.has(providerId) && modelId === "k3") {
-    return ["max"];
-  }
-  if (providerId === "anthropic" || providerId === "anthropic_vertex") {
-    return resolveAnthropicModelEfforts(modelId);
-  }
-  if (providerId === "google" || providerId === "google_vertex") {
-    if (/^gemini-3(?:\.1)?-.*pro/.test(modelId)) return [...GOOGLE_3_PRO_EFFORTS];
-    return [...GOOGLE_EFFORTS];
-  }
-  if (
-    providerId === "openai" ||
-    providerId === "openai-codex" ||
-    providerId === "openai-codex-responses" ||
-    providerId === "azure-openai" ||
-    !modelId
-  ) {
-    return resolveOpenAIModelEfforts(modelId);
-  }
-  return [...GENERIC_OPENAI_EFFORTS];
-}
-
-export function supportsXHighReasoning(provider?: string | null, model?: string | null): boolean {
-  return supportedEfforts(provider, model).includes("xhigh");
-}
-
-function isBinaryThinkingProvider(provider?: string | null): boolean {
-  return BINARY_THINKING_PROVIDERS.has((provider || "").trim().toLowerCase());
-}
-
-function isAdaptiveThinkingProvider(provider?: string | null, model?: string | null): boolean {
-  const providerId = (provider || "").trim().toLowerCase();
-  return (
-    ADAPTIVE_THINKING_PROVIDERS.has(providerId) && /(?:^|\/)minimax-m3(?:[.-]|$)/i.test(model ?? "")
-  );
-}
-
 export function supportedReasoningOptions(
   provider?: string | null,
   model?: string | null
 ): ReasoningOption[] {
-  if (isAdaptiveThinkingProvider(provider, model)) {
+  if (usesProviderAdaptiveReasoning(provider, model)) {
     return [{ value: "", label: "Adaptive" }];
   }
-  if (isBinaryThinkingProvider(provider)) {
+  if (usesBinaryReasoning(provider)) {
     return [
       { value: "", label: "Default" },
       { value: "medium", label: "Thinking" },
@@ -144,7 +37,7 @@ export function supportedReasoningOptions(
   }
   return [
     { value: "", label: "Default" },
-    ...supportedEfforts(provider, model).map((level) => ({
+    ...supportedReasoningEfforts(provider, model).map((level) => ({
       value: level,
       label: LEVEL_LABELS[level],
     })),

--- a/ui/src/pages/Chat.tsx
+++ b/ui/src/pages/Chat.tsx
@@ -69,6 +69,7 @@ import {
   shouldShowSessionPlanInComposer,
 } from "./chat/chatModel";
 import { ChatPageHeader } from "./chat/ChatPageHeader";
+import { buildMultiChatPath } from "./chat/multiChatLayout";
 import { parseInitialChatRoute } from "./chat/chatRoute";
 import { ChatSessionLoadingState } from "./chat/ChatSessionLoadingState";
 import { ChatWorkspaceDock } from "./chat/ChatWorkspaceDock";
@@ -1573,6 +1574,7 @@ export function Chat() {
             onOpenCybaraIde: handleOpenWorkspaceInCybaraIde,
           }}
           workspacePanelOpen={showWorkspacePanel}
+          onOpenMultiChat={() => navigate(buildMultiChatPath([sessionId]))}
           onOpenNearbyShare={() => setShowNearbyShare(true)}
           onToggleEnvironment={() => setShowEnvironmentOverview(!showEnvironmentOverview)}
           onToggleFileReview={() => toggleWorkspaceTab("review")}
@@ -1600,7 +1602,7 @@ export function Chat() {
                 ref={messagesContainerRef}
                 onScroll={refreshScrollToBottomVisibility}
                 className={cn(
-                  "flex-1 overflow-y-auto py-4",
+                  "chat-scroll-region flex-1 overflow-y-auto py-4",
                   chatHorizontalPaddingClassName(chatAppearance.horizontalPadding),
                   typedMessages.length === 0 ? "flex items-center justify-center" : "space-y-4"
                 )}

--- a/ui/src/pages/chat/ChatAgentControls.tsx
+++ b/ui/src/pages/chat/ChatAgentControls.tsx
@@ -13,6 +13,7 @@ export function ChatAgentControls({
   providerPlan,
   onSelectAgent,
   updating,
+  controlId = "chat-agent-selector",
 }: {
   agents: AgentSummary[];
   selectedAgentId?: string;
@@ -22,6 +23,7 @@ export function ChatAgentControls({
   providerPlan?: ProviderPlanSnapshot | null;
   onSelectAgent: (agentId?: string) => void;
   updating?: boolean;
+  controlId?: string;
 }) {
   const selectedAgent = agents.find((agent) => agent.id === selectedAgentId);
   const routeLabel = useModelRouter
@@ -35,12 +37,12 @@ export function ChatAgentControls({
   return (
     <div className="chat-agent-controls flex min-w-0 items-center gap-0.5">
       <ContextUsageRing usage={contextUsage} providerPlan={providerPlan} />
-      <label className="sr-only" htmlFor="chat-agent-selector">
+      <label className="sr-only" htmlFor={controlId}>
         Chat agent
       </label>
       <div className="chat-agent-selector-shell relative min-w-0">
         <select
-          id="chat-agent-selector"
+          id={controlId}
           value={useModelRouter ? MODEL_ROUTER_SELECTOR_VALUE : selectedAgentId || ""}
           disabled={updating}
           onChange={(event) => onSelectAgent(event.target.value || undefined)}

--- a/ui/src/pages/chat/ChatComposer.tsx
+++ b/ui/src/pages/chat/ChatComposer.tsx
@@ -1,23 +1,7 @@
-import {
-  AlertTriangle,
-  CheckCircle2,
-  FileText,
-  Loader2,
-  Mic,
-  MicOff,
-  Paperclip,
-  X,
-} from "lucide-react";
+import { AlertTriangle, CheckCircle2, Loader2, Mic, MicOff, Paperclip } from "lucide-react";
 import type { ClipboardEvent, DragEvent, RefObject } from "react";
 import type { ChatHorizontalPadding } from "../../../../shared/chat-appearance";
 import type { ChatFileAttachment } from "@/lib/chatImages";
-import {
-  chatImageSrc,
-  formatBytes,
-  imageAttachmentBytes,
-  MAX_CHAT_IMAGES,
-  mediaSummaryLabel,
-} from "@/lib/chatImages";
 import type { PendingChatMessage } from "@/lib/status-stream";
 import { cn } from "@/lib/utils";
 import type {
@@ -28,6 +12,7 @@ import type {
   SessionContextUsage,
 } from "@/types";
 import { ChatAgentControls } from "./ChatAgentControls";
+import { ChatComposerAttachments } from "./ChatComposerAttachments";
 import { ChatCapabilityMenu } from "./ChatCapabilityMenu";
 import { ChatComposerActionButton } from "./ChatComposerActionButton";
 import {
@@ -230,81 +215,13 @@ export function ChatComposer({
         onDragLeave={() => onDragActiveChange(false)}
         onDrop={onDrop}
       >
-        {pendingImages.length > 0 || pendingFiles.length > 0 ? (
-          <div className="mb-2">
-            <div className="mb-1 flex items-center gap-1.5 text-[11px] text-gray-400">
-              <Paperclip className="h-3 w-3 shrink-0" />
-              <span>{mediaSummaryLabel(pendingImages, pendingFiles)}</span>
-              {pendingImages.length >= MAX_CHAT_IMAGES ? (
-                <span className="text-amber-300/80">· max {MAX_CHAT_IMAGES} images</span>
-              ) : null}
-            </div>
-            <div className="flex flex-wrap gap-2">
-              {pendingImages.map((image, index) => (
-                <div
-                  key={`pending-image-${index}`}
-                  className="group relative h-16 w-16 overflow-hidden rounded-lg border border-white/12"
-                  title={`${image.name || "image"}${
-                    imageAttachmentBytes(image)
-                      ? ` · ${formatBytes(imageAttachmentBytes(image))}`
-                      : ""
-                  }`}
-                >
-                  <img
-                    src={chatImageSrc(image)}
-                    alt={image.name || "Attachment preview"}
-                    className="h-full w-full object-cover"
-                  />
-                  {imageAttachmentBytes(image) > 0 ? (
-                    <span className="absolute bottom-0 left-0 right-0 bg-black/55 px-1 py-px text-[9px] leading-tight text-white/90">
-                      {formatBytes(imageAttachmentBytes(image))}
-                    </span>
-                  ) : null}
-                  <button
-                    type="button"
-                    onClick={() => onRemovePendingImage(index)}
-                    className="absolute right-0.5 top-0.5 inline-flex h-4 w-4 items-center justify-center rounded-full bg-black/60 text-white opacity-0 transition-opacity hover:bg-black/80 group-hover:opacity-100"
-                    aria-label="Remove image"
-                  >
-                    <X className="h-2.5 w-2.5" />
-                  </button>
-                </div>
-              ))}
-              {pendingFiles.map((file, index) => (
-                <div
-                  key={`pending-file-${index}`}
-                  className="flex items-center gap-1.5 rounded-lg border border-white/12 bg-white/[0.04] px-2 py-1 text-xs text-gray-200"
-                >
-                  <FileText className="h-3.5 w-3.5 shrink-0 text-gray-400" />
-                  <span className="flex min-w-0 flex-col leading-tight">
-                    <span className="max-w-[160px] truncate">{file.name}</span>
-                    {formatBytes(file.size) ? (
-                      <span className="text-[10px] text-gray-500">{formatBytes(file.size)}</span>
-                    ) : null}
-                  </span>
-                  <button
-                    type="button"
-                    onClick={() => onRemovePendingFile(index)}
-                    className="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full text-gray-400 hover:bg-white/10 hover:text-white"
-                    aria-label="Remove file"
-                  >
-                    <X className="h-2.5 w-2.5" />
-                  </button>
-                </div>
-              ))}
-            </div>
-          </div>
-        ) : null}
-        <input
-          ref={imageInputRef}
-          type="file"
-          accept="image/png,image/jpeg,image/gif,image/webp,text/*,.md,.markdown,.json,.jsonc,.csv,.tsv,.xml,.yaml,.yml,.toml,.ini,.log,.html,.css,.scss,.js,.jsx,.mjs,.cjs,.ts,.tsx,.py,.rb,.go,.rs,.java,.kt,.swift,.c,.h,.cpp,.hpp,.cc,.cs,.php,.sh,.bash,.zsh,.sql,.env,.vue,.svelte"
-          multiple
-          className="hidden"
-          onChange={(event) => {
-            if (event.target.files) void onAddAttachmentFiles(event.target.files);
-            event.target.value = "";
-          }}
+        <ChatComposerAttachments
+          imageInputRef={imageInputRef}
+          pendingFiles={pendingFiles}
+          pendingImages={pendingImages}
+          onAddAttachmentFiles={onAddAttachmentFiles}
+          onRemovePendingFile={onRemovePendingFile}
+          onRemovePendingImage={onRemovePendingImage}
         />
         <textarea
           ref={inputRef}
@@ -350,6 +267,8 @@ export function ChatComposer({
               activeAgent?.provider_type ?? activeAgent?.provider ?? activeAgent?.provider_id
             }
             model={activeAgent?.model}
+            mode={activeAgent?.reasoning_mode}
+            supportedEfforts={activeAgent?.reasoning_efforts}
             disabled={useModelRouter || !activeAgent}
             updating={reasoningUpdating}
             onChange={onReasoningChange}

--- a/ui/src/pages/chat/ChatComposerAttachments.tsx
+++ b/ui/src/pages/chat/ChatComposerAttachments.tsx
@@ -1,0 +1,129 @@
+import type { ChatFileAttachment } from "@/lib/chatImages";
+import {
+  chatImageSrc,
+  formatBytes,
+  imageAttachmentBytes,
+  MAX_CHAT_IMAGES,
+  mediaSummaryLabel,
+} from "@/lib/chatImages";
+import { cn } from "@/lib/utils";
+import type { ChatImageAttachment } from "@/types";
+import { FileText, Paperclip, X } from "lucide-react";
+import type { RefObject } from "react";
+
+const attachmentKeys = new WeakMap<object, number>();
+let nextAttachmentKey = 0;
+
+function attachmentKey(attachment: object): number {
+  const current = attachmentKeys.get(attachment);
+  if (current !== undefined) return current;
+  nextAttachmentKey += 1;
+  attachmentKeys.set(attachment, nextAttachmentKey);
+  return nextAttachmentKey;
+}
+
+export function ChatComposerAttachments({
+  compact = false,
+  imageInputRef,
+  pendingFiles,
+  pendingImages,
+  onAddAttachmentFiles,
+  onRemovePendingFile,
+  onRemovePendingImage,
+}: {
+  compact?: boolean;
+  imageInputRef: RefObject<HTMLInputElement | null>;
+  pendingFiles: ChatFileAttachment[];
+  pendingImages: ChatImageAttachment[];
+  onAddAttachmentFiles: (files: Iterable<File>) => void | Promise<void>;
+  onRemovePendingFile: (index: number) => void;
+  onRemovePendingImage: (index: number) => void;
+}) {
+  return (
+    <>
+      {pendingImages.length > 0 || pendingFiles.length > 0 ? (
+        <div className="mb-2">
+          <div className="mb-1 flex items-center gap-1.5 text-[11px] text-[var(--text-muted)]">
+            <Paperclip className="h-3 w-3 shrink-0" />
+            <span>{mediaSummaryLabel(pendingImages, pendingFiles)}</span>
+            {pendingImages.length >= MAX_CHAT_IMAGES ? (
+              <span className="text-amber-300/80">· max {MAX_CHAT_IMAGES} images</span>
+            ) : null}
+          </div>
+          <div className="flex max-h-20 flex-wrap gap-1.5 overflow-y-auto">
+            {pendingImages.map((image, index) => (
+              <div
+                key={`pending-image-${attachmentKey(image)}`}
+                className={cn(
+                  "group relative overflow-hidden rounded-lg border border-[var(--surface-border)]",
+                  compact ? "h-10 w-10" : "h-16 w-16"
+                )}
+                title={`${image.name || "image"}${
+                  imageAttachmentBytes(image)
+                    ? ` · ${formatBytes(imageAttachmentBytes(image))}`
+                    : ""
+                }`}
+              >
+                <img
+                  src={chatImageSrc(image)}
+                  alt={image.name || "Attachment preview"}
+                  className="h-full w-full object-cover"
+                />
+                {imageAttachmentBytes(image) > 0 && !compact ? (
+                  <span className="absolute bottom-0 left-0 right-0 bg-black/55 px-1 py-px text-[9px] leading-tight text-white/90">
+                    {formatBytes(imageAttachmentBytes(image))}
+                  </span>
+                ) : null}
+                <button
+                  type="button"
+                  onClick={() => onRemovePendingImage(index)}
+                  className="absolute right-0.5 top-0.5 inline-flex h-4 w-4 items-center justify-center rounded-full bg-black/60 text-white opacity-0 transition-opacity hover:bg-black/80 group-hover:opacity-100"
+                  aria-label="Remove image"
+                >
+                  <X className="h-2.5 w-2.5" />
+                </button>
+              </div>
+            ))}
+            {pendingFiles.map((file, index) => (
+              <div
+                key={`pending-file-${attachmentKey(file)}`}
+                className="flex min-w-0 items-center gap-1.5 rounded-lg border border-[var(--surface-border)] bg-[var(--surface-hover)] px-2 py-1 text-xs text-[var(--text-secondary)]"
+              >
+                <FileText className="h-3.5 w-3.5 shrink-0 text-[var(--icon-muted)]" />
+                <span className="flex min-w-0 flex-col leading-tight">
+                  <span className={cn("truncate", compact ? "max-w-20" : "max-w-40")}>
+                    {file.name}
+                  </span>
+                  {!compact && formatBytes(file.size) ? (
+                    <span className="text-[10px] text-[var(--text-muted)]">
+                      {formatBytes(file.size)}
+                    </span>
+                  ) : null}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => onRemovePendingFile(index)}
+                  className="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full text-[var(--icon-muted)] hover:bg-[var(--surface-raised)] hover:text-[var(--text-primary)]"
+                  aria-label="Remove file"
+                >
+                  <X className="h-2.5 w-2.5" />
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : null}
+      <input
+        ref={imageInputRef}
+        type="file"
+        accept="image/png,image/jpeg,image/gif,image/webp,text/*,.md,.markdown,.json,.jsonc,.csv,.tsv,.xml,.yaml,.yml,.toml,.ini,.log,.html,.css,.scss,.js,.jsx,.mjs,.cjs,.ts,.tsx,.py,.rb,.go,.rs,.java,.kt,.swift,.c,.h,.cpp,.hpp,.cc,.cs,.php,.sh,.bash,.zsh,.sql,.env,.vue,.svelte"
+        multiple
+        className="hidden"
+        onChange={(event) => {
+          if (event.target.files) void onAddAttachmentFiles(event.target.files);
+          event.target.value = "";
+        }}
+      />
+    </>
+  );
+}

--- a/ui/src/pages/chat/ChatEnvironmentOverview.tsx
+++ b/ui/src/pages/chat/ChatEnvironmentOverview.tsx
@@ -120,7 +120,7 @@ export function ChatEnvironmentOverview({
 
   const panel = (
     <div
-      className="chat-environment-panel fixed right-3 top-[52px] z-[2147483000] max-h-[calc(100vh-68px)] w-[360px] max-w-[calc(100vw-24px)] overflow-y-auto rounded-xl border p-3 text-sm shadow-[0_28px_90px_rgba(0,0,0,0.92)]"
+      className="chat-environment-panel fixed right-3 top-[52px] z-[2147483000] max-h-[calc(100vh-68px)] w-[360px] max-w-[calc(100vw-24px)] overflow-y-auto rounded-xl border p-3 text-sm"
       data-session-id={sessionId || "new-chat"}
       data-testid="chat-environment-overview"
       style={{

--- a/ui/src/pages/chat/ChatMessageTimeline.tsx
+++ b/ui/src/pages/chat/ChatMessageTimeline.tsx
@@ -40,6 +40,7 @@ interface VisibleMessageEntry {
 }
 
 interface ChatMessageTimelineProps {
+  compact?: boolean;
   copiedMessageIndex: number | null;
   entries: VisibleMessageEntry[];
   forkingMessageIndex: number | null;
@@ -65,6 +66,7 @@ interface ChatMessageTimelineProps {
 }
 
 export function ChatMessageTimeline({
+  compact = false,
   copiedMessageIndex,
   entries,
   forkingMessageIndex,
@@ -232,7 +234,7 @@ export function ChatMessageTimeline({
                     <Copy className="h-3 w-3" />
                   )}
                 </button>
-                {message.role === "assistant" && message.content.trim() && (
+                {!compact && message.role === "assistant" && message.content.trim() && (
                   <button
                     type="button"
                     onClick={() => onReadAloud(originalIndex, message.content)}
@@ -251,7 +253,7 @@ export function ChatMessageTimeline({
                     )}
                   </button>
                 )}
-                {sessionId && (
+                {!compact && sessionId && (
                   <button
                     type="button"
                     onClick={() => onForkSession(originalIndex)}
@@ -267,7 +269,7 @@ export function ChatMessageTimeline({
                     )}
                   </button>
                 )}
-                {message.role === "assistant" && sessionId && goldenTurnsEnabled && (
+                {!compact && message.role === "assistant" && sessionId && goldenTurnsEnabled && (
                   <button
                     type="button"
                     onClick={() => onSaveGolden(originalIndex)}
@@ -283,7 +285,7 @@ export function ChatMessageTimeline({
                     )}
                   </button>
                 )}
-                {message.role === "user" && sessionId && (
+                {!compact && message.role === "user" && sessionId && (
                   <button
                     type="button"
                     onClick={() =>

--- a/ui/src/pages/chat/ChatPageHeader.tsx
+++ b/ui/src/pages/chat/ChatPageHeader.tsx
@@ -1,4 +1,4 @@
-import { FileText, PanelRightOpen, Share2, SlidersHorizontal } from "lucide-react";
+import { FileText, LayoutGrid, PanelRightOpen, Share2, SlidersHorizontal } from "lucide-react";
 import type { ComponentProps, ReactElement } from "react";
 import { cn } from "@/lib/utils";
 import { ChatEnvironmentOverview } from "./ChatEnvironmentOverview";
@@ -16,6 +16,7 @@ interface ChatPageHeaderProps {
   workspacePanelOpen: boolean;
   subagentsActive: boolean;
   onOpenNearbyShare: () => void;
+  onOpenMultiChat: () => void;
   onToggleEnvironment: () => void;
   onToggleFileReview: () => void;
   onToggleSubagents: () => void;
@@ -32,6 +33,7 @@ export function ChatPageHeader({
   workspacePanelOpen,
   subagentsActive,
   onOpenNearbyShare,
+  onOpenMultiChat,
   onToggleEnvironment,
   onToggleFileReview,
   onToggleSubagents,
@@ -44,6 +46,15 @@ export function ChatPageHeader({
       </div>
       <div className="flex items-center gap-1 sm:gap-2">
         <WorkspaceOpenMenu {...workspaceMenu} />
+        <button
+          type="button"
+          aria-label="Open multi-chat"
+          onClick={onOpenMultiChat}
+          className="theme-muted-icon-button relative cursor-pointer rounded-lg p-1.5 transition-colors sm:p-2"
+          title="Open multi-chat"
+        >
+          <LayoutGrid className="h-4 w-4" />
+        </button>
         {nearbyEnabled ? (
           <button
             type="button"

--- a/ui/src/pages/chat/ChatReasoningControl.tsx
+++ b/ui/src/pages/chat/ChatReasoningControl.tsx
@@ -21,10 +21,21 @@ const LEVEL_HINTS: Record<string, string> = {
   max: "Maximum thinking depth, slowest",
 };
 
+const EFFORT_LABELS: Record<AgentReasoningEffort, string> = {
+  minimal: "Minimal",
+  low: "Low",
+  medium: "Medium",
+  high: "High",
+  xhigh: "Extra High",
+  max: "Max",
+};
+
 export function ChatReasoningControl({
   effort,
   provider,
   model,
+  mode,
+  supportedEfforts,
   disabled,
   updating,
   onChange,
@@ -32,6 +43,8 @@ export function ChatReasoningControl({
   effort?: AgentReasoningEffort | null;
   provider?: string | null;
   model?: string | null;
+  mode?: "adaptive" | "binary" | "effort";
+  supportedEfforts?: AgentReasoningEffort[];
   disabled?: boolean;
   updating?: boolean;
   onChange: (effort: AgentReasoningEffort | null) => void;
@@ -43,14 +56,26 @@ export function ChatReasoningControl({
   const rootRef = useRef<HTMLDivElement>(null);
   const trackRef = useRef<HTMLDivElement>(null);
 
-  const options = useMemo<ReasoningOption[]>(
-    () =>
-      supportedReasoningOptions(provider, model).map((option) => ({
-        value: option.value === "" ? null : option.value,
-        label: option.label,
-      })),
-    [provider, model]
-  );
+  const options = useMemo<ReasoningOption[]>(() => {
+    const resolved =
+      mode === "adaptive"
+        ? [{ value: "" as const, label: "Adaptive" }]
+        : mode === "binary"
+          ? [
+              { value: "" as const, label: "Default" },
+              { value: "medium" as const, label: "Thinking" },
+            ]
+          : supportedEfforts
+            ? [
+                { value: "" as const, label: "Default" },
+                ...supportedEfforts.map((value) => ({ value, label: EFFORT_LABELS[value] })),
+              ]
+            : supportedReasoningOptions(provider, model);
+    return resolved.map((option) => ({
+      value: option.value === "" ? null : option.value,
+      label: option.label,
+    }));
+  }, [mode, model, provider, supportedEfforts]);
   const currentIndex = useMemo(() => {
     const index = options.findIndex((option) => option.value === (effort ?? null));
     return index >= 0 ? index : 0;

--- a/ui/src/pages/chat/ChatReasoningControl.tsx
+++ b/ui/src/pages/chat/ChatReasoningControl.tsx
@@ -1,13 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Brain, HelpCircle, Loader2 } from "lucide-react";
 import type { AgentReasoningEffort } from "@/types";
-import { supportedReasoningOptions } from "@/lib/reasoning";
 import { cn } from "@/lib/utils";
-
-interface ReasoningOption {
-  value: AgentReasoningEffort | null;
-  label: string;
-}
+import { resolveChatReasoningOptions } from "./chatReasoningOptions";
 
 const LEVEL_HINTS: Record<string, string> = {
   default: "Follows the provider's own setting",
@@ -19,15 +14,6 @@ const LEVEL_HINTS: Record<string, string> = {
   high: "Deeper reasoning for harder tasks",
   "extra high": "Extensive reasoning, slower",
   max: "Maximum thinking depth, slowest",
-};
-
-const EFFORT_LABELS: Record<AgentReasoningEffort, string> = {
-  minimal: "Minimal",
-  low: "Low",
-  medium: "Medium",
-  high: "High",
-  xhigh: "Extra High",
-  max: "Max",
 };
 
 export function ChatReasoningControl({
@@ -56,26 +42,10 @@ export function ChatReasoningControl({
   const rootRef = useRef<HTMLDivElement>(null);
   const trackRef = useRef<HTMLDivElement>(null);
 
-  const options = useMemo<ReasoningOption[]>(() => {
-    const resolved =
-      mode === "adaptive"
-        ? [{ value: "" as const, label: "Adaptive" }]
-        : mode === "binary"
-          ? [
-              { value: "" as const, label: "Default" },
-              { value: "medium" as const, label: "Thinking" },
-            ]
-          : supportedEfforts
-            ? [
-                { value: "" as const, label: "Default" },
-                ...supportedEfforts.map((value) => ({ value, label: EFFORT_LABELS[value] })),
-              ]
-            : supportedReasoningOptions(provider, model);
-    return resolved.map((option) => ({
-      value: option.value === "" ? null : option.value,
-      label: option.label,
-    }));
-  }, [mode, model, provider, supportedEfforts]);
+  const options = useMemo(
+    () => resolveChatReasoningOptions(provider, model, mode, supportedEfforts),
+    [mode, model, provider, supportedEfforts]
+  );
   const currentIndex = useMemo(() => {
     const index = options.findIndex((option) => option.value === (effort ?? null));
     return index >= 0 ? index : 0;

--- a/ui/src/pages/chat/ContextUsageRing.tsx
+++ b/ui/src/pages/chat/ContextUsageRing.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useId, useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import type { ProviderPlanSnapshot, SessionContextUsage } from "@/types";
 import {
   providerPlanUsageClasses,
@@ -137,6 +138,13 @@ export function ContextUsageRing({
   providerPlan?: ProviderPlanSnapshot | null;
 }) {
   const [open, setOpen] = useState(false);
+  const [position, setPosition] = useState<{
+    left: number;
+    placement: "above" | "below";
+    top: number;
+  } | null>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const tooltipId = useId();
   const percent = usage ? Math.min(100, Math.max(0, usage.usedPercent)) : 0;
   const color =
     percent >= 90
@@ -146,54 +154,98 @@ export function ContextUsageRing({
         : "var(--context-ring-ok)";
   const tooltip = contextUsageTooltip(usage, providerPlan);
   const label = contextUsageLabel(usage);
-  const tooltipClassName = [
-    "context-usage-tooltip pointer-events-none absolute bottom-full left-1/2 z-50 mb-3 w-max max-w-[280px] -translate-x-1/2 rounded-lg border px-3 py-2 text-center text-[12px] leading-5",
-    open ? "block" : "hidden",
-  ].join(" ");
-  return (
-    <button
-      type="button"
-      aria-label={label}
-      aria-expanded={open}
-      className="relative h-5 w-5 shrink-0 appearance-none rounded-full border-0 bg-transparent p-0 outline-none"
-      onBlur={() => setOpen(false)}
-      onClick={() => setOpen(true)}
-      onFocus={() => setOpen(true)}
-      onMouseEnter={() => setOpen(true)}
-      onMouseLeave={() => setOpen(false)}
-      tabIndex={0}
+  useLayoutEffect(() => {
+    if (!open) {
+      setPosition(null);
+      return;
+    }
+    const updatePosition = (): void => {
+      const trigger = triggerRef.current;
+      if (!trigger) return;
+      const rect = trigger.getBoundingClientRect();
+      const tooltipWidth = Math.min(280, window.innerWidth - 16);
+      const halfWidth = tooltipWidth / 2;
+      const placement = rect.top >= 180 ? "above" : "below";
+      setPosition({
+        left: Math.min(
+          window.innerWidth - halfWidth - 8,
+          Math.max(halfWidth + 8, rect.left + rect.width / 2)
+        ),
+        placement,
+        top: placement === "above" ? rect.top - 10 : rect.bottom + 10,
+      });
+    };
+    updatePosition();
+    window.addEventListener("resize", updatePosition);
+    window.addEventListener("scroll", updatePosition, true);
+    return () => {
+      window.removeEventListener("resize", updatePosition);
+      window.removeEventListener("scroll", updatePosition, true);
+    };
+  }, [open]);
+
+  const tooltipContent = position ? (
+    <div
+      id={tooltipId}
+      role="tooltip"
+      className="context-usage-tooltip pointer-events-none fixed z-[200] w-max max-w-[min(280px,calc(100vw-16px))] rounded-lg border px-3 py-2 text-center text-[12px] leading-5"
+      style={{
+        left: position.left,
+        top: position.top,
+        transform: position.placement === "above" ? "translate(-50%, -100%)" : "translateX(-50%)",
+      }}
     >
-      <div
-        className="absolute inset-[3px] rounded-full p-[1.5px]"
-        style={{
-          background: `conic-gradient(${color} ${percent * 3.6}deg, var(--context-ring-track) 0deg)`,
-        }}
+      <div className="context-usage-tooltip-title">{tooltip.title}</div>
+      <div className="context-usage-tooltip-body font-medium">{tooltip.body}</div>
+      <div className="context-usage-tooltip-detail">{tooltip.detail}</div>
+      {tooltip.detailRows.length > 0 && (
+        <div className="mt-1 space-y-0.5 text-left text-[11px] leading-4">
+          {tooltip.detailRows.map((row) => (
+            <div key={row} className="context-usage-tooltip-detail">
+              {row}
+            </div>
+          ))}
+        </div>
+      )}
+      {tooltip.planRows.length > 0 && (
+        <div className="context-usage-tooltip-plan mt-2 space-y-1.5 border-t pt-2 text-left">
+          <div className="text-[11px] font-medium">Plan usage</div>
+          {tooltip.planRows.map(({ label, usage }) => (
+            <ProviderPlanTooltipBar key={label} label={label} usage={usage} />
+          ))}
+          {tooltip.planDetail && <div className="sr-only">Plan usage: {tooltip.planDetail}</div>}
+        </div>
+      )}
+    </div>
+  ) : null;
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        aria-label={label}
+        aria-describedby={open ? tooltipId : undefined}
+        aria-expanded={open}
+        className="relative h-5 w-5 shrink-0 appearance-none rounded-full border-0 bg-transparent p-0 outline-none"
+        onBlur={() => setOpen(false)}
+        onClick={() => setOpen((current) => !current)}
+        onFocus={() => setOpen(true)}
+        onMouseEnter={() => setOpen(true)}
+        onMouseLeave={() => setOpen(false)}
+        tabIndex={0}
       >
-        <div className="context-usage-ring-fill h-full w-full rounded-full" />
-      </div>
-      <div role="tooltip" className={tooltipClassName}>
-        <div className="context-usage-tooltip-title">{tooltip.title}</div>
-        <div className="context-usage-tooltip-body font-medium">{tooltip.body}</div>
-        <div className="context-usage-tooltip-detail">{tooltip.detail}</div>
-        {tooltip.detailRows.length > 0 && (
-          <div className="mt-1 space-y-0.5 text-left text-[11px] leading-4">
-            {tooltip.detailRows.map((row) => (
-              <div key={row} className="context-usage-tooltip-detail">
-                {row}
-              </div>
-            ))}
-          </div>
-        )}
-        {tooltip.planRows.length > 0 && (
-          <div className="context-usage-tooltip-plan mt-2 space-y-1.5 border-t pt-2 text-left">
-            <div className="text-[11px] font-medium">Plan usage</div>
-            {tooltip.planRows.map(({ label, usage }) => (
-              <ProviderPlanTooltipBar key={label} label={label} usage={usage} />
-            ))}
-            {tooltip.planDetail && <div className="sr-only">Plan usage: {tooltip.planDetail}</div>}
-          </div>
-        )}
-      </div>
-    </button>
+        <div
+          className="absolute inset-[3px] rounded-full p-[1.5px]"
+          style={{
+            background: `conic-gradient(${color} ${percent * 3.6}deg, var(--context-ring-track) 0deg)`,
+          }}
+        >
+          <div className="context-usage-ring-fill h-full w-full rounded-full" />
+        </div>
+      </button>
+      {tooltipContent && typeof document !== "undefined"
+        ? createPortal(tooltipContent, document.body)
+        : null}
+    </>
   );
 }

--- a/ui/src/pages/chat/MultiChatPaneEnvironment.tsx
+++ b/ui/src/pages/chat/MultiChatPaneEnvironment.tsx
@@ -1,0 +1,215 @@
+import type { LoadedChatSession } from "@/hooks/useChat";
+import type { AgentSummary } from "@/types";
+import {
+  Activity,
+  Brain,
+  Database,
+  FolderOpen,
+  Gauge,
+  MessageSquare,
+  Replace,
+  Route,
+} from "lucide-react";
+import type { ReactNode } from "react";
+
+function compactNumber(value?: number): string {
+  if (!value) return "0";
+  return Intl.NumberFormat(undefined, { notation: "compact", maximumFractionDigits: 1 }).format(
+    value
+  );
+}
+
+function formatMilliseconds(value?: number | null): string {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) return "—";
+  if (value < 1_000) return `${Math.round(value)}ms`;
+  return `${(value / 1_000).toFixed(value < 10_000 ? 1 : 0)}s`;
+}
+
+function EnvironmentValue({
+  children,
+  multiline = false,
+  title,
+}: {
+  children: ReactNode;
+  multiline?: boolean;
+  title?: string;
+}) {
+  return (
+    <span
+      className={
+        multiline
+          ? "min-w-0 break-words text-right text-[10px] leading-4 text-[var(--text-secondary)]"
+          : "min-w-0 truncate text-right text-[11px] text-[var(--text-secondary)]"
+      }
+      title={title}
+    >
+      {children}
+    </span>
+  );
+}
+
+function EnvironmentRow({
+  icon,
+  label,
+  children,
+  multiline = false,
+  title,
+}: {
+  icon: ReactNode;
+  label: string;
+  children: ReactNode;
+  multiline?: boolean;
+  title?: string;
+}) {
+  return (
+    <div className="grid grid-cols-[16px_minmax(0,1fr)_minmax(0,1.25fr)] items-center gap-2 py-1.5">
+      <span className="text-[var(--icon-muted)]">{icon}</span>
+      <span className="text-[11px] text-[var(--text-muted)]">{label}</span>
+      <EnvironmentValue multiline={multiline} title={title}>
+        {children}
+      </EnvironmentValue>
+    </div>
+  );
+}
+
+function UsageStat({ label, value }: { label: string; value: string }) {
+  return (
+    <span className="min-w-0 rounded-md bg-[var(--surface-raised)] px-2 py-1.5">
+      <span className="theme-text-muted block truncate text-[9px] uppercase">{label}</span>
+      <span className="theme-text-primary mt-0.5 block truncate text-[11px] font-semibold tabular-nums">
+        {value}
+      </span>
+    </span>
+  );
+}
+
+export function MultiChatPaneEnvironment({
+  agent,
+  detail,
+  draft,
+  messageCount,
+  statusLabel,
+  onReplace,
+}: {
+  agent?: AgentSummary;
+  detail?: LoadedChatSession;
+  draft: boolean;
+  messageCount: number;
+  statusLabel: string;
+  onReplace: () => void;
+}) {
+  const contextUsage = detail?.contextUsage;
+  const tokenUsage = detail?.tokenUsage;
+  const routeLabel = detail?.use_model_router
+    ? "Model Router"
+    : agent?.name || detail?.provider_name || detail?.provider || "Gateway default";
+  const modelLabel = agent?.model || detail?.model || "Automatic";
+  const providerLabel = detail?.provider_name || detail?.provider || agent?.provider || "Automatic";
+  const workspace = detail?.workspace_dir || "No workspace";
+  const contextPercent = contextUsage ? Math.min(100, Math.max(0, contextUsage.usedPercent)) : 0;
+
+  return (
+    <aside
+      className="absolute left-2 right-2 top-[52px] z-50 rounded-lg border border-[var(--surface-border)] bg-[var(--surface-panel)] p-3 sm:left-auto sm:w-80"
+      data-testid="multi-chat-environment"
+    >
+      <div className="mb-2 flex items-center justify-between gap-3 border-b border-[var(--surface-border)] pb-2">
+        <span>
+          <span className="theme-text-primary block text-xs font-semibold">Environment</span>
+          <span className="theme-text-muted block text-[10px]">
+            {draft ? "New chat" : statusLabel}
+          </span>
+        </span>
+        <button
+          type="button"
+          onClick={onReplace}
+          className="theme-muted-icon-button inline-flex h-7 items-center gap-1.5 rounded-md px-2 text-[10px]"
+        >
+          <Replace className="h-3 w-3" />
+          Replace
+        </button>
+      </div>
+      <div className="divide-y divide-[var(--surface-border)]">
+        <EnvironmentRow icon={<Route className="h-3.5 w-3.5" />} label="Agent">
+          {routeLabel}
+        </EnvironmentRow>
+        <EnvironmentRow icon={<Brain className="h-3.5 w-3.5" />} label="Model">
+          {modelLabel}
+        </EnvironmentRow>
+        <EnvironmentRow icon={<Database className="h-3.5 w-3.5" />} label="Provider">
+          {providerLabel}
+        </EnvironmentRow>
+        <EnvironmentRow
+          icon={<FolderOpen className="h-3.5 w-3.5" />}
+          label="Workspace"
+          multiline
+          title={workspace}
+        >
+          {workspace}
+        </EnvironmentRow>
+        <EnvironmentRow icon={<Activity className="h-3.5 w-3.5" />} label="Status">
+          {draft ? "Draft" : statusLabel}
+        </EnvironmentRow>
+        <EnvironmentRow icon={<MessageSquare className="h-3.5 w-3.5" />} label="Messages">
+          {messageCount}
+        </EnvironmentRow>
+        <EnvironmentRow icon={<Gauge className="h-3.5 w-3.5" />} label="Context">
+          {contextUsage
+            ? `${compactNumber(contextUsage.usedTokens)} / ${compactNumber(contextUsage.limitTokens)}`
+            : "Not available"}
+        </EnvironmentRow>
+        <EnvironmentRow icon={<Gauge className="h-3.5 w-3.5" />} label="Tokens">
+          {tokenUsage ? compactNumber(tokenUsage.totalTokens) : "Not available"}
+        </EnvironmentRow>
+      </div>
+      {contextUsage ? (
+        <div className="mt-2">
+          <div className="h-1 overflow-hidden rounded-full bg-[var(--surface-raised)]">
+            <div
+              className="h-full rounded-full bg-[rgb(var(--accent-primary))]"
+              style={{ width: `${Math.max(2, contextPercent)}%` }}
+            />
+          </div>
+          <div className="theme-text-muted mt-1 flex justify-between text-[9px] tabular-nums">
+            <span>{Math.round(contextPercent)}% context used</span>
+            <span>{compactNumber(contextUsage.remainingTokens)} remaining</span>
+          </div>
+        </div>
+      ) : null}
+      <div className="mt-2 grid grid-cols-3 gap-1.5">
+        <UsageStat label="Input" value={tokenUsage ? compactNumber(tokenUsage.inputTokens) : "—"} />
+        <UsageStat
+          label="Output"
+          value={tokenUsage ? compactNumber(tokenUsage.outputTokens) : "—"}
+        />
+        <UsageStat
+          label="Cache read"
+          value={tokenUsage ? compactNumber(tokenUsage.cachedInputTokens) : "—"}
+        />
+        <UsageStat
+          label="Cache write"
+          value={tokenUsage ? compactNumber(tokenUsage.cacheWriteTokens) : "—"}
+        />
+        <UsageStat
+          label="Cache hit"
+          value={
+            tokenUsage?.cacheHitRate === null || tokenUsage?.cacheHitRate === undefined
+              ? "—"
+              : `${tokenUsage.cacheHitRate}%`
+          }
+        />
+        <UsageStat label="Calls" value={tokenUsage ? compactNumber(tokenUsage.callCount) : "—"} />
+        <UsageStat
+          label="Speed"
+          value={
+            tokenUsage?.tokensPerSecond === null || tokenUsage?.tokensPerSecond === undefined
+              ? "—"
+              : `${tokenUsage.tokensPerSecond.toFixed(1)}/s`
+          }
+        />
+        <UsageStat label="TTFT" value={formatMilliseconds(tokenUsage?.firstTokenMs)} />
+        <UsageStat label="Duration" value={formatMilliseconds(tokenUsage?.durationMs)} />
+      </div>
+    </aside>
+  );
+}

--- a/ui/src/pages/chat/MultiChatWorkspace.tsx
+++ b/ui/src/pages/chat/MultiChatWorkspace.tsx
@@ -1,0 +1,1251 @@
+import { Modal } from "@/components/ui";
+import { useAgentSummaries, useUpdateAgentReasoning } from "@/hooks/useApi";
+import {
+  useChat,
+  useSessionDetail,
+  useSessions,
+  useUpdateSessionAgent,
+  SESSION_DETAIL_QUERY_KEY,
+} from "@/hooks/useChat";
+import { chatApi, routerApi, settingsApi } from "@/lib/api";
+import {
+  connectStatusStream,
+  type StatusStreamEvent,
+  type StreamAgentStatus,
+} from "@/lib/status-stream";
+import { cn } from "@/lib/utils";
+import { useUIStore } from "@/stores/uiStore";
+import { openExternal } from "@/utils/openExternal";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  ArrowUpRight,
+  GripVertical,
+  LayoutGrid,
+  Loader2,
+  MessageSquare,
+  MessageSquarePlus,
+  Mic,
+  MicOff,
+  Paperclip,
+  Plus,
+  Search,
+  Send,
+  SlidersHorizontal,
+  Square,
+  X,
+} from "lucide-react";
+import {
+  type FormEvent,
+  type KeyboardEvent,
+  useCallback,
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import type { ChatLightboxImage } from "./ChatImageLightbox";
+import { ChatAgentControls, MODEL_ROUTER_SELECTOR_VALUE } from "./ChatAgentControls";
+import { ChatComposerAttachments } from "./ChatComposerAttachments";
+import {
+  ChatApprovalControls,
+  normalizeToolApprovalMode,
+  type ToolApprovalMode,
+} from "./ChatFollowUpControls";
+import { ChatImageLightbox } from "./ChatImageLightbox";
+import { ChatMessageTimeline } from "./ChatMessageTimeline";
+import { MultiChatPaneEnvironment } from "./MultiChatPaneEnvironment";
+import { ChatReasoningControl } from "./ChatReasoningControl";
+import type { ChatMessage } from "./chatModel";
+import { sessionDisplayTitle, sessionPreviewText, sessionRouteLabel } from "./chatModel";
+import {
+  addMultiChatSession,
+  buildMultiChatPath,
+  MULTI_CHAT_DRAG_TYPE,
+  MULTI_CHAT_MAX_PANES,
+  MULTI_CHAT_MIN_SLOTS,
+  normalizeMultiChatSessionIds,
+  parseMultiChatSessionIds,
+  persistMultiChatSessionIds,
+  readPersistedMultiChatSessionIds,
+  reorderMultiChatSessions,
+  replaceMultiChatSession,
+  resolveActiveMultiChatDropIndex,
+} from "./multiChatLayout";
+import { useMultiChatDropTarget } from "./useMultiChatDropTarget";
+import { useChatAttachments } from "./useChatAttachments";
+import { useChatDictation } from "./useChatDictation";
+import type { AgentSummary } from "@/types";
+import type { ChatSidebarSession } from "./sessionGrouping";
+
+const MULTI_CHAT_RENDERED_MESSAGE_LIMIT = 80;
+const MULTI_CHAT_REFRESH_THROTTLE_MS = 750;
+const ACTIVE_STATUSES = new Set<StreamAgentStatus>([
+  "thinking",
+  "generating",
+  "tool_executing",
+  "compacting",
+]);
+
+interface MultiChatPaneStatus {
+  status: StreamAgentStatus;
+  detail?: string;
+  timestamp: number;
+}
+
+interface MultiChatPickerProps {
+  isOpen: boolean;
+  sessions: ChatSidebarSession[];
+  selectedIds: string[];
+  onClose: () => void;
+  onSelect: (sessionId: string) => void;
+}
+
+interface MultiChatPaneProps {
+  dropActive: boolean;
+  agents: AgentSummary[];
+  approvalMode: ToolApprovalMode;
+  approvalUpdating: boolean;
+  environmentOpen: boolean;
+  index: number;
+  modelRouterEnabled: boolean;
+  sessionId: string;
+  summary?: ChatSidebarSession;
+  status?: MultiChatPaneStatus;
+  onDropSession: (sessionId: string, index: number) => void;
+  onDropTargetChange: (index: number, active: boolean) => void;
+  onApprovalChange: (mode: ToolApprovalMode) => void;
+  onOpenPicker: (index: number) => void;
+  onOpenImage: (src: string, alt: string) => void;
+  onRemove: (sessionId: string) => void;
+  onReplaceSession: (previousSessionId: string, nextSessionId: string) => void;
+  onRefresh: (sessionId: string) => void;
+  onToggleEnvironment: (sessionId: string) => void;
+}
+
+const MULTI_CHAT_DRAFT_PREFIX = "draft-";
+
+function createMultiChatDraftId(): string {
+  return `${MULTI_CHAT_DRAFT_PREFIX}${crypto.randomUUID()}`;
+}
+
+function arraysEqual(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+function multiChatStatusLabel(status?: MultiChatPaneStatus): string {
+  if (!status || !ACTIVE_STATUSES.has(status.status)) return "Ready";
+  if (status.status === "tool_executing") return status.detail || "Using tools";
+  if (status.status === "compacting") return "Compacting context";
+  if (status.status === "generating") return "Responding";
+  return status.detail || "Thinking";
+}
+
+function sessionSearchText(session: ChatSidebarSession): string {
+  const record = session as unknown as Record<string, unknown>;
+  return [
+    sessionDisplayTitle(record),
+    sessionRouteLabel(record),
+    session.workspace_dir,
+    sessionPreviewText(session.last_message?.content),
+  ]
+    .filter((value): value is string => typeof value === "string")
+    .join(" ")
+    .toLowerCase();
+}
+
+function MultiChatPicker({
+  isOpen,
+  sessions,
+  selectedIds,
+  onClose,
+  onSelect,
+}: MultiChatPickerProps) {
+  const [query, setQuery] = useState("");
+  const deferredQuery = useDeferredValue(query.trim().toLowerCase());
+  const selectedIdSet = useMemo(() => new Set(selectedIds), [selectedIds]);
+  const results = useMemo(
+    () =>
+      sessions
+        .filter(
+          (session) =>
+            !selectedIdSet.has(session.id) &&
+            (!deferredQuery || sessionSearchText(session).includes(deferredQuery))
+        )
+        .slice(0, 30),
+    [deferredQuery, selectedIdSet, sessions]
+  );
+
+  const closePicker = () => {
+    setQuery("");
+    onClose();
+  };
+
+  const selectSession = (sessionId: string) => {
+    setQuery("");
+    onSelect(sessionId);
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={closePicker} size="md" surface="bare" backdrop="subtle">
+      <div className="space-y-2" data-testid="multi-chat-picker">
+        <div className="theme-tooltip-panel relative rounded-xl p-2 shadow-2xl">
+          <Search className="theme-text-subtle absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2" />
+          <input
+            type="text"
+            role="searchbox"
+            aria-label="Search chats to add"
+            data-autofocus
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key !== "Enter" || !results[0]) return;
+              event.preventDefault();
+              selectSession(results[0].id);
+            }}
+            placeholder="Search chats to add…"
+            className="themed-form-control w-full rounded-lg !border-0 py-2.5 pl-10 pr-9 text-sm !outline-none !ring-0 !shadow-none hover:!border-0 focus:!border-0 focus:!outline-none focus:!ring-0 focus:!shadow-none"
+          />
+          {query ? (
+            <button
+              type="button"
+              onClick={() => setQuery("")}
+              className="theme-muted-icon-button absolute right-2.5 top-1/2 -translate-y-1/2"
+              aria-label="Clear chat search"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          ) : null}
+        </div>
+        <div className="theme-tooltip-panel max-h-[min(65vh,34rem)] space-y-1 overflow-y-auto rounded-xl p-1 shadow-2xl">
+          {results.length ? (
+            results.map((session) => {
+              const record = session as unknown as Record<string, unknown>;
+              return (
+                <button
+                  key={session.id}
+                  type="button"
+                  onClick={() => selectSession(session.id)}
+                  className="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left transition-colors hover:bg-[var(--surface-hover)]"
+                >
+                  <MessageSquare className="theme-text-subtle h-4 w-4 shrink-0" />
+                  <span className="min-w-0 flex-1">
+                    <span className="theme-text-primary block truncate text-sm font-medium">
+                      {sessionDisplayTitle(record)}
+                    </span>
+                    <span className="theme-text-muted block truncate text-xs">
+                      {[session.workspace_dir, sessionRouteLabel(record)]
+                        .filter(Boolean)
+                        .join(" · ") || "No workspace"}
+                    </span>
+                  </span>
+                </button>
+              );
+            })
+          ) : (
+            <div className="theme-text-muted py-8 text-center text-sm">No matching chats</div>
+          )}
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+function MultiChatPane({
+  agents,
+  approvalMode,
+  approvalUpdating,
+  dropActive,
+  environmentOpen,
+  index,
+  modelRouterEnabled,
+  sessionId,
+  summary,
+  status,
+  onApprovalChange,
+  onDropSession,
+  onDropTargetChange,
+  onOpenPicker,
+  onOpenImage,
+  onRemove,
+  onReplaceSession,
+  onRefresh,
+  onToggleEnvironment,
+}: MultiChatPaneProps) {
+  const navigate = useNavigate();
+  const isDraft = sessionId.startsWith(MULTI_CHAT_DRAFT_PREFIX);
+  const detailQuery = useSessionDetail(sessionId, !isDraft);
+  const detail = detailQuery.data;
+  const updateSessionAgent = useUpdateSessionAgent();
+  const updateAgentReasoning = useUpdateAgentReasoning();
+  const [selectedAgentId, setSelectedAgentId] = useState<string | undefined>();
+  const [useModelRouter, setUseModelRouter] = useState(false);
+  const [draft, setDraft] = useState("");
+  const {
+    messages: liveMessages,
+    isLoading: responsePending,
+    loadSession,
+    sendMessage,
+    stopGenerating,
+  } = useChat(selectedAgentId || detail?.agent_id, { useModelRouter });
+  const {
+    addAttachmentFiles,
+    consumeAttachments,
+    handleComposerDrop,
+    handleComposerPaste,
+    imageDragActive,
+    pendingFiles,
+    pendingImages,
+    removePendingFile,
+    removePendingImage,
+    setImageDragActive,
+  } = useChatAttachments();
+  const {
+    dictating,
+    error: dictationError,
+    handleToggle: handleToggleDictation,
+    runtime: dictationRuntime,
+    status: dictationStatus,
+    transcribing: dictationTranscribing,
+  } = useChatDictation(setDraft);
+  const [sending, setSending] = useState(false);
+  const [copiedIndex, setCopiedIndex] = useState<number | null>(null);
+  const [autoFollow, setAutoFollow] = useState(true);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const endRef = useRef<HTMLDivElement>(null);
+  const imageInputRef = useRef<HTMLInputElement>(null);
+  const dropTarget = useMultiChatDropTarget({
+    active: dropActive,
+    index,
+    onDropSession,
+    onTargetChange: onDropTargetChange,
+  });
+  const isActive = !!status && ACTIVE_STATUSES.has(status.status);
+  const selectedAgent = agents.find((agent) => agent.id === (selectedAgentId || detail?.agent_id));
+
+  useEffect(() => {
+    if (!detail) return;
+    setSelectedAgentId(detail.agent_id || undefined);
+    setUseModelRouter(detail.use_model_router === true);
+  }, [detail]);
+
+  useEffect(() => {
+    if (isActive) setSending(false);
+  }, [isActive]);
+
+  useEffect(() => {
+    if (!detail || isDraft) return;
+    loadSession(sessionId, detail.messagesList, detail.workspace_dir || null, isActive);
+  }, [detail, isActive, isDraft, loadSession, sessionId]);
+
+  const messages = useMemo(
+    () => (liveMessages.length > 0 ? liveMessages : detail?.messagesList || []),
+    [detail?.messagesList, liveMessages]
+  );
+  const firstRenderedIndex = Math.max(0, messages.length - MULTI_CHAT_RENDERED_MESSAGE_LIMIT);
+  const visibleEntries = useMemo(
+    () =>
+      messages.slice(firstRenderedIndex).map((message, offset) => ({
+        message: message as ChatMessage,
+        originalIndex: firstRenderedIndex + offset,
+      })),
+    [firstRenderedIndex, messages]
+  );
+
+  useEffect(() => {
+    if (!autoFollow) return;
+    requestAnimationFrame(() => endRef.current?.scrollIntoView({ block: "end" }));
+  }, [autoFollow, messages.length, status?.detail, status?.status]);
+
+  const titleRecord = (detail || summary || { id: sessionId }) as unknown as Record<
+    string,
+    unknown
+  >;
+  const title = isDraft ? "New chat" : sessionDisplayTitle(titleRecord);
+  const route = isDraft
+    ? selectedAgent?.model || selectedAgent?.name || "Select an agent"
+    : sessionRouteLabel(titleRecord);
+
+  const handleSelectAgent = async (agentId?: string) => {
+    const previousAgentId = selectedAgentId;
+    const previousUseModelRouter = useModelRouter;
+    const nextUseModelRouter = agentId === MODEL_ROUTER_SELECTOR_VALUE;
+    const nextAgentId = nextUseModelRouter ? undefined : agentId;
+    setUseModelRouter(nextUseModelRouter);
+    setSelectedAgentId(nextAgentId);
+    if (isDraft) return;
+    try {
+      await updateSessionAgent.mutateAsync({
+        sessionId,
+        agentId: nextAgentId,
+        useModelRouter: nextUseModelRouter,
+      });
+      onRefresh(sessionId);
+    } catch (error) {
+      setSelectedAgentId(previousAgentId);
+      setUseModelRouter(previousUseModelRouter);
+      useUIStore
+        .getState()
+        .addToast(
+          "error",
+          error instanceof Error ? error.message : "Failed to update session agent"
+        );
+    }
+  };
+
+  const handleReasoningChange = async (effort: AgentSummary["reasoning_effort"]): Promise<void> => {
+    if (!selectedAgent) return;
+    try {
+      await updateAgentReasoning.mutateAsync({ id: selectedAgent.id, effort: effort ?? null });
+    } catch (error) {
+      useUIStore
+        .getState()
+        .addToast(
+          "error",
+          error instanceof Error ? error.message : "Failed to update reasoning effort"
+        );
+    }
+  };
+
+  const handleSend = async (event?: FormEvent) => {
+    event?.preventDefault();
+    const content = draft.trim();
+    const hasAttachments = pendingImages.length > 0 || pendingFiles.length > 0;
+    if ((!content && !hasAttachments) || sending) return;
+    const attachments = consumeAttachments(content);
+    setDraft("");
+    setSending(true);
+    setAutoFollow(true);
+    try {
+      const response = await sendMessage(attachments.message, {
+        ...(!isDraft ? { sessionId } : {}),
+        workspaceDir: detail?.workspace_dir || null,
+        queueMode: isActive ? "queue" : undefined,
+        images: attachments.images,
+      });
+      const resolvedSessionId = response?.sessionId;
+      if (isDraft && resolvedSessionId) {
+        onReplaceSession(sessionId, resolvedSessionId);
+        onRefresh(resolvedSessionId);
+      } else {
+        onRefresh(sessionId);
+      }
+    } catch (error) {
+      setDraft(content);
+      useUIStore
+        .getState()
+        .addToast("error", error instanceof Error ? error.message : "Failed to send message");
+    } finally {
+      setSending(false);
+    }
+  };
+
+  const handleStop = async () => {
+    try {
+      if (isDraft) return;
+      await chatApi.stopSession(sessionId);
+      stopGenerating(sessionId);
+      onRefresh(sessionId);
+    } catch (error) {
+      useUIStore
+        .getState()
+        .addToast("error", error instanceof Error ? error.message : "Failed to stop response");
+    }
+  };
+
+  return (
+    <section
+      className={cn(
+        "group/pane relative flex min-h-[24rem] min-w-0 flex-col overflow-hidden rounded-lg border bg-[var(--surface-panel)] transition-[border-color,background-color] duration-150 lg:min-h-0",
+        dropTarget.active
+          ? "border-[rgb(var(--accent-primary))] bg-[rgba(var(--accent-primary),0.06)]"
+          : "border-[var(--surface-border)]"
+      )}
+      data-testid="multi-chat-pane"
+      data-session-id={sessionId}
+      data-drop-active={dropTarget.active}
+      onDragEnter={dropTarget.onDragEnter}
+      onDragLeave={dropTarget.onDragLeave}
+      onDragOver={dropTarget.onDragOver}
+      onDrop={dropTarget.onDrop}
+    >
+      {dropTarget.active ? (
+        <div className="pointer-events-none absolute inset-1 z-40 flex items-center justify-center rounded-md border border-dashed border-[rgb(var(--accent-primary))] bg-[rgba(var(--surface-panel-rgb),0.9)]">
+          <span className="flex items-center gap-2 rounded-md bg-[rgb(var(--accent-primary))] px-3 py-2 text-xs font-semibold text-white">
+            <MessageSquarePlus className="h-4 w-4" />
+            Drop chat here
+          </span>
+        </div>
+      ) : null}
+      <header
+        draggable
+        onDragStart={(event) => {
+          event.dataTransfer.effectAllowed = "move";
+          event.dataTransfer.setData(MULTI_CHAT_DRAG_TYPE, sessionId);
+        }}
+        className="flex h-11 shrink-0 cursor-grab items-center gap-2 border-b border-[var(--surface-border)] px-2.5 active:cursor-grabbing"
+      >
+        <GripVertical className="theme-text-subtle h-4 w-4 shrink-0" />
+        <span className="min-w-0 flex-1">
+          <span className="theme-text-primary block truncate text-[13px] font-semibold">
+            {title}
+          </span>
+          <span className="theme-text-muted flex items-center gap-1.5 truncate text-[10px]">
+            {isActive ? <Loader2 className="h-2.5 w-2.5 shrink-0 animate-spin" /> : null}
+            <span className="truncate">
+              {isActive ? multiChatStatusLabel(status) : route || "Ready"}
+            </span>
+          </span>
+        </span>
+        <button
+          type="button"
+          className={cn(
+            "theme-muted-icon-button flex h-7 w-7 items-center justify-center rounded-md",
+            environmentOpen && "bg-[var(--surface-hover)] text-[var(--text-primary)]"
+          )}
+          onClick={() => onToggleEnvironment(sessionId)}
+          title="Environment"
+          aria-label={`${environmentOpen ? "Hide" : "Show"} environment for ${title}`}
+          aria-expanded={environmentOpen}
+        >
+          <SlidersHorizontal className="h-3.5 w-3.5" />
+        </button>
+        {!isDraft ? (
+          <button
+            type="button"
+            className="theme-muted-icon-button flex h-7 w-7 items-center justify-center rounded-md"
+            onClick={() => navigate(`/chat?session=${encodeURIComponent(sessionId)}`)}
+            title="Open full chat"
+            aria-label={`Open ${title} as full chat`}
+          >
+            <ArrowUpRight className="h-3.5 w-3.5" />
+          </button>
+        ) : null}
+        <button
+          type="button"
+          className="theme-muted-icon-button flex h-7 w-7 items-center justify-center rounded-md"
+          onClick={() => onRemove(sessionId)}
+          title="Close pane"
+          aria-label={`Close ${title}`}
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+      </header>
+
+      {environmentOpen ? (
+        <MultiChatPaneEnvironment
+          agent={selectedAgent}
+          detail={detail}
+          draft={isDraft}
+          messageCount={messages.length}
+          statusLabel={multiChatStatusLabel(status)}
+          onReplace={() => onOpenPicker(index)}
+        />
+      ) : null}
+
+      <div
+        ref={scrollRef}
+        onScroll={(event) => {
+          const element = event.currentTarget;
+          setAutoFollow(element.scrollHeight - element.scrollTop - element.clientHeight < 96);
+        }}
+        className="chat-scroll-region min-h-0 flex-1 overflow-y-auto px-4 py-3"
+      >
+        {!isDraft && detailQuery.isLoading && messages.length === 0 ? (
+          <div className="theme-text-muted flex h-full min-h-48 items-center justify-center gap-2 text-xs">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Loading chat…
+          </div>
+        ) : !isDraft && detailQuery.isError && messages.length === 0 ? (
+          <div className="flex h-full min-h-48 flex-col items-center justify-center gap-3 text-center">
+            <p className="text-sm text-red-300">Unable to load this chat.</p>
+            <button
+              type="button"
+              onClick={() => void detailQuery.refetch()}
+              className="rounded-md border border-[var(--surface-border)] px-3 py-1.5 text-xs text-[var(--text-secondary)] hover:bg-[var(--surface-hover)]"
+            >
+              Retry
+            </button>
+          </div>
+        ) : messages.length === 0 ? (
+          <div className="theme-text-muted flex h-full min-h-48 items-center justify-center text-sm">
+            {isDraft ? "Start a new conversation." : "This chat has no messages yet."}
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {firstRenderedIndex > 0 ? (
+              <button
+                type="button"
+                onClick={() => navigate(`/chat?session=${encodeURIComponent(sessionId)}`)}
+                className="theme-text-muted mx-auto block rounded-md px-3 py-1.5 text-xs hover:bg-[var(--surface-hover)] hover:text-[var(--text-primary)]"
+              >
+                Open full chat to view {firstRenderedIndex} earlier messages
+              </button>
+            ) : null}
+            <ChatMessageTimeline
+              compact
+              copiedMessageIndex={copiedIndex}
+              entries={visibleEntries}
+              forkingMessageIndex={null}
+              goldenTurnsEnabled={false}
+              liveActivities={[]}
+              liveCurrentStep={null}
+              liveStatus="idle"
+              messageProcessMap={{}}
+              savingGoldenMessageIndex={null}
+              sessionId={sessionId}
+              showWorkingTimeline={false}
+              speakingMessageIndex={null}
+              workspaceDir={detail?.workspace_dir || null}
+              onCopyMessage={(messageIndex, content) => {
+                void navigator.clipboard.writeText(content).then(() => {
+                  setCopiedIndex(messageIndex);
+                  window.setTimeout(() => setCopiedIndex(null), 1400);
+                });
+              }}
+              onForkSession={() => undefined}
+              onOpenArtifact={() => navigate(`/chat?session=${encodeURIComponent(sessionId)}`)}
+              onOpenImage={onOpenImage}
+              onOpenLink={(href) => {
+                void openExternal(href);
+                return true;
+              }}
+              onReadAloud={() => undefined}
+              onRevert={() => undefined}
+              onSaveGolden={() => undefined}
+            />
+            {isActive ? (
+              <div className="theme-text-muted flex items-center gap-2 py-1 text-xs">
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                <span className="truncate">{multiChatStatusLabel(status)}</span>
+              </div>
+            ) : null}
+            <div ref={endRef} />
+          </div>
+        )}
+      </div>
+
+      <form
+        onSubmit={(event) => void handleSend(event)}
+        className="chat-composer-responsive shrink-0 border-t border-[var(--surface-border)] p-2.5"
+      >
+        {dictationError || dictationStatus ? (
+          <div
+            className={cn(
+              "mb-1.5 truncate rounded-md px-2 py-1 text-[10px]",
+              dictationError ? "bg-red-500/10 text-red-300" : "bg-emerald-500/10 text-emerald-300"
+            )}
+            role={dictationError ? "alert" : "status"}
+          >
+            {dictationError || dictationStatus}
+          </div>
+        ) : null}
+        <div
+          className={cn(
+            "chat-composer-surface rounded-lg border px-3 py-2 transition-colors",
+            imageDragActive && "border-[rgba(var(--accent-primary),0.6)]"
+          )}
+          onDragOver={(event) => {
+            if (Array.from(event.dataTransfer?.items || []).some((item) => item.kind === "file")) {
+              event.preventDefault();
+              setImageDragActive(true);
+            }
+          }}
+          onDragLeave={() => setImageDragActive(false)}
+          onDrop={handleComposerDrop}
+        >
+          <ChatComposerAttachments
+            compact
+            imageInputRef={imageInputRef}
+            pendingFiles={pendingFiles}
+            pendingImages={pendingImages}
+            onAddAttachmentFiles={addAttachmentFiles}
+            onRemovePendingFile={removePendingFile}
+            onRemovePendingImage={removePendingImage}
+          />
+          <textarea
+            value={draft}
+            onChange={(event) => setDraft(event.target.value)}
+            onPaste={handleComposerPaste}
+            onKeyDown={(event: KeyboardEvent<HTMLTextAreaElement>) => {
+              if (event.key !== "Enter" || event.shiftKey || event.nativeEvent.isComposing) return;
+              event.preventDefault();
+              void handleSend();
+            }}
+            rows={1}
+            data-chat-composer-input="true"
+            placeholder={isActive ? "Queue a follow-up…" : "Message this chat…"}
+            aria-label={`Message ${title}`}
+            className="max-h-28 min-h-7 w-full resize-none border-0 bg-transparent text-sm text-[var(--text-primary)] !outline-none !ring-0 placeholder:text-[var(--form-control-placeholder)] focus:border-transparent focus:!outline-none focus:!ring-0 focus-visible:!outline-none"
+          />
+          <div className="mt-1 flex min-w-0 items-center gap-1">
+            <ChatApprovalControls
+              mode={approvalMode}
+              onChange={onApprovalChange}
+              updating={approvalUpdating}
+            />
+            <ChatAgentControls
+              agents={agents}
+              selectedAgentId={selectedAgentId || detail?.agent_id}
+              modelRouterEnabled={modelRouterEnabled}
+              useModelRouter={useModelRouter}
+              contextUsage={detail?.contextUsage}
+              onSelectAgent={(agentId) => void handleSelectAgent(agentId)}
+              updating={updateSessionAgent.isPending}
+              controlId={`multi-chat-agent-selector-${index}`}
+            />
+            <span className="min-w-0 flex-1" />
+            <ChatReasoningControl
+              effort={selectedAgent?.reasoning_effort}
+              provider={
+                selectedAgent?.provider_type ??
+                selectedAgent?.provider ??
+                selectedAgent?.provider_id
+              }
+              model={selectedAgent?.model}
+              mode={selectedAgent?.reasoning_mode}
+              supportedEfforts={selectedAgent?.reasoning_efforts}
+              disabled={!selectedAgent || useModelRouter}
+              updating={updateAgentReasoning.isPending}
+              onChange={(effort) => void handleReasoningChange(effort)}
+            />
+            <button
+              type="button"
+              onClick={() => imageInputRef.current?.click()}
+              className="composer-icon-btn flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-transparent text-[var(--icon-muted)] hover:text-[var(--text-primary)]"
+              title="Attach image or file"
+              aria-label={`Attach image or file to ${title}`}
+            >
+              <Paperclip className="h-4 w-4" />
+            </button>
+            <button
+              type="button"
+              onClick={() => void handleToggleDictation()}
+              disabled={dictationTranscribing}
+              className={cn(
+                "composer-icon-btn flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-transparent text-[var(--icon-muted)] hover:text-[var(--text-primary)] disabled:opacity-40",
+                dictating && "bg-red-500/15 text-red-300"
+              )}
+              title={
+                dictationTranscribing
+                  ? "Transcribing dictation"
+                  : dictating
+                    ? "Stop dictation"
+                    : dictationRuntime.engine
+                      ? `Start ${dictationRuntime.label.toLowerCase()}`
+                      : dictationRuntime.unsupportedReason || "Dictation unavailable"
+              }
+              aria-label={dictating ? `Stop dictation in ${title}` : `Start dictation in ${title}`}
+            >
+              {dictationTranscribing ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : dictating ? (
+                <MicOff className="h-4 w-4" />
+              ) : (
+                <Mic className="h-4 w-4" />
+              )}
+            </button>
+            {isActive ? (
+              <button
+                type="button"
+                onClick={() => void handleStop()}
+                className="theme-muted-icon-button flex h-8 w-8 shrink-0 items-center justify-center rounded-full"
+                title="Stop response"
+                aria-label={`Stop ${title}`}
+              >
+                <Square className="h-3.5 w-3.5 fill-current" />
+              </button>
+            ) : null}
+            <button
+              type="submit"
+              disabled={
+                (!draft.trim() && pendingImages.length === 0 && pendingFiles.length === 0) ||
+                sending ||
+                responsePending
+              }
+              className="accent-bg flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-white transition-opacity disabled:opacity-35"
+              title={isActive ? "Queue follow-up" : "Send message"}
+              aria-label={isActive ? `Queue follow-up in ${title}` : `Send message to ${title}`}
+            >
+              {sending ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Send className="h-3.5 w-3.5" />
+              )}
+            </button>
+          </div>
+        </div>
+      </form>
+    </section>
+  );
+}
+
+function EmptyMultiChatPane({
+  dropActive,
+  index,
+  onCreateDraft,
+  onDropSession,
+  onDropTargetChange,
+  onOpenPicker,
+}: {
+  dropActive: boolean;
+  index: number;
+  onCreateDraft: (index: number) => void;
+  onDropSession: (sessionId: string, index: number) => void;
+  onDropTargetChange: (index: number, active: boolean) => void;
+  onOpenPicker: (index: number) => void;
+}) {
+  const dropTarget = useMultiChatDropTarget({
+    active: dropActive,
+    index,
+    onDropSession,
+    onTargetChange: onDropTargetChange,
+  });
+  return (
+    <section
+      onDragEnter={dropTarget.onDragEnter}
+      onDragOver={dropTarget.onDragOver}
+      onDragLeave={dropTarget.onDragLeave}
+      onDrop={dropTarget.onDrop}
+      className={cn(
+        "theme-text-muted flex min-h-[24rem] min-w-0 flex-col items-center justify-center gap-3 rounded-lg border border-dashed bg-[var(--surface-panel)] p-6 text-center transition-colors lg:min-h-0",
+        dropTarget.active
+          ? "border-[rgb(var(--accent-primary))] bg-[rgba(var(--accent-primary),0.08)]"
+          : "border-[var(--surface-border)]"
+      )}
+      data-testid="multi-chat-empty-pane"
+      data-drop-active={dropTarget.active}
+    >
+      <span className="flex h-10 w-10 items-center justify-center rounded-lg bg-[var(--surface-raised)]">
+        <MessageSquarePlus className="h-5 w-5" />
+      </span>
+      <span>
+        <span className="theme-text-primary block text-sm font-medium">Add a chat</span>
+        <span className="mt-1 block text-xs">Search or drag a chat here from the sidebar</span>
+      </span>
+      <span className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={() => onCreateDraft(index)}
+          className="accent-bg inline-flex h-8 items-center gap-1.5 rounded-md px-3 text-xs font-medium text-white"
+        >
+          <MessageSquarePlus className="h-3.5 w-3.5" />
+          New chat
+        </button>
+        <button
+          type="button"
+          onClick={() => onOpenPicker(index)}
+          className="theme-muted-icon-button inline-flex h-8 items-center gap-1.5 rounded-md px-3 text-xs"
+        >
+          <Search className="h-3.5 w-3.5" />
+          Existing
+        </button>
+      </span>
+    </section>
+  );
+}
+
+export function MultiChatWorkspace() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { data: sessions = [] } = useSessions({ limit: 150 });
+  const { data: agents = [] } = useAgentSummaries();
+  const { data: routerConfig } = useQuery({
+    queryKey: ["router", "config", "multi-chat"],
+    queryFn: routerApi.config,
+    staleTime: 60_000,
+  });
+  const { data: chatConfig } = useQuery({
+    queryKey: ["config", "multi-chat"],
+    queryFn: settingsApi.getConfig,
+    staleTime: 60_000,
+  });
+  const initialRouteIds = parseMultiChatSessionIds(location.search);
+  const [sessionIds, setSessionIds] = useState(() =>
+    initialRouteIds.length ? initialRouteIds : readPersistedMultiChatSessionIds(window.localStorage)
+  );
+  const [statuses, setStatuses] = useState<Record<string, MultiChatPaneStatus>>({});
+  const [activeDropIndex, setActiveDropIndex] = useState<number | null>(null);
+  const [pickerTargetIndex, setPickerTargetIndex] = useState<number | null>(null);
+  const [openEnvironmentIds, setOpenEnvironmentIds] = useState<Set<string>>(() => new Set());
+  const [lightboxImage, setLightboxImage] = useState<ChatLightboxImage | null>(null);
+  const [toolApprovalMode, setToolApprovalMode] = useState<ToolApprovalMode>("ask");
+  const [savingToolApprovalMode, setSavingToolApprovalMode] = useState(false);
+  const initializedRef = useRef(false);
+  const refreshTimersRef = useRef<Map<string, number>>(new Map());
+
+  useEffect(() => {
+    if (!chatConfig?.success) return;
+    setToolApprovalMode(normalizeToolApprovalMode(chatConfig.data?.tool_approval_mode));
+  }, [chatConfig]);
+
+  const updateToolApprovalMode = useCallback(
+    async (nextMode: ToolApprovalMode): Promise<void> => {
+      if (savingToolApprovalMode || nextMode === toolApprovalMode) return;
+      const previousMode = toolApprovalMode;
+      setToolApprovalMode(nextMode);
+      setSavingToolApprovalMode(true);
+      try {
+        const response = await settingsApi.updateConfig({ tool_approval_mode: nextMode });
+        if (!response.success || response.data?.success !== true) {
+          throw new Error(response.error || "Failed to update tool approvals");
+        }
+      } catch (error) {
+        setToolApprovalMode(previousMode);
+        useUIStore
+          .getState()
+          .addToast(
+            "error",
+            error instanceof Error ? error.message : "Failed to update tool approvals"
+          );
+      } finally {
+        setSavingToolApprovalMode(false);
+      }
+    },
+    [savingToolApprovalMode, toolApprovalMode]
+  );
+
+  const updateDropTarget = useCallback((index: number, active: boolean): void => {
+    setActiveDropIndex((current) => resolveActiveMultiChatDropIndex(current, index, active));
+  }, []);
+
+  useEffect(() => {
+    const clearDropTarget = (): void => setActiveDropIndex(null);
+    window.addEventListener("dragend", clearDropTarget, true);
+    window.addEventListener("drop", clearDropTarget, true);
+    window.addEventListener("blur", clearDropTarget);
+    return () => {
+      window.removeEventListener("dragend", clearDropTarget, true);
+      window.removeEventListener("drop", clearDropTarget, true);
+      window.removeEventListener("blur", clearDropTarget);
+    };
+  }, []);
+
+  const syncSessionIds = useCallback(
+    (nextValues: readonly string[], replace = true) => {
+      const next = normalizeMultiChatSessionIds(nextValues);
+      const nextSet = new Set(next);
+      setSessionIds(next);
+      setOpenEnvironmentIds((current) => {
+        const retained = new Set([...current].filter((sessionId) => nextSet.has(sessionId)));
+        return retained.size === current.size ? current : retained;
+      });
+      persistMultiChatSessionIds(window.localStorage, next);
+      navigate(buildMultiChatPath(next), { replace });
+    },
+    [navigate]
+  );
+
+  useEffect(() => {
+    const routeIds = parseMultiChatSessionIds(location.search);
+    if (!initializedRef.current) {
+      initializedRef.current = true;
+      if (!routeIds.length && sessionIds.length) {
+        navigate(buildMultiChatPath(sessionIds), { replace: true });
+      }
+      return;
+    }
+    if (!arraysEqual(routeIds, sessionIds)) {
+      setSessionIds(routeIds);
+      persistMultiChatSessionIds(window.localStorage, routeIds);
+    }
+  }, [location.search, navigate, sessionIds]);
+
+  const refreshSession = useCallback(
+    (sessionId: string) => {
+      const existing = refreshTimersRef.current.get(sessionId);
+      if (existing) return;
+      const timer = window.setTimeout(() => {
+        refreshTimersRef.current.delete(sessionId);
+        void queryClient.invalidateQueries({ queryKey: [SESSION_DETAIL_QUERY_KEY, sessionId] });
+        void queryClient.invalidateQueries({ queryKey: ["sessions"] });
+      }, MULTI_CHAT_REFRESH_THROTTLE_MS);
+      refreshTimersRef.current.set(sessionId, timer);
+    },
+    [queryClient]
+  );
+
+  const sessionIdSet = useMemo(() => new Set(sessionIds), [sessionIds]);
+
+  useEffect(() => {
+    const updateStatus = (sessionId: string, next?: MultiChatPaneStatus) => {
+      if (!sessionIdSet.has(sessionId)) return;
+      setStatuses((current) => {
+        if (!next) {
+          if (!current[sessionId]) return current;
+          const copy = { ...current };
+          delete copy[sessionId];
+          return copy;
+        }
+        const existing = current[sessionId];
+        if (existing?.status === next.status && existing.detail === next.detail) return current;
+        return { ...current, [sessionId]: next };
+      });
+    };
+
+    const handleEvent = (event: StatusStreamEvent) => {
+      if (event.type === "snapshot") {
+        const next: Record<string, MultiChatPaneStatus> = {};
+        for (const snapshot of event.activeSessions) {
+          if (!sessionIdSet.has(snapshot.sessionId) || !ACTIVE_STATUSES.has(snapshot.status)) {
+            continue;
+          }
+          next[snapshot.sessionId] = {
+            status: snapshot.status,
+            detail: snapshot.detail,
+            timestamp: snapshot.timestamp,
+          };
+          refreshSession(snapshot.sessionId);
+        }
+        setStatuses(next);
+        return;
+      }
+      if (event.type === "task_completed") {
+        if (event.sessionId) {
+          updateStatus(event.sessionId);
+          refreshSession(event.sessionId);
+        }
+        return;
+      }
+      if (event.type === "assistant_token") {
+        updateStatus(event.sessionId, {
+          status: "generating",
+          timestamp: event.timestamp,
+        });
+        refreshSession(event.sessionId);
+        return;
+      }
+      const sessionId = event.sessionId;
+      if (!sessionId) return;
+      if (ACTIVE_STATUSES.has(event.status)) {
+        updateStatus(sessionId, {
+          status: event.status,
+          detail: event.detail,
+          timestamp: event.timestamp,
+        });
+        refreshSession(sessionId);
+      } else if (event.status === "idle" || event.status === "error") {
+        updateStatus(sessionId);
+        refreshSession(sessionId);
+      }
+    };
+
+    const disconnect = connectStatusStream({ onEvent: handleEvent });
+    return () => disconnect();
+  }, [refreshSession, sessionIdSet]);
+
+  useEffect(
+    () => () => {
+      for (const timer of refreshTimersRef.current.values()) window.clearTimeout(timer);
+      refreshTimersRef.current.clear();
+    },
+    []
+  );
+
+  const sessionById = useMemo(
+    () => new Map(sessions.map((session) => [session.id, session as ChatSidebarSession])),
+    [sessions]
+  );
+  const modelRouterEnabled = routerConfig?.success === true && routerConfig.data?.enabled === true;
+  const allEnvironmentsOpen =
+    sessionIds.length > 0 && sessionIds.every((sessionId) => openEnvironmentIds.has(sessionId));
+  const slotCount = sessionIds.length >= 3 ? 4 : MULTI_CHAT_MIN_SLOTS;
+
+  const addOrMoveSession = useCallback(
+    (sessionId: string, targetIndex: number) => {
+      const sourceIndex = sessionIds.indexOf(sessionId);
+      if (sourceIndex >= 0) {
+        syncSessionIds(reorderMultiChatSessions(sessionIds, sessionId, targetIndex));
+        return;
+      }
+      if (sessionIds.length < MULTI_CHAT_MAX_PANES) {
+        const added = addMultiChatSession(sessionIds, sessionId);
+        syncSessionIds(reorderMultiChatSessions(added, sessionId, targetIndex));
+        return;
+      }
+      syncSessionIds(replaceMultiChatSession(sessionIds, targetIndex, sessionId));
+    },
+    [sessionIds, syncSessionIds]
+  );
+
+  const selectFromPicker = (sessionId: string) => {
+    const targetIndex = pickerTargetIndex ?? sessionIds.length;
+    addOrMoveSession(sessionId, targetIndex);
+    setPickerTargetIndex(null);
+  };
+
+  const createDraftAt = useCallback(
+    (targetIndex: number) => {
+      const draftId = createMultiChatDraftId();
+      if (sessionIds.length < MULTI_CHAT_MAX_PANES) {
+        const added = addMultiChatSession(sessionIds, draftId);
+        syncSessionIds(reorderMultiChatSessions(added, draftId, targetIndex));
+        return;
+      }
+      syncSessionIds(replaceMultiChatSession(sessionIds, targetIndex, draftId));
+    },
+    [sessionIds, syncSessionIds]
+  );
+
+  const replacePaneSessionId = useCallback(
+    (previousSessionId: string, nextSessionId: string) => {
+      const index = sessionIds.indexOf(previousSessionId);
+      if (index < 0) return;
+      const next = replaceMultiChatSession(sessionIds, index, nextSessionId);
+      const environmentWasOpen = openEnvironmentIds.has(previousSessionId);
+      syncSessionIds(next);
+      if (environmentWasOpen) {
+        setOpenEnvironmentIds((current) => {
+          const updated = new Set(current);
+          updated.delete(previousSessionId);
+          updated.add(nextSessionId);
+          return updated;
+        });
+      }
+    },
+    [openEnvironmentIds, sessionIds, syncSessionIds]
+  );
+
+  const toggleEnvironment = useCallback((sessionId: string) => {
+    setOpenEnvironmentIds((current) => {
+      const next = new Set(current);
+      if (next.has(sessionId)) next.delete(sessionId);
+      else next.add(sessionId);
+      return next;
+    });
+  }, []);
+
+  const toggleAllEnvironments = useCallback(() => {
+    setOpenEnvironmentIds(allEnvironmentsOpen ? new Set() : new Set(sessionIds));
+  }, [allEnvironmentsOpen, sessionIds]);
+
+  return (
+    <div
+      className="flex h-screen min-h-0 flex-col bg-[var(--surface-backdrop)]"
+      data-testid="multi-chat-workspace"
+    >
+      <header className="flex h-12 shrink-0 items-center gap-3 border-b border-[var(--surface-border)] px-3 sm:px-4">
+        <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-[var(--surface-raised)]">
+          <LayoutGrid className="h-4 w-4 text-[var(--icon-muted)]" />
+        </span>
+        <span className="min-w-0 flex-1">
+          <span className="theme-text-primary block text-sm font-semibold">Multi-chat</span>
+          <span className="theme-text-muted block text-[11px]">
+            {sessionIds.length} of {MULTI_CHAT_MAX_PANES} chats open
+          </span>
+        </span>
+        <button
+          type="button"
+          onClick={() => createDraftAt(sessionIds.length)}
+          disabled={sessionIds.length >= MULTI_CHAT_MAX_PANES}
+          className="theme-muted-icon-button inline-flex h-8 w-8 items-center justify-center rounded-md disabled:opacity-40"
+          title="New chat"
+          aria-label="New chat"
+        >
+          <MessageSquarePlus className="h-3.5 w-3.5" />
+        </button>
+        <button
+          type="button"
+          onClick={() => setPickerTargetIndex(sessionIds.length)}
+          disabled={sessionIds.length >= MULTI_CHAT_MAX_PANES}
+          className="theme-muted-icon-button inline-flex h-8 w-8 items-center justify-center rounded-md disabled:opacity-40"
+          title="Add existing chat"
+          aria-label="Add existing chat"
+        >
+          <Plus className="h-3.5 w-3.5" />
+        </button>
+        <button
+          type="button"
+          onClick={toggleAllEnvironments}
+          disabled={sessionIds.length === 0}
+          className={cn(
+            "theme-muted-icon-button inline-flex h-8 w-8 items-center justify-center rounded-md disabled:opacity-40",
+            allEnvironmentsOpen && "bg-[var(--surface-hover)] text-[var(--text-primary)]"
+          )}
+          aria-pressed={allEnvironmentsOpen}
+          title={allEnvironmentsOpen ? "Hide all environments" : "Show all environments"}
+          aria-label={allEnvironmentsOpen ? "Hide all environments" : "Show all environments"}
+        >
+          <SlidersHorizontal className="h-3.5 w-3.5" />
+        </button>
+        <button
+          type="button"
+          onClick={() =>
+            navigate(sessionIds[0] ? `/chat?session=${encodeURIComponent(sessionIds[0])}` : "/chat")
+          }
+          className="theme-muted-icon-button inline-flex h-8 w-8 items-center justify-center rounded-md"
+          title="Open single chat"
+          aria-label="Open single chat"
+        >
+          <ArrowUpRight className="h-3.5 w-3.5" />
+        </button>
+      </header>
+
+      <main
+        className={cn(
+          "grid min-h-0 flex-1 gap-2 overflow-y-auto p-2 lg:overflow-hidden",
+          slotCount === 2
+            ? "grid-cols-1 lg:grid-cols-2"
+            : "grid-cols-1 lg:grid-cols-2 lg:grid-rows-[minmax(0,1fr)_minmax(0,1fr)]"
+        )}
+      >
+        {Array.from({ length: slotCount }, (_, index) => {
+          const sessionId = sessionIds[index];
+          return sessionId ? (
+            <MultiChatPane
+              key={sessionId}
+              agents={agents}
+              approvalMode={toolApprovalMode}
+              approvalUpdating={savingToolApprovalMode}
+              dropActive={activeDropIndex === index}
+              environmentOpen={openEnvironmentIds.has(sessionId)}
+              index={index}
+              modelRouterEnabled={modelRouterEnabled}
+              sessionId={sessionId}
+              summary={sessionById.get(sessionId)}
+              status={statuses[sessionId]}
+              onApprovalChange={(mode) => void updateToolApprovalMode(mode)}
+              onDropSession={addOrMoveSession}
+              onDropTargetChange={updateDropTarget}
+              onOpenPicker={setPickerTargetIndex}
+              onOpenImage={(src, alt) => setLightboxImage({ src, alt })}
+              onRemove={(removedId) =>
+                syncSessionIds(sessionIds.filter((value) => value !== removedId))
+              }
+              onReplaceSession={replacePaneSessionId}
+              onRefresh={refreshSession}
+              onToggleEnvironment={toggleEnvironment}
+            />
+          ) : (
+            <EmptyMultiChatPane
+              key={`empty-${index}`}
+              dropActive={activeDropIndex === index}
+              index={index}
+              onCreateDraft={createDraftAt}
+              onDropSession={addOrMoveSession}
+              onDropTargetChange={updateDropTarget}
+              onOpenPicker={setPickerTargetIndex}
+            />
+          );
+        })}
+      </main>
+
+      <MultiChatPicker
+        isOpen={pickerTargetIndex !== null}
+        sessions={sessions as ChatSidebarSession[]}
+        selectedIds={sessionIds}
+        onClose={() => setPickerTargetIndex(null)}
+        onSelect={selectFromPicker}
+      />
+      {lightboxImage ? (
+        <ChatImageLightbox
+          images={[lightboxImage]}
+          initialIndex={0}
+          onClose={() => setLightboxImage(null)}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/ui/src/pages/chat/MultiChatWorkspace.tsx
+++ b/ui/src/pages/chat/MultiChatWorkspace.tsx
@@ -762,7 +762,7 @@ function MultiChatPane({
               disabled={
                 (!draft.trim() && pendingImages.length === 0 && pendingFiles.length === 0) ||
                 sending ||
-                responsePending
+                (!isActive && responsePending)
               }
               className="accent-bg flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-white transition-opacity disabled:opacity-35"
               title={isActive ? "Queue follow-up" : "Send message"}

--- a/ui/src/pages/chat/SessionSidebar.tsx
+++ b/ui/src/pages/chat/SessionSidebar.tsx
@@ -45,6 +45,7 @@ import { cn } from "@/lib/utils";
 import type { SessionContextUsage, SessionTokenUsage, Task } from "@/types";
 import type { ChatMessage } from "./chatModel";
 import { sessionDisplayTitle, sessionPreviewText, sessionRouteLabel } from "./chatModel";
+import { MULTI_CHAT_DRAG_TYPE } from "./multiChatLayout";
 import {
   type ChatSidebarSession,
   type ChatSidebarSessionGroup,
@@ -820,6 +821,13 @@ export function SessionsPanel({
                           <>
                             <button
                               type="button"
+                              draggable
+                              onDragStart={(event) => {
+                                setHoveredSessionTooltip(null);
+                                event.dataTransfer.effectAllowed = "copyMove";
+                                event.dataTransfer.setData(MULTI_CHAT_DRAG_TYPE, session.id);
+                                event.dataTransfer.setData("text/plain", session.id);
+                              }}
                               className="flex h-full min-w-0 w-full cursor-pointer items-center text-left outline-none focus-visible:bg-[var(--surface-hover)]"
                               aria-label={tooltip}
                               aria-busy={isRowLoading}

--- a/ui/src/pages/chat/chatReasoningOptions.ts
+++ b/ui/src/pages/chat/chatReasoningOptions.ts
@@ -1,0 +1,42 @@
+import { supportedReasoningOptions } from "@/lib/reasoning";
+import type { AgentReasoningEffort } from "@/types";
+
+export interface ChatReasoningOption {
+  value: AgentReasoningEffort | null;
+  label: string;
+}
+
+const EFFORT_LABELS: Record<AgentReasoningEffort, string> = {
+  minimal: "Minimal",
+  low: "Low",
+  medium: "Medium",
+  high: "High",
+  xhigh: "Extra High",
+  max: "Max",
+};
+
+export function resolveChatReasoningOptions(
+  provider?: string | null,
+  model?: string | null,
+  mode?: "adaptive" | "binary" | "effort",
+  supportedEfforts?: AgentReasoningEffort[]
+): ChatReasoningOption[] {
+  const resolved =
+    mode === "adaptive"
+      ? [{ value: "" as const, label: "Adaptive" }]
+      : mode === "binary"
+        ? [
+            { value: "" as const, label: "Default" },
+            { value: "medium" as const, label: "Thinking" },
+          ]
+        : supportedEfforts?.length
+          ? [
+              { value: "" as const, label: "Default" },
+              ...supportedEfforts.map((value) => ({ value, label: EFFORT_LABELS[value] })),
+            ]
+          : supportedReasoningOptions(provider, model);
+  return resolved.map((option) => ({
+    value: option.value === "" ? null : option.value,
+    label: option.label,
+  }));
+}

--- a/ui/src/pages/chat/multiChatLayout.ts
+++ b/ui/src/pages/chat/multiChatLayout.ts
@@ -1,0 +1,98 @@
+export const MULTI_CHAT_MAX_PANES = 4;
+export const MULTI_CHAT_MIN_SLOTS = 2;
+export const MULTI_CHAT_STORAGE_KEY = "cybara.chat.multiChatSessionIds";
+export const MULTI_CHAT_DRAG_TYPE = "application/x-cybara-chat-session";
+
+export function resolveActiveMultiChatDropIndex(
+  currentIndex: number | null,
+  targetIndex: number,
+  active: boolean
+): number | null {
+  if (active) return targetIndex;
+  return currentIndex === targetIndex ? null : currentIndex;
+}
+
+function normalizeSessionId(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim();
+  return normalized && normalized.length <= 256 ? normalized : null;
+}
+
+export function normalizeMultiChatSessionIds(values: readonly unknown[]): string[] {
+  const unique: string[] = [];
+  const seen = new Set<string>();
+  for (const value of values) {
+    const sessionId = normalizeSessionId(value);
+    if (!sessionId || seen.has(sessionId)) continue;
+    seen.add(sessionId);
+    unique.push(sessionId);
+    if (unique.length === MULTI_CHAT_MAX_PANES) break;
+  }
+  return unique;
+}
+
+export function isMultiChatSearch(search: string): boolean {
+  return new URLSearchParams(search).get("multi") === "1";
+}
+
+export function parseMultiChatSessionIds(search: string): string[] {
+  return normalizeMultiChatSessionIds(new URLSearchParams(search).getAll("pane"));
+}
+
+export function buildMultiChatPath(sessionIds: readonly string[]): string {
+  const params = new URLSearchParams({ multi: "1" });
+  for (const sessionId of normalizeMultiChatSessionIds(sessionIds)) {
+    params.append("pane", sessionId);
+  }
+  return `/chat?${params.toString()}`;
+}
+
+export function addMultiChatSession(sessionIds: readonly string[], sessionId: string): string[] {
+  const normalizedId = normalizeSessionId(sessionId);
+  if (!normalizedId) return normalizeMultiChatSessionIds(sessionIds);
+  const current = normalizeMultiChatSessionIds(sessionIds);
+  if (current.includes(normalizedId)) return current;
+  return normalizeMultiChatSessionIds([...current, normalizedId]);
+}
+
+export function replaceMultiChatSession(
+  sessionIds: readonly string[],
+  index: number,
+  sessionId: string
+): string[] {
+  const normalizedId = normalizeSessionId(sessionId);
+  const current = normalizeMultiChatSessionIds(sessionIds);
+  if (!normalizedId || index < 0 || index >= MULTI_CHAT_MAX_PANES) return current;
+  const withoutTarget = current.filter((id, currentIndex) => currentIndex !== index);
+  const withoutDuplicate = withoutTarget.filter((id) => id !== normalizedId);
+  withoutDuplicate.splice(Math.min(index, withoutDuplicate.length), 0, normalizedId);
+  return normalizeMultiChatSessionIds(withoutDuplicate);
+}
+
+export function reorderMultiChatSessions(
+  sessionIds: readonly string[],
+  sourceId: string,
+  targetIndex: number
+): string[] {
+  const current = normalizeMultiChatSessionIds(sessionIds);
+  const sourceIndex = current.indexOf(sourceId);
+  if (sourceIndex < 0 || targetIndex < 0 || targetIndex >= MULTI_CHAT_MAX_PANES) return current;
+  const next = [...current];
+  const [moved] = next.splice(sourceIndex, 1);
+  if (!moved) return current;
+  next.splice(Math.min(targetIndex, next.length), 0, moved);
+  return next;
+}
+
+export function readPersistedMultiChatSessionIds(storage: Storage): string[] {
+  try {
+    const value = JSON.parse(storage.getItem(MULTI_CHAT_STORAGE_KEY) || "[]") as unknown;
+    return Array.isArray(value) ? normalizeMultiChatSessionIds(value) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function persistMultiChatSessionIds(storage: Storage, sessionIds: readonly string[]): void {
+  storage.setItem(MULTI_CHAT_STORAGE_KEY, JSON.stringify(normalizeMultiChatSessionIds(sessionIds)));
+}

--- a/ui/src/pages/chat/useMultiChatDropTarget.ts
+++ b/ui/src/pages/chat/useMultiChatDropTarget.ts
@@ -1,0 +1,70 @@
+import { type DragEventHandler, useCallback } from "react";
+import { MULTI_CHAT_DRAG_TYPE } from "./multiChatLayout";
+
+interface UseMultiChatDropTargetOptions {
+  active: boolean;
+  index: number;
+  onDropSession: (sessionId: string, index: number) => void;
+  onTargetChange: (index: number, active: boolean) => void;
+}
+
+interface MultiChatDropTargetHandlers {
+  active: boolean;
+  onDragEnter: DragEventHandler<HTMLElement>;
+  onDragLeave: DragEventHandler<HTMLElement>;
+  onDragOver: DragEventHandler<HTMLElement>;
+  onDrop: DragEventHandler<HTMLElement>;
+}
+
+export function useMultiChatDropTarget({
+  active,
+  index,
+  onDropSession,
+  onTargetChange,
+}: UseMultiChatDropTargetOptions): MultiChatDropTargetHandlers {
+  const acceptsDrop = useCallback(
+    (types: readonly string[]): boolean => types.includes(MULTI_CHAT_DRAG_TYPE),
+    []
+  );
+
+  const onDragEnter = useCallback<DragEventHandler<HTMLElement>>(
+    (event) => {
+      if (!acceptsDrop(event.dataTransfer.types)) return;
+      event.preventDefault();
+      onTargetChange(index, true);
+    },
+    [acceptsDrop, index, onTargetChange]
+  );
+
+  const onDragOver = useCallback<DragEventHandler<HTMLElement>>(
+    (event) => {
+      if (!acceptsDrop(event.dataTransfer.types)) return;
+      event.preventDefault();
+      event.dataTransfer.dropEffect = "move";
+      if (!active) onTargetChange(index, true);
+    },
+    [acceptsDrop, active, index, onTargetChange]
+  );
+
+  const onDragLeave = useCallback<DragEventHandler<HTMLElement>>(
+    (event) => {
+      const nextTarget = event.relatedTarget;
+      if (nextTarget instanceof Node && event.currentTarget.contains(nextTarget)) return;
+      onTargetChange(index, false);
+    },
+    [index, onTargetChange]
+  );
+
+  const onDrop = useCallback<DragEventHandler<HTMLElement>>(
+    (event) => {
+      if (!acceptsDrop(event.dataTransfer.types)) return;
+      event.preventDefault();
+      const sessionId = event.dataTransfer.getData(MULTI_CHAT_DRAG_TYPE).trim();
+      onTargetChange(index, false);
+      if (sessionId) onDropSession(sessionId, index);
+    },
+    [acceptsDrop, index, onDropSession, onTargetChange]
+  );
+
+  return { active, onDragEnter, onDragLeave, onDragOver, onDrop };
+}

--- a/ui/src/pages/ide/IDEChatPanel.tsx
+++ b/ui/src/pages/ide/IDEChatPanel.tsx
@@ -1379,7 +1379,7 @@ export function IDEChatPanel({
         onScroll={(event) => {
           shouldFollowOutputRef.current = isChatNearBottom(event.currentTarget, 80);
         }}
-        className="flex-1 overflow-y-auto px-3 py-2 space-y-2"
+        className="chat-scroll-region flex-1 overflow-y-auto px-3 py-2 space-y-2"
       >
         {messages.length === 0 ? (
           <div className="text-xs text-gray-500">

--- a/ui/src/styles/index-foundation.css
+++ b/ui/src/styles/index-foundation.css
@@ -172,6 +172,15 @@ body::before {
   background: rgba(255, 255, 255, 0.2);
 }
 
+.chat-scroll-region {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.chat-scroll-region::-webkit-scrollbar {
+  display: none;
+}
+
 /* ==================== INTERACTION HYGIENE ==================== */
 
 /* Keyboard focus: a clearly visible accent ring. The previous 1px 30%-white

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -38,6 +38,8 @@ export interface AgentSummary {
   status?: Agent["status"];
   created_at?: string;
   reasoning_effort?: AgentReasoningEffort | null;
+  reasoning_mode?: "adaptive" | "binary" | "effort";
+  reasoning_efforts?: AgentReasoningEffort[];
   tool_profile?: string;
   supports_images?: boolean;
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches agent reasoning APIs and chat UX on web, mobile, and macOS, plus sidecar startup/port selection and release build verification—moderate scope but not auth or payment critical.
> 
> **Overview**
> **Reasoning** is centralized in `shared/reasoning-capabilities.ts` and wired through the gateway, TUI, web, mobile, and macOS native clients. Agent summaries now expose **`reasoning_mode`** and **`reasoning_efforts`**, with updates **coerced** to supported levels (e.g. Kimi K3, Gemini 3 Flash, OAuth provider aliases). UIs prefer gateway capabilities when present and fall back to shared inference when lists are empty.
> 
> The web app adds a **multi-chat workspace** (`?panes=` URLs, sidebar/header entry, drag-and-drop from the session list, shared composer controls, per-pane environment panels) plus smaller chat polish: extracted composer attachments, portal-based context-usage tooltips, and hidden transcript scrollbars.
> 
> **Packaging and native shell:** sidecar builds go through **`buildStandaloneCli`** with `src/index.ts` and embedded UI; release and native macOS packaging run **`smoke-tauri-sidecar-ui`** (dashboard HTML, assets, health version). Compiled UI resolution prefers the current Tauri macOS **`Resources/ui/dist`** path. **macOS sidecar** can **auto-fallback ports** when the default is occupied (attach compatible gateway or launch on a free port unless `CYBARA_NATIVE_PORT` is explicitly set).
> 
> Site **download totals** subtract per-installer companion metadata instead of a single release-wide automation baseline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10e98a308e848a656277d4ce77d8eaa2b4d6d937. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- GITZILLA_SUMMARY -->
> [!NOTE]
> **Medium Risk**
>
> **Overview**
> Centralizes agent reasoning handling in a new shared module and propagates `reasoning_mode`/`reasoning_efforts` across agent routes, the TUI, web chat UI, mobile API normalizers, and macOS native clients. Reorganizes the web chat surface by extracting attachments into a dedicated component, introducing a multi-chat workspace with drag-and-drop layout support, and refreshing the chat composer, reasoning controls, message timeline, header, sidebar, and context usage ring. Streamlines the mobile dashboard by trimming session-detail glue, and adds matching tests across UI, mobile, scripts, runtime, and site layers. Updates macOS sidecar management (port selection, startup lifecycle) along with build, packaging, release workflow, and a new Tauri sidecar UI smoke test.
>
> <sup>Written by [Gitzilla](https://gitzilla.ai) for commit 10e98a3. This will update automatically on new runs. Configure in the [Gitzilla dashboard](https://gitzilla.ai/dashboard).</sup>
<!-- /GITZILLA_SUMMARY -->