### PR TITLE
New release

### DIFF
--- a/tests/ui/active-session-tracker.test.ts
+++ b/tests/ui/active-session-tracker.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import {
+  pruneInactiveSessions,
+  reconcileActiveSessionSnapshot,
+  SIDEBAR_ACTIVE_STATUSES,
+} from "../../ui/src/components/layout/activeSessionTracker";
+
+describe("sidebar active session tracker", () => {
+  test("retains an active session across a transient empty snapshot", () => {
+    const active = new Map([["session-1", 1_000]]);
+    const reconciled = reconcileActiveSessionSnapshot(active, [], 1_100);
+
+    expect([...reconciled.keys()]).toEqual(["session-1"]);
+    expect(pruneInactiveSessions(reconciled, 2_000, 60_000).has("session-1")).toBe(true);
+  });
+
+  test("treats tool completion as an active point in the run", () => {
+    const reconciled = reconcileActiveSessionSnapshot(
+      new Map(),
+      [
+        {
+          sessionId: "session-1",
+          status: "tool_completed",
+          timestamp: 1_000,
+          activities: [],
+        },
+      ],
+      1_100
+    );
+
+    expect(SIDEBAR_ACTIVE_STATUSES.has("tool_completed")).toBe(true);
+    expect(reconciled.get("session-1")).toBe(1_100);
+  });
+
+  test("expires activity when no terminal event arrives", () => {
+    const active = new Map([["session-1", 1_000]]);
+    expect(pruneInactiveSessions(active, 62_001, 60_000).size).toBe(0);
+  });
+});

--- a/tests/ui/multi-chat-live-status.test.ts
+++ b/tests/ui/multi-chat-live-status.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "bun:test";
+import {
+  MULTI_CHAT_ACTIVE_STATUSES,
+  projectMultiChatSnapshot,
+  projectMultiChatStatusEvent,
+} from "../../ui/src/pages/chat/multiChatLiveStatus";
+
+describe("multi-chat live status", () => {
+  test("hydrates in-progress tool calls and thoughts from a session snapshot", () => {
+    const state = projectMultiChatSnapshot(
+      {
+        sessionId: "session-1",
+        runId: "run-1",
+        sequence: 8,
+        status: "tool_executing",
+        timestamp: 1_000,
+        detail: "Searching the workspace",
+        activities: [
+          {
+            id: "thought-1",
+            phase: "result",
+            text: "I will inspect the relevant files first.",
+            timestamp: 900,
+            toolName: "__thought",
+          },
+          {
+            id: "tool-1",
+            phase: "start",
+            text: "Searching for configuration",
+            timestamp: 1_000,
+            toolName: "grep",
+            toolCallId: "call-1",
+          },
+        ],
+      },
+      undefined,
+      1_100
+    );
+
+    expect(state.activities).toHaveLength(2);
+    expect(state.activities.map((activity) => activity.text)).toEqual([
+      "I will inspect the relevant files first.",
+      "Searching for configuration",
+    ]);
+    expect(state.currentStep).toBe("Searching for configuration");
+    expect(state.liveStatus).toBe("thinking");
+    expect(state.startedAtMs).toBe(1_000);
+  });
+
+  test("keeps a session active between a tool result and the next model step", () => {
+    const running = projectMultiChatStatusEvent(undefined, {
+      type: "status",
+      sessionId: "session-1",
+      runId: "run-1",
+      sequence: 1,
+      status: "tool_executing",
+      timestamp: 1_000,
+      toolName: "read",
+      toolCallId: "call-1",
+      detail: "Exploring package.json",
+    });
+    const completed = projectMultiChatStatusEvent(running || undefined, {
+      type: "status",
+      sessionId: "session-1",
+      runId: "run-1",
+      sequence: 2,
+      status: "tool_completed",
+      timestamp: 1_100,
+      toolName: "read",
+      toolCallId: "call-1",
+      detail: "Explored package.json",
+    });
+
+    expect(completed).not.toBeNull();
+    expect(MULTI_CHAT_ACTIVE_STATUSES.has(completed?.status || "idle")).toBe(true);
+    expect(completed?.activities).toHaveLength(1);
+    expect(completed?.activities[0]?.phase).toBe("result");
+    expect(completed?.activities[0]?.text).toBe("Explored package.json");
+  });
+
+  test("clears live state only for a terminal status", () => {
+    const running = projectMultiChatStatusEvent(undefined, {
+      type: "status",
+      sessionId: "session-1",
+      status: "thinking",
+      timestamp: 1_000,
+      detail: "Reviewing the test output",
+    });
+    const idle = projectMultiChatStatusEvent(running || undefined, {
+      type: "status",
+      sessionId: "session-1",
+      status: "idle",
+      timestamp: 1_100,
+    });
+
+    expect(running?.activities[0]?.toolName).toBe("__thought");
+    expect(idle).toBeNull();
+  });
+});

--- a/tests/ui/multi-chat-wiring.test.ts
+++ b/tests/ui/multi-chat-wiring.test.ts
@@ -48,18 +48,20 @@ describe("multi-chat workspace wiring", () => {
 
   test("shares status streaming, bounds rendering, and queues active follow-ups", () => {
     const workspace = readSource("ui/src/pages/chat/MultiChatWorkspace.tsx");
+    const liveStatuses = readSource("ui/src/pages/chat/useMultiChatLiveStatuses.ts");
 
-    expect(workspace).toContain("const disconnect = connectStatusStream");
-    expect(workspace.match(/connectStatusStream\(/g)).toHaveLength(1);
+    expect(workspace).toContain("useMultiChatLiveStatuses");
+    expect(liveStatuses).toContain("const response = await chatApi.getSessionStatus()");
+    expect(liveStatuses).toContain("replayBufferedSessionEvents: true");
+    expect(liveStatuses).toContain("projectMultiChatSnapshot");
+    expect(liveStatuses).toContain("projectMultiChatStatusEvent");
     expect(workspace).toContain("MULTI_CHAT_RENDERED_MESSAGE_LIMIT = 80");
     expect(workspace).toContain("MULTI_CHAT_REFRESH_THROTTLE_MS = 750");
     expect(workspace).toContain('queueMode: isActive ? "queue" : undefined');
     expect(workspace).toContain("(!isActive && responsePending)");
     expect(workspace).toContain("useSessionDetail(sessionId, !isDraft)");
-    expect(workspace).toContain("if (existing) return");
-    expect(workspace).toContain(
-      "existing?.status === next.status && existing.detail === next.detail"
-    );
+    expect(workspace).toContain("liveActivities={status?.activities || []}");
+    expect(workspace).toContain("showWorkingTimeline={isActive}");
   });
 
   test("uses true desktop quadrants and stacked responsive panes", () => {

--- a/tests/ui/sidebar-status-indicator.test.ts
+++ b/tests/ui/sidebar-status-indicator.test.ts
@@ -7,6 +7,9 @@ import { readUiStylesSource } from "../shared/source-bundles";
 const sidebarPath = fileURLToPath(
   new URL("../../ui/src/components/layout/Sidebar.tsx", import.meta.url)
 );
+const activeSessionTrackerPath = fileURLToPath(
+  new URL("../../ui/src/components/layout/activeSessionTracker.ts", import.meta.url)
+);
 const logoPath = fileURLToPath(new URL("../../ui/public/cybara.png", import.meta.url));
 const thinkingLogoPath = fileURLToPath(
   new URL("../../ui/public/cybara-thinking.png", import.meta.url)
@@ -32,18 +35,24 @@ describe("Sidebar status indicator behavior", () => {
 
   test("treats every in-turn status event as activity so the indicator never flickers", () => {
     const source = readSidebarSource();
+    const tracker = readFileSync(activeSessionTrackerPath, "utf8");
 
-    for (const status of ["thinking", "generating", "tool_executing", "compacting"]) {
-      expect(source).toContain(`"${status}"`);
+    for (const status of [
+      "thinking",
+      "generating",
+      "tool_executing",
+      "tool_completed",
+      "compacting",
+    ]) {
+      expect(tracker).toContain(`"${status}"`);
     }
-    expect(source).not.toContain('"tool_completed",');
-    expect(source).toContain('statusValue === "tool_completed"');
+    expect(source).toContain("SIDEBAR_ACTIVE_STATUSES.has(statusValue)");
     expect(source).toContain('data.type === "task_completed"');
     expect(source).toMatch(
       /setStatus\(globalActive \|\| hasActiveSessions \? ["']active["'] : ["']idle["']\)/
     );
-    expect(source).toContain("ACTIVE_WINDOW_MS = 60_000");
-    expect(source).toContain("activeSessions.length === 0");
+    expect(tracker).toContain("SIDEBAR_ACTIVE_SESSION_WINDOW_MS = 60_000");
+    expect(source).toContain('statusValue === "idle" || statusValue === "error"');
     expect(source).toContain("globalLastSeenRef.current = 0");
   });
 

--- a/ui/src/components/layout/Sidebar.tsx
+++ b/ui/src/components/layout/Sidebar.tsx
@@ -61,6 +61,12 @@ import {
   usesAvailableMainSidebarChatHeight,
 } from "./sidebarSizing";
 import { UpdateButton } from "./UpdateButton";
+import {
+  pruneInactiveSessions,
+  reconcileActiveSessionSnapshot,
+  SIDEBAR_ACTIVE_SESSION_WINDOW_MS,
+  SIDEBAR_ACTIVE_STATUSES,
+} from "./activeSessionTracker";
 
 interface SidebarContextType {
   collapsed: boolean;
@@ -125,18 +131,16 @@ function useAgentStatus() {
   const globalLastSeenRef = useRef<number>(0);
 
   useEffect(() => {
-    const ACTIVE_WINDOW_MS = 60_000;
-    const ACTIVE_STATUSES = new Set(["thinking", "generating", "tool_executing", "compacting"]);
-
     const refreshDerivedStatus = () => {
       const now = Date.now();
-      for (const [sessionId, lastSeen] of activeSessionLastSeenRef.current.entries()) {
-        if (now - lastSeen > ACTIVE_WINDOW_MS) {
-          activeSessionLastSeenRef.current.delete(sessionId);
-        }
-      }
+      activeSessionLastSeenRef.current = pruneInactiveSessions(
+        activeSessionLastSeenRef.current,
+        now,
+        SIDEBAR_ACTIVE_SESSION_WINDOW_MS
+      );
       const globalActive =
-        globalLastSeenRef.current > 0 && now - globalLastSeenRef.current <= ACTIVE_WINDOW_MS;
+        globalLastSeenRef.current > 0 &&
+        now - globalLastSeenRef.current <= SIDEBAR_ACTIVE_SESSION_WINDOW_MS;
       const hasActiveSessions = activeSessionLastSeenRef.current.size > 0;
       setStatus(globalActive || hasActiveSessions ? "active" : "idle");
       setActiveSessionIds([...activeSessionLastSeenRef.current.keys()]);
@@ -152,22 +156,12 @@ function useAgentStatus() {
         const now = Date.now();
 
         if (data.type === "snapshot") {
-          activeSessionLastSeenRef.current.clear();
           const activeSessions = Array.isArray(data.activeSessions) ? data.activeSessions : [];
-          if (activeSessions.length === 0) {
-            globalLastSeenRef.current = 0;
-          }
-          for (const snapshot of activeSessions) {
-            const sessionId =
-              typeof snapshot?.sessionId === "string" ? snapshot.sessionId.trim() : "";
-            const snapshotStatus = typeof snapshot?.status === "string" ? snapshot.status : "";
-            if (!sessionId || !ACTIVE_STATUSES.has(snapshotStatus)) continue;
-            const lastSeen =
-              typeof snapshot.timestamp === "number" && Number.isFinite(snapshot.timestamp)
-                ? snapshot.timestamp
-                : now;
-            activeSessionLastSeenRef.current.set(sessionId, lastSeen);
-          }
+          activeSessionLastSeenRef.current = reconcileActiveSessionSnapshot(
+            activeSessionLastSeenRef.current,
+            activeSessions,
+            now
+          );
           refreshDerivedStatus();
           return;
         }
@@ -186,29 +180,20 @@ function useAgentStatus() {
 
         if (data.type !== "status") return;
 
-        const statusValue = typeof data.status === "string" ? data.status : "";
+        const statusValue = data.status;
         const sessionId = typeof data.sessionId === "string" ? data.sessionId.trim() : "";
-        if (!statusValue) return;
-        const isActiveStatus = ACTIVE_STATUSES.has(statusValue);
+        const isActiveStatus = SIDEBAR_ACTIVE_STATUSES.has(statusValue);
 
         if (sessionId) {
           if (isActiveStatus) {
             activeSessionLastSeenRef.current.set(sessionId, now);
-          } else if (
-            statusValue === "idle" ||
-            statusValue === "error" ||
-            statusValue === "tool_completed"
-          ) {
+          } else if (statusValue === "idle" || statusValue === "error") {
             activeSessionLastSeenRef.current.delete(sessionId);
           }
         } else {
           if (isActiveStatus) {
             globalLastSeenRef.current = now;
-          } else if (
-            statusValue === "idle" ||
-            statusValue === "error" ||
-            statusValue === "tool_completed"
-          ) {
+          } else if (statusValue === "idle" || statusValue === "error") {
             globalLastSeenRef.current = 0;
           }
         }

--- a/ui/src/components/layout/activeSessionTracker.ts
+++ b/ui/src/components/layout/activeSessionTracker.ts
@@ -1,0 +1,33 @@
+import type { StatusSessionSnapshot, StreamAgentStatus } from "@/lib/status-stream";
+
+export const SIDEBAR_ACTIVE_SESSION_WINDOW_MS = 60_000;
+
+export const SIDEBAR_ACTIVE_STATUSES = new Set<StreamAgentStatus>([
+  "thinking",
+  "generating",
+  "tool_executing",
+  "tool_completed",
+  "compacting",
+]);
+
+export function reconcileActiveSessionSnapshot(
+  previous: ReadonlyMap<string, number>,
+  snapshots: readonly StatusSessionSnapshot[],
+  observedAt = Date.now()
+): Map<string, number> {
+  const next = new Map(previous);
+  for (const snapshot of snapshots) {
+    const sessionId = snapshot.sessionId.trim();
+    if (!sessionId || !SIDEBAR_ACTIVE_STATUSES.has(snapshot.status)) continue;
+    next.set(sessionId, observedAt);
+  }
+  return next;
+}
+
+export function pruneInactiveSessions(
+  previous: ReadonlyMap<string, number>,
+  now = Date.now(),
+  activeWindowMs = SIDEBAR_ACTIVE_SESSION_WINDOW_MS
+): Map<string, number> {
+  return new Map([...previous].filter(([, lastSeen]) => now - lastSeen <= activeWindowMs));
+}

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1,5 +1,5 @@
 import { fetchApi } from "@/lib/api-client";
-import type { PendingChatMessage } from "@/lib/status-stream";
+import type { PendingChatMessage, StatusSessionSnapshot } from "@/lib/status-stream";
 import type {
   Agent,
   AgentSummary,
@@ -1485,36 +1485,10 @@ export const chatApi = {
     }),
   getSessionStatus: (sessionId?: string) =>
     fetchApi<{
-      activeSessions?: Array<{
-        sessionId: string;
-        status: string;
-        timestamp: number;
-        detail?: string;
-        agentId?: string;
-        activities: Array<{
-          id: string;
-          phase: "start" | "result" | "error" | "blocked";
-          text: string;
-          timestamp: number;
-          toolName?: string;
-        }>;
-      }>;
+      activeSessions?: StatusSessionSnapshot[];
       activeSessionIds: string[];
       count?: number;
-      session?: {
-        sessionId: string;
-        status: string;
-        timestamp: number;
-        detail?: string;
-        agentId?: string;
-        activities: Array<{
-          id: string;
-          phase: "start" | "result" | "error" | "blocked";
-          text: string;
-          timestamp: number;
-          toolName?: string;
-        }>;
-      } | null;
+      session?: StatusSessionSnapshot | null;
       active?: boolean;
       sessionId?: string;
     }>("/status/sessions" + (sessionId ? `?sessionId=${encodeURIComponent(sessionId)}` : "")),

--- a/ui/src/pages/chat/MultiChatWorkspace.tsx
+++ b/ui/src/pages/chat/MultiChatWorkspace.tsx
@@ -8,11 +8,6 @@ import {
   SESSION_DETAIL_QUERY_KEY,
 } from "@/hooks/useChat";
 import { chatApi, routerApi, settingsApi } from "@/lib/api";
-import {
-  connectStatusStream,
-  type StatusStreamEvent,
-  type StreamAgentStatus,
-} from "@/lib/status-stream";
 import { cn } from "@/lib/utils";
 import { useUIStore } from "@/stores/uiStore";
 import { openExternal } from "@/utils/openExternal";
@@ -76,24 +71,13 @@ import {
 import { useMultiChatDropTarget } from "./useMultiChatDropTarget";
 import { useChatAttachments } from "./useChatAttachments";
 import { useChatDictation } from "./useChatDictation";
+import { MULTI_CHAT_ACTIVE_STATUSES, type MultiChatLiveState } from "./multiChatLiveStatus";
+import { useMultiChatLiveStatuses } from "./useMultiChatLiveStatuses";
 import type { AgentSummary } from "@/types";
 import type { ChatSidebarSession } from "./sessionGrouping";
 
 const MULTI_CHAT_RENDERED_MESSAGE_LIMIT = 80;
 const MULTI_CHAT_REFRESH_THROTTLE_MS = 750;
-const ACTIVE_STATUSES = new Set<StreamAgentStatus>([
-  "thinking",
-  "generating",
-  "tool_executing",
-  "compacting",
-]);
-
-interface MultiChatPaneStatus {
-  status: StreamAgentStatus;
-  detail?: string;
-  timestamp: number;
-}
-
 interface MultiChatPickerProps {
   isOpen: boolean;
   sessions: ChatSidebarSession[];
@@ -112,7 +96,7 @@ interface MultiChatPaneProps {
   modelRouterEnabled: boolean;
   sessionId: string;
   summary?: ChatSidebarSession;
-  status?: MultiChatPaneStatus;
+  status?: MultiChatLiveState;
   onDropSession: (sessionId: string, index: number) => void;
   onDropTargetChange: (index: number, active: boolean) => void;
   onApprovalChange: (mode: ToolApprovalMode) => void;
@@ -134,8 +118,8 @@ function arraysEqual(left: readonly string[], right: readonly string[]): boolean
   return left.length === right.length && left.every((value, index) => value === right[index]);
 }
 
-function multiChatStatusLabel(status?: MultiChatPaneStatus): string {
-  if (!status || !ACTIVE_STATUSES.has(status.status)) return "Ready";
+function multiChatStatusLabel(status?: MultiChatLiveState): string {
+  if (!status || !MULTI_CHAT_ACTIVE_STATUSES.has(status.status)) return "Ready";
   if (status.status === "tool_executing") return status.detail || "Using tools";
   if (status.status === "compacting") return "Compacting context";
   if (status.status === "generating") return "Responding";
@@ -321,7 +305,7 @@ function MultiChatPane({
     onDropSession,
     onTargetChange: onDropTargetChange,
   });
-  const isActive = !!status && ACTIVE_STATUSES.has(status.status);
+  const isActive = !!status && MULTI_CHAT_ACTIVE_STATUSES.has(status.status);
   const selectedAgent = agents.find((agent) => agent.id === (selectedAgentId || detail?.agent_id));
 
   useEffect(() => {
@@ -589,13 +573,14 @@ function MultiChatPane({
               entries={visibleEntries}
               forkingMessageIndex={null}
               goldenTurnsEnabled={false}
-              liveActivities={[]}
-              liveCurrentStep={null}
-              liveStatus="idle"
+              liveActivities={status?.activities || []}
+              liveCurrentStep={status?.currentStep || null}
+              liveStatus={status?.liveStatus || "idle"}
+              liveStartedAtMs={status?.startedAtMs}
               messageProcessMap={{}}
               savingGoldenMessageIndex={null}
               sessionId={sessionId}
-              showWorkingTimeline={false}
+              showWorkingTimeline={isActive}
               speakingMessageIndex={null}
               workspaceDir={detail?.workspace_dir || null}
               onCopyMessage={(messageIndex, content) => {
@@ -615,12 +600,6 @@ function MultiChatPane({
               onRevert={() => undefined}
               onSaveGolden={() => undefined}
             />
-            {isActive ? (
-              <div className="theme-text-muted flex items-center gap-2 py-1 text-xs">
-                <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                <span className="truncate">{multiChatStatusLabel(status)}</span>
-              </div>
-            ) : null}
             <div ref={endRef} />
           </div>
         )}
@@ -866,7 +845,6 @@ export function MultiChatWorkspace() {
   const [sessionIds, setSessionIds] = useState(() =>
     initialRouteIds.length ? initialRouteIds : readPersistedMultiChatSessionIds(window.localStorage)
   );
-  const [statuses, setStatuses] = useState<Record<string, MultiChatPaneStatus>>({});
   const [activeDropIndex, setActiveDropIndex] = useState<number | null>(null);
   const [pickerTargetIndex, setPickerTargetIndex] = useState<number | null>(null);
   const [openEnvironmentIds, setOpenEnvironmentIds] = useState<Set<string>>(() => new Set());
@@ -967,74 +945,7 @@ export function MultiChatWorkspace() {
     [queryClient]
   );
 
-  const sessionIdSet = useMemo(() => new Set(sessionIds), [sessionIds]);
-
-  useEffect(() => {
-    const updateStatus = (sessionId: string, next?: MultiChatPaneStatus) => {
-      if (!sessionIdSet.has(sessionId)) return;
-      setStatuses((current) => {
-        if (!next) {
-          if (!current[sessionId]) return current;
-          const copy = { ...current };
-          delete copy[sessionId];
-          return copy;
-        }
-        const existing = current[sessionId];
-        if (existing?.status === next.status && existing.detail === next.detail) return current;
-        return { ...current, [sessionId]: next };
-      });
-    };
-
-    const handleEvent = (event: StatusStreamEvent) => {
-      if (event.type === "snapshot") {
-        const next: Record<string, MultiChatPaneStatus> = {};
-        for (const snapshot of event.activeSessions) {
-          if (!sessionIdSet.has(snapshot.sessionId) || !ACTIVE_STATUSES.has(snapshot.status)) {
-            continue;
-          }
-          next[snapshot.sessionId] = {
-            status: snapshot.status,
-            detail: snapshot.detail,
-            timestamp: snapshot.timestamp,
-          };
-          refreshSession(snapshot.sessionId);
-        }
-        setStatuses(next);
-        return;
-      }
-      if (event.type === "task_completed") {
-        if (event.sessionId) {
-          updateStatus(event.sessionId);
-          refreshSession(event.sessionId);
-        }
-        return;
-      }
-      if (event.type === "assistant_token") {
-        updateStatus(event.sessionId, {
-          status: "generating",
-          timestamp: event.timestamp,
-        });
-        refreshSession(event.sessionId);
-        return;
-      }
-      const sessionId = event.sessionId;
-      if (!sessionId) return;
-      if (ACTIVE_STATUSES.has(event.status)) {
-        updateStatus(sessionId, {
-          status: event.status,
-          detail: event.detail,
-          timestamp: event.timestamp,
-        });
-        refreshSession(sessionId);
-      } else if (event.status === "idle" || event.status === "error") {
-        updateStatus(sessionId);
-        refreshSession(sessionId);
-      }
-    };
-
-    const disconnect = connectStatusStream({ onEvent: handleEvent });
-    return () => disconnect();
-  }, [refreshSession, sessionIdSet]);
+  const statuses = useMultiChatLiveStatuses({ sessionIds, onRefresh: refreshSession });
 
   useEffect(
     () => () => {

--- a/ui/src/pages/chat/multiChatLiveStatus.ts
+++ b/ui/src/pages/chat/multiChatLiveStatus.ts
@@ -1,0 +1,197 @@
+import type { LiveActivityItem } from "@/lib/chatActivities";
+import {
+  type StatusSessionSnapshot,
+  type StatusStreamStatusEvent,
+  type StreamAgentStatus,
+} from "@/lib/status-stream";
+import {
+  applyLiveActivityEvent,
+  formatToolIntent,
+  getLatestInFlightStep,
+  isGenericStatusLabel,
+  isMeaningfulThoughtDetail,
+  normalizeSessionStatus,
+  normalizeSnapshotActivities,
+  resolveStatusSnapshotActivities,
+  toLiveActivityItems,
+} from "./chatModel";
+
+export type MultiChatLiveStatusValue = "thinking" | "generating" | "compacting" | "idle";
+
+export interface MultiChatLiveState {
+  status: StreamAgentStatus;
+  liveStatus: MultiChatLiveStatusValue;
+  detail?: string;
+  timestamp: number;
+  observedAt: number;
+  startedAtMs: number;
+  activities: LiveActivityItem[];
+  currentStep: string | null;
+  runId: string | null;
+  sequence: number;
+}
+
+export const MULTI_CHAT_ACTIVE_STATUSES = new Set<StreamAgentStatus>([
+  "thinking",
+  "generating",
+  "tool_executing",
+  "tool_completed",
+  "compacting",
+]);
+
+function defaultCurrentStep(
+  status: MultiChatLiveStatusValue,
+  detail?: string,
+  activities: LiveActivityItem[] = []
+): string | null {
+  const activeTool = getLatestInFlightStep(activities);
+  if (activeTool && !isGenericStatusLabel(activeTool)) return activeTool;
+  const normalizedDetail = typeof detail === "string" ? detail.trim() : "";
+  if (isMeaningfulThoughtDetail(normalizedDetail)) return normalizedDetail;
+  if (status === "generating") return "Generating response...";
+  if (status === "compacting") return "Compacting earlier context...";
+  if (status === "thinking") return "Thinking...";
+  return null;
+}
+
+function snapshotLatestTimestamp(snapshot: StatusSessionSnapshot): number {
+  let latest = Number.isFinite(snapshot.timestamp) ? snapshot.timestamp : 0;
+  for (const activity of snapshot.activities || []) {
+    if (Number.isFinite(activity.timestamp) && activity.timestamp > latest) {
+      latest = activity.timestamp;
+    }
+  }
+  return latest;
+}
+
+export function projectMultiChatSnapshot(
+  snapshot: StatusSessionSnapshot,
+  previous?: MultiChatLiveState,
+  observedAt = Date.now()
+): MultiChatLiveState {
+  const liveStatus = normalizeSessionStatus(snapshot.status);
+  const snapshotActivities = normalizeSnapshotActivities(
+    toLiveActivityItems(snapshot.activities),
+    snapshot.status
+  );
+  const activities = resolveStatusSnapshotActivities(
+    snapshotActivities,
+    previous?.activities || [],
+    liveStatus
+  );
+  const timestamp = snapshotLatestTimestamp(snapshot) || observedAt;
+  const currentStep = defaultCurrentStep(liveStatus, snapshot.detail, activities);
+  return {
+    status: snapshot.status,
+    liveStatus,
+    detail: snapshot.detail,
+    timestamp,
+    observedAt,
+    startedAtMs: previous?.startedAtMs || timestamp,
+    activities,
+    currentStep,
+    runId: snapshot.runId?.trim() || previous?.runId || null,
+    sequence: snapshot.sequence || previous?.sequence || 0,
+  };
+}
+
+export function projectMultiChatStatusEvent(
+  previous: MultiChatLiveState | undefined,
+  event: StatusStreamStatusEvent,
+  observedAt = Date.now()
+): MultiChatLiveState | null {
+  const detail = typeof event.detail === "string" ? event.detail.trim() : "";
+  const steeringHandoff =
+    event.status === "idle" && detail.toLowerCase() === "steering to follow-up...";
+  if ((event.status === "idle" && !steeringHandoff) || event.status === "error") return null;
+
+  const timestamp = Number.isFinite(event.timestamp) ? event.timestamp : observedAt;
+  let status = event.status;
+  let liveStatus = normalizeSessionStatus(event.status);
+  let activities = previous?.activities || [];
+  let currentStep = previous?.currentStep || null;
+
+  if (steeringHandoff) {
+    status = "thinking";
+    liveStatus = "thinking";
+    activities = applyLiveActivityEvent(activities, {
+      phase: "result",
+      text: detail,
+      timestamp,
+      toolName: "__thought",
+    });
+    currentStep = detail;
+  } else if (
+    event.status === "thinking" ||
+    event.status === "generating" ||
+    event.status === "compacting"
+  ) {
+    if (!event.toolName && isMeaningfulThoughtDetail(detail)) {
+      activities = applyLiveActivityEvent(activities, {
+        phase: "result",
+        text: detail,
+        timestamp,
+        toolName: "__thought",
+      });
+    }
+    currentStep = defaultCurrentStep(liveStatus, detail, activities);
+  } else if (event.status === "tool_executing" || event.status === "tool_completed") {
+    const phase = event.toolPhase || (event.status === "tool_executing" ? "start" : "result");
+    const toolName = event.toolName || "tool";
+    const text = formatToolIntent(toolName, {}, phase, event.detail);
+    activities = applyLiveActivityEvent(activities, {
+      phase,
+      text,
+      timestamp,
+      toolName: event.toolName,
+      toolCallId: event.toolCallId,
+      sandboxProvider: event.sandboxProvider,
+    });
+    liveStatus = "thinking";
+    currentStep =
+      phase === "start"
+        ? isGenericStatusLabel(text)
+          ? "Thinking..."
+          : text
+        : defaultCurrentStep("thinking", undefined, activities);
+  }
+
+  return {
+    status,
+    liveStatus,
+    detail: detail || undefined,
+    timestamp,
+    observedAt,
+    startedAtMs: previous?.startedAtMs || timestamp,
+    activities,
+    currentStep,
+    runId: event.runId?.trim() || previous?.runId || null,
+    sequence: event.sequence || previous?.sequence || 0,
+  };
+}
+
+export function multiChatStateFromCache(
+  cached: {
+    status: MultiChatLiveStatusValue;
+    activities: LiveActivityItem[];
+    currentStep: string | null;
+    runId: string | null;
+    sequence: number;
+    startedAtMs: number | null;
+    updatedAt: number;
+  },
+  observedAt = Date.now()
+): MultiChatLiveState {
+  const status: StreamAgentStatus = cached.status === "idle" ? "thinking" : cached.status;
+  return {
+    status,
+    liveStatus: cached.status === "idle" ? "thinking" : cached.status,
+    timestamp: cached.updatedAt,
+    observedAt,
+    startedAtMs: cached.startedAtMs || cached.updatedAt,
+    activities: cached.activities,
+    currentStep: cached.currentStep,
+    runId: cached.runId,
+    sequence: cached.sequence,
+  };
+}

--- a/ui/src/pages/chat/useMultiChatLiveStatuses.ts
+++ b/ui/src/pages/chat/useMultiChatLiveStatuses.ts
@@ -1,0 +1,247 @@
+import { chatApi } from "@/lib/api";
+import {
+  connectStatusStream,
+  type StatusSessionSnapshot,
+  type StatusStreamEvent,
+} from "@/lib/status-stream";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  resolveSessionEventOrder,
+  type SessionEventCursor,
+} from "../../../../shared/session-event-order";
+import {
+  clearCachedLiveSessionState,
+  readCachedLiveSessionState,
+  writeCachedLiveSessionState,
+} from "./liveSessionState";
+import {
+  MULTI_CHAT_ACTIVE_STATUSES,
+  type MultiChatLiveState,
+  multiChatStateFromCache,
+  projectMultiChatSnapshot,
+  projectMultiChatStatusEvent,
+} from "./multiChatLiveStatus";
+
+interface UseMultiChatLiveStatusesOptions {
+  sessionIds: string[];
+  onRefresh: (sessionId: string) => void;
+}
+
+function snapshotIdentity(snapshot: StatusSessionSnapshot): {
+  runId?: string;
+  sequence?: number;
+  timestamp: number;
+} {
+  return {
+    runId: snapshot.runId,
+    sequence: snapshot.sequence,
+    timestamp: snapshot.timestamp,
+  };
+}
+
+export function useMultiChatLiveStatuses({
+  sessionIds,
+  onRefresh,
+}: UseMultiChatLiveStatusesOptions): Record<string, MultiChatLiveState> {
+  const [statuses, setStatuses] = useState<Record<string, MultiChatLiveState>>({});
+  const cursorsRef = useRef<Record<string, SessionEventCursor>>({});
+  const sessionIdSet = useMemo(() => new Set(sessionIds), [sessionIds]);
+  const sessionIdSetRef = useRef(sessionIdSet);
+
+  useEffect(() => {
+    sessionIdSetRef.current = sessionIdSet;
+    setStatuses((current) => {
+      const next: Record<string, MultiChatLiveState> = {};
+      for (const sessionId of sessionIds) {
+        const existing = current[sessionId];
+        if (existing) {
+          next[sessionId] = existing;
+          continue;
+        }
+        const cached = readCachedLiveSessionState(sessionId);
+        if (cached && cached.status !== "idle") {
+          next[sessionId] = multiChatStateFromCache(cached);
+        }
+      }
+      return next;
+    });
+  }, [sessionIdSet, sessionIds]);
+
+  const acceptEvent = useCallback(
+    (sessionId: string, identity: Parameters<typeof resolveSessionEventOrder>[1]): boolean => {
+      const decision = resolveSessionEventOrder(cursorsRef.current[sessionId], identity);
+      if (!decision.accepted) return false;
+      cursorsRef.current[sessionId] = decision.cursor;
+      return true;
+    },
+    []
+  );
+
+  const storeStatus = useCallback((sessionId: string, state: MultiChatLiveState | null): void => {
+    setStatuses((current) => {
+      if (!state) {
+        if (!current[sessionId]) return current;
+        const next = { ...current };
+        delete next[sessionId];
+        return next;
+      }
+      return { ...current, [sessionId]: state };
+    });
+    if (!state) {
+      clearCachedLiveSessionState(sessionId);
+      return;
+    }
+    writeCachedLiveSessionState(sessionId, {
+      status: state.liveStatus,
+      activities: state.activities,
+      currentStep: state.currentStep,
+      streamingContent: null,
+      runId: state.runId,
+      sequence: state.sequence,
+      startedAtMs: state.startedAtMs,
+      updatedAt: state.observedAt,
+    });
+  }, []);
+
+  const applySnapshot = useCallback(
+    (snapshot: StatusSessionSnapshot, observedAt = Date.now()): void => {
+      const sessionId = snapshot.sessionId.trim();
+      if (!sessionId || !sessionIdSetRef.current.has(sessionId)) return;
+      if (!MULTI_CHAT_ACTIVE_STATUSES.has(snapshot.status)) return;
+      if (!acceptEvent(sessionId, snapshotIdentity(snapshot))) return;
+      setStatuses((current) => {
+        const next = projectMultiChatSnapshot(snapshot, current[sessionId], observedAt);
+        writeCachedLiveSessionState(sessionId, {
+          status: next.liveStatus,
+          activities: next.activities,
+          currentStep: next.currentStep,
+          streamingContent: null,
+          runId: next.runId,
+          sequence: next.sequence,
+          startedAtMs: next.startedAtMs,
+          updatedAt: next.observedAt,
+        });
+        return { ...current, [sessionId]: next };
+      });
+      onRefresh(sessionId);
+    },
+    [acceptEvent, onRefresh]
+  );
+
+  const hydrate = useCallback(async (): Promise<void> => {
+    const requestedAt = Date.now();
+    try {
+      const response = await chatApi.getSessionStatus();
+      if (!response.success || !response.data) return;
+      const activeIds = new Set(
+        (response.data.activeSessionIds || []).filter(
+          (sessionId): sessionId is string => typeof sessionId === "string" && !!sessionId.trim()
+        )
+      );
+      for (const snapshot of response.data.activeSessions || []) {
+        applySnapshot(snapshot);
+      }
+      setStatuses((current) => {
+        let changed = false;
+        const next = { ...current };
+        for (const [sessionId, state] of Object.entries(current)) {
+          if (
+            sessionIdSetRef.current.has(sessionId) &&
+            !activeIds.has(sessionId) &&
+            state.observedAt <= requestedAt
+          ) {
+            delete next[sessionId];
+            clearCachedLiveSessionState(sessionId);
+            changed = true;
+          }
+        }
+        return changed ? next : current;
+      });
+    } catch {
+      return;
+    }
+  }, [applySnapshot]);
+
+  useEffect(() => {
+    void hydrate();
+  }, [hydrate, sessionIdSet]);
+
+  useEffect(() => {
+    const handleEvent = (event: StatusStreamEvent): void => {
+      if (event.type === "snapshot") {
+        for (const snapshot of event.activeSessions) applySnapshot(snapshot);
+        return;
+      }
+      if (event.type === "task_completed") {
+        const sessionId = event.sessionId?.trim();
+        if (!sessionId || !sessionIdSetRef.current.has(sessionId)) return;
+        storeStatus(sessionId, null);
+        onRefresh(sessionId);
+        return;
+      }
+      const sessionId = event.sessionId?.trim();
+      if (!sessionId || !sessionIdSetRef.current.has(sessionId)) return;
+      if (!acceptEvent(sessionId, event)) return;
+      if (event.type === "assistant_token") {
+        setStatuses((current) => {
+          const previous = current[sessionId];
+          const observedAt = Date.now();
+          const next: MultiChatLiveState = {
+            status: "generating",
+            liveStatus: "generating",
+            timestamp: event.timestamp,
+            observedAt,
+            startedAtMs: previous?.startedAtMs || event.timestamp || observedAt,
+            activities: previous?.activities || [],
+            currentStep: previous?.currentStep || "Generating response...",
+            runId: event.runId?.trim() || previous?.runId || null,
+            sequence: event.sequence || previous?.sequence || 0,
+          };
+          writeCachedLiveSessionState(sessionId, {
+            status: next.liveStatus,
+            activities: next.activities,
+            currentStep: next.currentStep,
+            streamingContent: null,
+            runId: next.runId,
+            sequence: next.sequence,
+            startedAtMs: next.startedAtMs,
+            updatedAt: next.observedAt,
+          });
+          return { ...current, [sessionId]: next };
+        });
+        onRefresh(sessionId);
+        return;
+      }
+      setStatuses((current) => {
+        const next = projectMultiChatStatusEvent(current[sessionId], event);
+        if (!next) {
+          if (!current[sessionId]) return current;
+          const updated = { ...current };
+          delete updated[sessionId];
+          clearCachedLiveSessionState(sessionId);
+          return updated;
+        }
+        writeCachedLiveSessionState(sessionId, {
+          status: next.liveStatus,
+          activities: next.activities,
+          currentStep: next.currentStep,
+          streamingContent: null,
+          runId: next.runId,
+          sequence: next.sequence,
+          startedAtMs: next.startedAtMs,
+          updatedAt: next.observedAt,
+        });
+        return { ...current, [sessionId]: next };
+      });
+      onRefresh(sessionId);
+    };
+
+    return connectStatusStream({
+      replayBufferedSessionEvents: true,
+      onOpen: () => void hydrate(),
+      onEvent: handleEvent,
+    });
+  }, [acceptEvent, applySnapshot, hydrate, onRefresh, storeStatus]);
+
+  return statuses;
+}


### PR DESCRIPTION


<!-- GITZILLA_SUMMARY -->
> [!NOTE]
> **Low Risk**
>
> **Overview**
> Introduces a live status tracking system for multi-chat workspaces, refactoring inline session-status logic into a reusable `multiChatLiveStatus` module and a `useMultiChatLiveStatuses` hook. The sidebar gains an `activeSessionTracker` to monitor the active chat session, with the `Sidebar.tsx` component updated to consume tracker signals for its status indicator. The `MultiChatWorkspace` is simplified by delegating live-status concerns to the new hook, and the `api.ts` layer drops now-unused status code in favor of the centralized tracker. Corresponding unit tests cover the new tracker, live-status hook, sidebar indicator wiring, and multi-chat integration.
>
> <sup>Written by [Gitzilla](https://gitzilla.ai) for commit 628e08b. This will update automatically on new runs. Configure in the [Gitzilla dashboard](https://gitzilla.ai/dashboard).</sup>
<!-- /GITZILLA_SUMMARY -->