### PR TITLE
Release

### DIFF
--- a/plugins/huggingface-workflows/cybara-plugin.json
+++ b/plugins/huggingface-workflows/cybara-plugin.json
@@ -1,0 +1,14 @@
+{
+  "schemaVersion": 1,
+  "id": "huggingface-workflows",
+  "name": "Hugging Face Workflows",
+  "version": "1.0.0",
+  "description": "Hub, dataset, evaluation, training, experiment tracking, application, and local inference workflows for Hugging Face.",
+  "author": "Cybara",
+  "homepage": "https://huggingface.co/docs",
+  "contributions": {
+    "skills": {
+      "dirs": ["skills"]
+    }
+  }
+}

--- a/plugins/huggingface-workflows/skills/hf-cli/SKILL.md
+++ b/plugins/huggingface-workflows/skills/hf-cli/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: hf-cli
+description: Inspect and manage Hugging Face Hub models, datasets, Spaces, repositories, cache, authentication, and downloads with the current hf CLI.
+metadata: {"cybara":{"homepage":"https://huggingface.co/docs/huggingface_hub/guides/cli","os":["darwin","linux","win32"]}}
+---
+
+# Hugging Face CLI
+
+Use the current `hf` CLI for Hub operations. Do not use the deprecated `huggingface-cli` command.
+
+## Workflow
+
+1. Run `hf version` and `hf --help` before relying on a command that may vary by installed version.
+2. Use public read-only operations without authentication when possible.
+3. For private or write operations, run `hf auth whoami` without printing stored tokens.
+4. Prefer structured output such as `--format json` when another tool will consume the result.
+5. Use `--dry-run` when supported before downloads, cache cleanup, synchronization, or deletion.
+6. Confirm the repository, revision, visibility, and affected paths before uploads or destructive changes.
+
+## Common operations
+
+```bash
+hf models info namespace/model --format json
+hf models list --search "query" --limit 20 --format json
+hf datasets info namespace/dataset --format json
+hf datasets list --search "query" --limit 20 --format json
+hf download namespace/model --include "*.json" --dry-run
+hf cache list --limit 30
+hf papers list --limit 20 --format json
+```
+
+Use `hf upload` for a bounded file or directory and `hf upload-large-folder` for resumable large uploads. Never place a token in command arguments, source files, logs, or chat output. Use the authenticated credential store or `HF_TOKEN` environment variable.
+
+If `hf` is unavailable, report that prerequisite clearly. Do not install software unless the user requested installation.

--- a/plugins/huggingface-workflows/skills/huggingface-community-evals/SKILL.md
+++ b/plugins/huggingface-workflows/skills/huggingface-community-evals/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: huggingface-community-evals
+description: Run reproducible local or remote model evaluations with inspect-ai or LightEval, bounded smoke tests, captured configurations, and comparable results.
+metadata: {"cybara":{"homepage":"https://huggingface.co/docs/evaluate","os":["darwin","linux","win32"]}}
+---
+
+# Hugging Face Community Evaluations
+
+Use Inspect or LightEval for models hosted on the Hub. Keep evaluation execution separate from publishing results.
+
+## Workflow
+
+1. Record the model ID, immutable revision, inference backend, tokenizer, chat template, dtype, quantization, generation parameters, task revision, and seed.
+2. Check gated-model authentication without printing credentials.
+3. Choose a backend supported by the model and hardware. Prefer vLLM for supported throughput workloads and Transformers or Accelerate as compatibility fallbacks.
+4. Start with a bounded smoke run such as 10 examples.
+5. Inspect failures and sample outputs before scaling.
+6. Save raw results, aggregate metrics, environment metadata, and the exact command.
+7. Compare only runs with compatible task versions, prompts, few-shot settings, and inference parameters.
+
+Use `uv run` for Python evaluation environments. Run remote evaluation through the `huggingface-jobs` workflow only after confirming paid hardware and timeout.
+
+Do not cherry-pick favorable tasks, silently discard failures, or present incomparable scores in one ranking. Publishing model-card results, opening a pull request, or modifying a leaderboard is a separate external action that requires confirmation.

--- a/plugins/huggingface-workflows/skills/huggingface-datasets/SKILL.md
+++ b/plugins/huggingface-workflows/skills/huggingface-datasets/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: huggingface-datasets
+description: Explore, validate, filter, paginate, export, and prepare Hugging Face datasets through the Dataset Viewer API and Hub tooling.
+metadata: {"cybara":{"homepage":"https://huggingface.co/docs/dataset-viewer","os":["darwin","linux","win32"]}}
+---
+
+# Hugging Face Datasets
+
+Prefer the read-only Dataset Viewer API for discovery and validation. Use Cybara's `http` tool so responses remain structured and visible in the chat.
+
+## Read-only workflow
+
+1. Validate the dataset with `GET https://datasets-server.huggingface.co/is-valid?dataset=<id>`.
+2. Resolve subsets and splits through `/splits`.
+3. Inspect representative records with `/first-rows`.
+4. Paginate `/rows` with a zero-based `offset` and `length` no greater than 100.
+5. Use `/search` for text and `/filter` for predicates instead of downloading the full dataset.
+6. Inspect `/size`, `/statistics`, and `/parquet` before training or bulk processing.
+
+URL-encode dataset IDs, subset names, split names, queries, and predicates. Add `Authorization: Bearer <token>` only for a gated or private dataset, and never expose the token in output.
+
+## Training readiness
+
+Before proposing a training run, report:
+
+- dataset ID, revision, subset, and split
+- row count and relevant columns
+- a small redacted sample
+- missing, malformed, duplicate, or unexpectedly long records
+- license, gating, and provenance constraints visible in the dataset card
+- the exact mapping required by the selected trainer
+
+For SFT, verify text, conversational `messages`, or prompt-completion records. For preference training, verify prompt, chosen, and rejected values. For reward or RL workflows, verify the expected prompt and reward inputs.
+
+Cybara Lab can export `hf_session_trace` data. Validate and redact that export before uploading it as a dataset.
+
+Uploading, changing visibility, or deleting a dataset is an external side effect. Confirm the destination repository and affected files immediately before the write.

--- a/plugins/huggingface-workflows/skills/huggingface-gradio/SKILL.md
+++ b/plugins/huggingface-workflows/skills/huggingface-gradio/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: huggingface-gradio
+description: Build, test, and publish accessible Gradio interfaces for models and data workflows using reproducible Python environments.
+metadata: {"cybara":{"homepage":"https://www.gradio.app/docs","os":["darwin","linux","win32"]}}
+---
+
+# Hugging Face Gradio
+
+Use Gradio for focused model demos, dataset tools, and internal evaluation interfaces.
+
+## Workflow
+
+1. Define the smallest input and output schema that demonstrates the workflow.
+2. Put model loading outside the request handler and bound concurrency, queue size, timeouts, and upload sizes.
+3. Validate file types and user input before inference.
+4. Build the app in a UV-managed environment and run it locally first.
+5. Exercise keyboard navigation, labels, loading, empty, error, cancellation, and mobile-width states.
+6. Measure cold start and warmed request latency.
+7. Add authentication before exposing private models, datasets, or outputs.
+
+Do not enable a public share link or deploy a Space unless the user explicitly requests that external action. Before deployment, review secrets, repository visibility, hardware, sleep behavior, and expected cost.

--- a/plugins/huggingface-workflows/skills/huggingface-jobs/SKILL.md
+++ b/plugins/huggingface-workflows/skills/huggingface-jobs/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: huggingface-jobs
+description: Plan, launch, inspect, monitor, and cancel authenticated Hugging Face Jobs for CPU, GPU, TPU, batch, inference, and data workloads.
+metadata: {"cybara":{"homepage":"https://huggingface.co/docs/huggingface_hub/guides/jobs","os":["darwin","linux","win32"]}}
+---
+
+# Hugging Face Jobs
+
+Use `hf jobs` for remote workloads. Jobs consume paid compute and run outside the local workspace.
+
+## Preflight
+
+1. Run `hf version`, `hf jobs --help`, and `hf auth whoami`.
+2. Verify the account or organization has access and sufficient credits.
+3. Inspect available hardware with `hf jobs hardware`.
+4. Define the command or UV script, dependencies, hardware flavor, namespace, timeout, persistence path, and expected cost boundary.
+5. Present the exact launch plan and obtain confirmation before starting paid compute.
+
+Never transmit a token in source, command arguments, or logs. Use the authenticated CLI session and pass sensitive values through the Jobs secrets mechanism.
+
+## Execution
+
+Prefer a self-contained UV script for Python workloads:
+
+```bash
+hf jobs uv run --detach --flavor gpu-t4-small --timeout 2h train.py
+```
+
+Use a container only when the workload requires a specific system image:
+
+```bash
+hf jobs run --detach --flavor cpu-basic --timeout 30m python:3.12 python -c "print('ready')"
+```
+
+Start with the cheapest representative smoke run. Do not scale to the full dataset or larger hardware until inputs, imports, persistence, and metrics are verified.
+
+## Monitoring
+
+```bash
+hf jobs ps --all --format json
+hf jobs inspect <job-id>
+hf jobs logs <job-id> --tail 200
+hf jobs stats <job-id>
+hf jobs cancel <job-id>
+```
+
+After launch, report the job ID, URL, namespace, hardware, timeout, and where outputs will persist. Do not poll indefinitely. Check status when the user asks or when an active task explicitly requires completion.

--- a/plugins/huggingface-workflows/skills/huggingface-llm-trainer/SKILL.md
+++ b/plugins/huggingface-workflows/skills/huggingface-llm-trainer/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: huggingface-llm-trainer
+description: Design and run reproducible LLM fine-tuning with TRL, PEFT, Hugging Face Jobs, validated datasets, experiment tracking, and durable Hub outputs.
+metadata: {"cybara":{"homepage":"https://huggingface.co/docs/trl","os":["darwin","linux","win32"]}}
+---
+
+# Hugging Face LLM Trainer
+
+Use TRL and PEFT for supervised fine-tuning, preference optimization, reinforcement learning, and reward modeling. Use Hugging Face Jobs when remote compute is requested.
+
+## Method selection
+
+- SFT: instruction, conversation, or prompt-completion demonstrations
+- DPO: prompt with chosen and rejected responses
+- GRPO: prompts with deterministic, testable reward functions or environments
+- Reward modeling: examples labeled or ranked for preference quality
+
+Do not choose a method from the dataset name alone. Inspect the schema and sample records first with `huggingface-datasets`.
+
+## Training plan
+
+1. Record the base model ID and immutable revision, license, architecture, context length, tokenizer, and chat template.
+2. Validate train and evaluation splits, field mapping, length distribution, duplication, contamination risk, and redaction.
+3. Select full fine-tuning or PEFT from model size, hardware, memory, and deployment needs.
+4. Pin dependencies in a self-contained UV script.
+5. Seed data splitting and training, log the complete configuration, and define evaluation criteria before launch.
+6. Enable durable output with `push_to_hub`, a target model ID, and checkpoints or mounted storage appropriate to the run.
+7. Add Trackio or the requested tracker for loss, learning rate, throughput, evaluation metrics, and failure alerts.
+8. Run a tiny smoke job before the paid production run.
+
+Use current TRL configuration names verified from the installed version or official docs. Do not guess parameters from older examples.
+
+Before launching paid compute, present the model, dataset revision, method, hardware, timeout, estimated cost boundary, output repository, and command for confirmation. After launch, report the job ID and monitoring links. Do not claim model quality from training loss alone; run task-appropriate evaluation and preserve the results with the model card.

--- a/plugins/huggingface-workflows/skills/huggingface-paper-publisher/SKILL.md
+++ b/plugins/huggingface-workflows/skills/huggingface-paper-publisher/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: huggingface-paper-publisher
+description: Prepare and publish reproducible Hugging Face paper pages with linked code, models, datasets, demos, metadata, and validated claims.
+metadata: {"cybara":{"homepage":"https://huggingface.co/papers","os":["darwin","linux","win32"]}}
+---
+
+# Hugging Face Paper Publisher
+
+Prepare a publication package before changing any Hub repository or paper page.
+
+## Package
+
+- title, authors, affiliations, abstract, date, and stable paper identifier
+- canonical paper file or URL
+- code repository and immutable revision
+- model and dataset repositories with licenses
+- evaluation commands, raw results, hardware, and environment details
+- representative figures with alt text and captions
+- limitations, safety considerations, and known reproduction gaps
+
+Verify that every linked artifact exists and that reported values match the underlying results. Remove secrets, private URLs, personal data, and local filesystem paths.
+
+Creating repositories, uploading files, changing visibility, or publishing a page is an external side effect. Present the destination, files, metadata, and visibility for confirmation immediately before publishing. Afterward, reopen the public or private result as appropriate and verify links, rendering, and access controls.

--- a/plugins/huggingface-workflows/skills/huggingface-papers/SKILL.md
+++ b/plugins/huggingface-workflows/skills/huggingface-papers/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: huggingface-papers
+description: Discover and analyze Hugging Face papers with traceable sources, linked models and datasets, and clearly separated claims and evidence.
+metadata: {"cybara":{"homepage":"https://huggingface.co/papers","os":["darwin","linux","win32"]}}
+---
+
+# Hugging Face Papers
+
+Use `hf papers list --format json` or the Hub papers pages for discovery, then inspect the original paper before relying on a claim.
+
+## Workflow
+
+1. Capture the title, authors, publication date, paper URL, and stable identifier.
+2. Read the abstract, method, training data, evaluation setup, ablations, limitations, and license.
+3. Follow linked model, dataset, code, and demo repositories only when they are relevant.
+4. Distinguish author claims from reproduced or independently verified results.
+5. Compare metrics only when tasks, splits, prompts, baselines, and compute settings are compatible.
+6. Cite the original paper and primary artifacts near each technical claim.
+
+Do not infer implementation details that are absent from the paper or its linked source. State when evidence is missing, unpublished, or not reproducible from available artifacts.

--- a/plugins/huggingface-workflows/skills/huggingface-trackio/SKILL.md
+++ b/plugins/huggingface-workflows/skills/huggingface-trackio/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: huggingface-trackio
+description: Instrument, monitor, compare, and diagnose machine-learning experiments with Trackio metrics, alerts, dashboards, and structured exports.
+metadata: {"cybara":{"homepage":"https://huggingface.co/docs/trackio","os":["darwin","linux","win32"]}}
+---
+
+# Hugging Face Trackio
+
+Use Trackio to make training state observable and reproducible.
+
+## Instrumentation
+
+```python
+import trackio
+
+trackio.init(project="project-name", config={"learning_rate": 0.0001})
+trackio.log({"loss": 0.1, "learning_rate": 0.0001, "step": 1})
+trackio.finish()
+```
+
+Use `report_to="trackio"` when the selected trainer supports it. For remote training, configure a durable Space or other supported synchronization target so metrics survive the job.
+
+## Required signals
+
+- train and evaluation loss
+- task-specific evaluation metrics
+- learning rate and step or epoch
+- examples or tokens processed per second
+- GPU memory or system utilization when available
+- configuration, model revision, dataset revision, and seed
+- alerts for NaN/Inf values, loss divergence, stalled progress, and failed persistence
+
+Use structured CLI output when retrieving metrics for an agent. Compare runs only after verifying that their model, data, method, and evaluation settings are compatible.
+
+Creating or changing a public tracking Space, webhook, or external alert destination transmits data. Confirm the destination and the metrics being sent before enabling it, and never log secrets or raw sensitive examples.

--- a/plugins/huggingface-workflows/skills/huggingface-vision-trainer/SKILL.md
+++ b/plugins/huggingface-workflows/skills/huggingface-vision-trainer/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: huggingface-vision-trainer
+description: Prepare, train, evaluate, and publish computer-vision and vision-language models with Hugging Face datasets, Transformers, PEFT, and Jobs.
+metadata: {"cybara":{"homepage":"https://huggingface.co/docs/transformers/tasks","os":["darwin","linux","win32"]}}
+---
+
+# Hugging Face Vision Trainer
+
+Use this workflow for image classification, object detection, segmentation, depth estimation, and vision-language fine-tuning.
+
+## Workflow
+
+1. Inspect the dataset card, license, image features, labels, splits, corrupt records, class balance, dimensions, and annotation coordinate format.
+2. Visualize a small representative sample before transforming labels or augmenting images.
+3. Choose a model and processor that explicitly support the task and license requirements.
+4. Preserve label mappings, preprocessing settings, image normalization, and augmentation seeds in the training configuration.
+5. Split by source or subject when random row splitting could leak near-duplicate images.
+6. Select task-appropriate metrics such as accuracy/F1, mAP, IoU, or VQA-style scores.
+7. Run a small batch through preprocessing, forward pass, loss, and metric computation before launching remote training.
+8. Save the processor with the model and publish representative evaluation outputs in the model card.
+
+For vision-language models, ensure image tokens are not truncated and verify the model's chat template. Use PEFT when it materially reduces memory without invalidating the task.
+
+Remote GPU work follows the `huggingface-jobs` confirmation and monitoring workflow. Do not upload private images, biometric data, or sensitive annotations without explicit authorization.

--- a/plugins/huggingface-workflows/skills/transformers-js/SKILL.md
+++ b/plugins/huggingface-workflows/skills/transformers-js/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: transformers-js
+description: Build and validate local browser or Bun inference with Hugging Face Transformers.js, WebGPU or WASM backends, quantization, caching, and cleanup.
+metadata: {"cybara":{"homepage":"https://huggingface.co/docs/transformers.js","os":["darwin","linux","win32"]}}
+---
+
+# Transformers.js
+
+Use `@huggingface/transformers` for JavaScript or TypeScript inference in Bun, Node-compatible runtimes, and browsers.
+
+## Setup
+
+```bash
+bun add @huggingface/transformers
+```
+
+```ts
+import { pipeline } from "@huggingface/transformers";
+
+const classifier = await pipeline("text-classification");
+try {
+  const result = await classifier("Cybara runs this model locally.");
+  console.log(result);
+} finally {
+  await classifier.dispose();
+}
+```
+
+## Workflow
+
+1. Choose a model whose card lists Transformers.js or ONNX compatibility for the required task.
+2. Pin the model ID and revision when reproducibility matters.
+3. Start with CPU/WASM compatibility, then enable WebGPU only after feature detection.
+4. Select dtype or quantization from measured memory, latency, and quality requirements.
+5. Configure the cache explicitly for desktop or server runtimes.
+6. Warm the model before benchmarking and separate download time from inference latency.
+7. Dispose pipelines and tensors when the workflow ends.
+8. Test unavailable WebGPU, interrupted downloads, offline cache reuse, and malformed inputs.
+
+Do not load untrusted custom model code. For browser applications, keep model downloads visible to the user and avoid blocking the main thread during initialization or long inference.

--- a/shared/tool-activity-detail.ts
+++ b/shared/tool-activity-detail.ts
@@ -1,0 +1,165 @@
+export type ToolActivityPhase = "start" | "result" | "error" | "blocked";
+
+interface PlanItemDetail {
+  content: string;
+  status: "pending" | "in_progress" | "completed";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function readString(
+  record: Record<string, unknown>,
+  keys: string[],
+): string | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value !== "string") continue;
+    const trimmed = value.trim();
+    if (trimmed) return trimmed;
+  }
+  return undefined;
+}
+
+function normalizePlanStatus(value: unknown): PlanItemDetail["status"] {
+  if (value === "completed" || value === "in_progress") return value;
+  return "pending";
+}
+
+function planItemsFrom(value: unknown): PlanItemDetail[] {
+  if (!Array.isArray(value)) return [];
+  const items: PlanItemDetail[] = [];
+  for (const candidate of value) {
+    if (!isRecord(candidate)) continue;
+    const content = readString(candidate, ["content", "step", "task"]);
+    if (!content) continue;
+    items.push({ content, status: normalizePlanStatus(candidate.status) });
+  }
+  return items;
+}
+
+function resolvePlanItems(
+  args: Record<string, unknown>,
+  result: unknown,
+): PlanItemDetail[] {
+  if (isRecord(result)) {
+    const resultItems = planItemsFrom(result.items);
+    if (resultItems.length > 0 || Array.isArray(result.items))
+      return resultItems;
+  }
+  return planItemsFrom(args.items);
+}
+
+function formatPlanSummary(
+  items: PlanItemDetail[],
+  phase: ToolActivityPhase,
+): string {
+  if (phase === "blocked") return "Plan update blocked";
+  if (phase === "error") return "Plan update failed";
+  if (items.length === 0)
+    return phase === "start" ? "Updating plan..." : "Cleared plan";
+
+  const completed = items.filter((item) => item.status === "completed");
+  const active = items.find((item) => item.status === "in_progress");
+
+  if (phase === "start") {
+    if (active) return `Updating plan: ${active.content}`;
+    if (completed.length === items.length) return "Completing plan...";
+    return `Updating plan (${items.length} items)...`;
+  }
+
+  if (completed.length === items.length) {
+    if (items.length === 1)
+      return `Completed "${items[0]?.content || "plan item"}"`;
+    return `Completed all ${items.length} plan items`;
+  }
+  if (active) {
+    return `Updated plan: ${active.content} in progress (${completed.length}/${items.length} complete)`;
+  }
+  if (completed.length > 0) {
+    return `Updated plan: ${completed.length}/${items.length} complete`;
+  }
+  return `Created plan with ${items.length} item${items.length === 1 ? "" : "s"}`;
+}
+
+export function formatStructuredToolActivityDetail(
+  toolName: string,
+  args: Record<string, unknown>,
+  phase: ToolActivityPhase,
+  result?: unknown,
+): string | undefined {
+  const key = toolName.trim().toLowerCase();
+
+  if (key === "skill_load") {
+    const resultName = isRecord(result)
+      ? readString(result, ["name"])
+      : undefined;
+    const name = resultName || readString(args, ["name"]);
+    const target = name ? ` ${name} skill` : " skill";
+    if (phase === "start") return `Loading${target}...`;
+    if (phase === "result") return `Loaded${target}`;
+    if (phase === "blocked")
+      return name ? `Skill load blocked for ${name}` : "Skill load blocked";
+    return name ? `Skill load failed for ${name}` : "Skill load failed";
+  }
+
+  if (key === "todo" || key === "update_plan") {
+    return formatPlanSummary(resolvePlanItems(args, result), phase);
+  }
+
+  return undefined;
+}
+
+function commandActivityDetail(
+  args: Record<string, unknown>,
+  phase: ToolActivityPhase,
+): string | undefined {
+  const command = readString(args, ["command", "cmd"]);
+  if (!command) return undefined;
+  const prefix =
+    phase === "start"
+      ? "Running"
+      : phase === "result"
+        ? "Ran"
+        : phase === "blocked"
+          ? "Command blocked"
+          : "Command failed";
+  return `${prefix} ${command}`;
+}
+
+function planActivityDetail(
+  args: Record<string, unknown>,
+  phase: ToolActivityPhase,
+  result?: unknown,
+): string | undefined {
+  const items = resolvePlanItems(args, result);
+  if (items.length === 0) return undefined;
+  const summary = formatPlanSummary(items, phase);
+  const lines = items.map((item) => {
+    const marker =
+      item.status === "completed"
+        ? "[x]"
+        : item.status === "in_progress"
+          ? "[~]"
+          : "[ ]";
+    return `${marker} ${item.content}`;
+  });
+  return `${summary}\n${lines.join("\n")}`;
+}
+
+export function formatExpandedToolActivityDetail(
+  toolName: string,
+  args: Record<string, unknown>,
+  phase: ToolActivityPhase,
+  result?: unknown,
+): string | undefined {
+  const key = toolName.trim().toLowerCase();
+  if (key === "exec" || key === "process" || key === "git") {
+    return commandActivityDetail(args, phase);
+  }
+  if (key === "todo" || key === "update_plan") {
+    return planActivityDetail(args, phase, result);
+  }
+  return formatStructuredToolActivityDetail(toolName, args, phase, result);
+}

--- a/src/api/chat-process-activities.ts
+++ b/src/api/chat-process-activities.ts
@@ -1,3 +1,5 @@
+import { formatStructuredToolActivityDetail } from "../../shared/tool-activity-detail";
+
 export interface ProcessActivityInfo {
   id: string;
   phase: "start" | "result" | "error" | "blocked";
@@ -93,6 +95,19 @@ function normalizeProcessActivityTextForPhase(
 export function formatProcessActivityFromToolCall(toolCall: ToolCallInfo): string {
   const key = toolCall.name.toLowerCase();
   const args = toolCall.args || {};
+  const phase =
+    toolCall.status === "pending" || toolCall.status === "executing"
+      ? "start"
+      : toolCall.status === "failed"
+        ? "error"
+        : "result";
+  const structuredDetail = formatStructuredToolActivityDetail(
+    toolCall.name,
+    args,
+    phase,
+    toolCall.result ?? toolCall.error
+  );
+  if (structuredDetail) return structuredDetail;
   const path = readToolArgString(args, "path");
   const displayPath = path ? toActivityDisplayPath(path) : undefined;
 

--- a/src/api/chat-run-recovery.ts
+++ b/src/api/chat-run-recovery.ts
@@ -18,6 +18,13 @@ import type { ProcessActivityInfo } from "./chat-process-activities";
 import { INTERRUPTED_RESPONSE } from "./chat-interruption";
 import type { ChatMessage } from "./chat-types";
 
+const LEGACY_RUN_RECOVERY_SETTLE_MS = 30_000;
+
+export interface ChatRunRecoveryOptions {
+  now?: number;
+  processAlive?: (processId: number) => boolean;
+}
+
 const AGENT_STATUSES = new Set<AgentStatus>([
   "idle",
   "thinking",
@@ -42,6 +49,45 @@ function eventTimestamp(event: SessionLedgerEvent): number {
     : `${event.createdAt.replace(" ", "T")}Z`;
   const parsed = Date.parse(normalized);
   return Number.isFinite(parsed) ? parsed : Date.now();
+}
+
+function runProcessId(events: SessionLedgerEvent[]): number | undefined {
+  for (const event of events) {
+    if (event.type !== "run_started" || !isRecord(event.payload)) continue;
+    const processId = event.payload.processId;
+    if (typeof processId === "number" && Number.isInteger(processId) && processId > 0) {
+      return processId;
+    }
+  }
+  return undefined;
+}
+
+function processIsAlive(processId: number): boolean {
+  if (processId === process.pid) return true;
+  try {
+    process.kill(processId, 0);
+    return true;
+  } catch (error) {
+    return isRecord(error) && error.code === "EPERM";
+  }
+}
+
+function latestRunActivityAt(events: SessionLedgerEvent[]): number {
+  return events.reduce((latest, event) => Math.max(latest, eventTimestamp(event)), 0);
+}
+
+function legacyRunIsSettled(events: SessionLedgerEvent[], now: number): boolean {
+  const latestActivityAt = latestRunActivityAt(events);
+  return latestActivityAt > 0 && now - latestActivityAt >= LEGACY_RUN_RECOVERY_SETTLE_MS;
+}
+
+function incompleteRunCanBeRecovered(
+  events: SessionLedgerEvent[],
+  options: Required<ChatRunRecoveryOptions>
+): boolean {
+  const ownerProcessId = runProcessId(events);
+  if (ownerProcessId !== undefined) return !options.processAlive(ownerProcessId);
+  return legacyRunIsSettled(events, options.now);
 }
 
 function statusPayload(event: SessionLedgerEvent): StatusPayload | null {
@@ -207,8 +253,13 @@ function hasDurableAssistantWithinRun(
 export async function recoverInterruptedSessionMessages(
   sessionId: string,
   agentId: string,
-  messages: ChatMessage[]
+  messages: ChatMessage[],
+  recoveryOptions: ChatRunRecoveryOptions = {}
 ): Promise<ChatMessage[]> {
+  const options: Required<ChatRunRecoveryOptions> = {
+    now: recoveryOptions.now ?? Date.now(),
+    processAlive: recoveryOptions.processAlive ?? processIsAlive,
+  };
   const eventCache = new Map<string, SessionLedgerEvent[]>();
   for (const event of listAllSessionEvents(sessionId)) {
     const events = eventCache.get(event.runId) || [];
@@ -238,7 +289,8 @@ export async function recoverInterruptedSessionMessages(
       !runId ||
       runId === activeRunId ||
       representedRunIds.has(runId) ||
-      hasDurableAssistantWithinRun(hydrated, events)
+      hasDurableAssistantWithinRun(hydrated, events) ||
+      !legacyRunIsSettled(events, options.now)
     ) {
       continue;
     }
@@ -266,7 +318,13 @@ export async function recoverInterruptedSessionMessages(
   for (const run of listIncompleteSessionRuns(sessionId)) {
     if (run.runId === activeRunId || representedRunIds.has(run.runId)) continue;
     const events = eventsForRun(run.runId);
-    if (events.length === 0 || hasPersistedAssistantEvent(events)) continue;
+    if (
+      events.length === 0 ||
+      hasPersistedAssistantEvent(events) ||
+      !incompleteRunCanBeRecovered(events, options)
+    ) {
+      continue;
+    }
     const processActivities = buildActivities(events, true);
     const content = sanitizeAssistantContent(events.map(assistantDelta).join(""));
     if (processActivities.length <= 1 && !content.trim()) continue;

--- a/src/api/chat-runtime.ts
+++ b/src/api/chat-runtime.ts
@@ -312,10 +312,10 @@ async function finishInterruptedChatTurn(
 ): Promise<ChatResponse> {
   clearActiveChatTurnAbortController(session.id, controller);
   const pendingSteeringId = interruptedChatTurnSteeringIds.get(controller);
-  const materializedMessage = materializeInterruptedAssistantBeforeSteering(session, undefined, {
-    ...(pendingSteeringId ? { pendingSteeringId } : {}),
-  });
-  if (materializedMessage) {
+  const materializedMessage = pendingSteeringId
+    ? materializeInterruptedAssistantBeforeSteering(session, undefined, { pendingSteeringId })
+    : await persistInterruptedAssistantTurn(session, "interrupted");
+  if (pendingSteeringId && materializedMessage) {
     const stableKey = materializedMessage._pendingSteeringId
       ? `interrupted:${materializedMessage._pendingSteeringId}`
       : `interrupted:${materializedMessage.timestamp || ""}`;
@@ -350,7 +350,7 @@ async function finishInterruptedChatTurn(
   broadcastStatus({
     status: "idle",
     timestamp: Date.now(),
-    detail: "Steering to follow-up...",
+    detail: pendingSteeringId ? "Steering to follow-up..." : "Interrupted",
     sessionId: session.id,
     agentId: agent.id,
   });
@@ -359,11 +359,13 @@ async function finishInterruptedChatTurn(
     workspaceDir: session.workspaceDir ?? null,
     interrupted: true,
     plan: extractLatestSessionPlan(session.id, session.messages),
-    message: {
-      role: "assistant",
-      content: "",
-      timestamp: new Date().toISOString(),
-    },
+    message:
+      materializedMessage ||
+      ({
+        role: "assistant",
+        content: "",
+        timestamp: new Date().toISOString(),
+      } satisfies ChatMessage),
     agent: {
       id: agent.id,
       name: agent.name,
@@ -488,16 +490,25 @@ function schedulePendingChatDrain(sessionId: string, delayMs = 0): void {
   timer.unref?.();
 }
 
-function finalizeStoppedProcessActivity(activity: ProcessActivityInfo): ProcessActivityInfo {
+type ChatTurnInterruptionKind = "stopped" | "interrupted";
+
+function finalizeInterruptedProcessActivity(
+  activity: ProcessActivityInfo,
+  kind: ChatTurnInterruptionKind
+): ProcessActivityInfo {
   if (activity.phase !== "start") return activity;
+  const label = kind === "stopped" ? "Stopped" : "Interrupted";
   return {
     ...activity,
     phase: "blocked",
-    text: `Stopped: ${activity.text}`,
+    text: `${label}: ${activity.text}`,
   };
 }
 
-function materializeStoppedAssistantTurn(session: InMemoryChatSession): ChatMessage | undefined {
+function materializeInterruptedAssistantTurn(
+  session: InMemoryChatSession,
+  kind: ChatTurnInterruptionKind
+): ChatMessage | undefined {
   const latestUserIndex = session.messages.findLastIndex((message) => message.role === "user");
   if (latestUserIndex < 0) return undefined;
   const nextMessage = session.messages[latestUserIndex + 1];
@@ -512,7 +523,7 @@ function materializeStoppedAssistantTurn(session: InMemoryChatSession): ChatMess
   });
   const activities = dedupeProcessActivities([
     ...(existing?.process_activities || []),
-    ...(observed || []).map(finalizeStoppedProcessActivity),
+    ...(observed || []).map((activity) => finalizeInterruptedProcessActivity(activity, kind)),
   ]);
   if (activities.length === 0) return existing;
   const stoppedAt = Date.now();
@@ -544,19 +555,26 @@ function materializeStoppedAssistantTurn(session: InMemoryChatSession): ChatMess
 async function persistStoppedAssistantTurn(
   session: InMemoryChatSession
 ): Promise<ChatMessage | undefined> {
-  const stoppedMessage = materializeStoppedAssistantTurn(session);
-  if (!stoppedMessage) return undefined;
+  return persistInterruptedAssistantTurn(session, "stopped");
+}
+
+async function persistInterruptedAssistantTurn(
+  session: InMemoryChatSession,
+  kind: ChatTurnInterruptionKind
+): Promise<ChatMessage | undefined> {
+  const interruptedMessage = materializeInterruptedAssistantTurn(session, kind);
+  if (!interruptedMessage) return undefined;
   const latestUser = [...session.messages]
-    .slice(0, session.messages.indexOf(stoppedMessage))
+    .slice(0, session.messages.indexOf(interruptedMessage))
     .reverse()
     .find((message) => message.role === "user");
-  await upsertPersistedSessionMessage(session.id, session.agentId, stoppedMessage, {
-    stableKey: `stopped:${latestUser?.timestamp || stoppedMessage.timestamp || session.id}`,
-    metadata: { source: "chat_stopped" },
+  await upsertPersistedSessionMessage(session.id, session.agentId, interruptedMessage, {
+    stableKey: `${kind}:${latestUser?.timestamp || interruptedMessage.timestamp || session.id}`,
+    metadata: { source: kind === "stopped" ? "chat_stopped" : "chat_interrupted" },
   });
-  await persistChatSessionSnapshot(session, stoppedMessage);
+  await persistChatSessionSnapshot(session, interruptedMessage);
   persistActiveSessionContext(session);
-  return stoppedMessage;
+  return interruptedMessage;
 }
 
 async function drainPendingChatQueue(sessionId: string): Promise<void> {
@@ -1655,6 +1673,10 @@ async function handleChatTurn(
           agentId: agent.id,
           sessionId: session.id,
           workspaceDir: session.workspaceDir || undefined,
+          useModelRouter,
+          activeModel: executionModelMetadata?.model || activeModelOverride,
+          activeProviderId: executionModelMetadata?.provider_id,
+          activeProviderName: executionModelMetadata?.provider_name,
         },
         responseContent,
         {

--- a/src/api/chat-runtime.ts
+++ b/src/api/chat-runtime.ts
@@ -147,7 +147,6 @@ import { constrainToolsForMessage } from "./chat-tool-constraints";
 import { resolveToolResponseContent } from "./chat-tool-response";
 import {
   buildNoUsableAssistantResponseMessage,
-  buildToolExecutionFallbackMessage,
   classifyToolCallResult,
   extractVisibleClarification,
   requiredDirectToolForMessage,
@@ -1694,14 +1693,15 @@ async function handleChatTurn(
           agentId: agent.id,
           channel,
           executionFailure,
+          executionMessages,
           maxOutputTokens: request.maxOutputTokens,
           message,
-          model: agent.model,
+          modelOverride: activeModelOverride,
           modelParamsOverride: request.modelParamsOverride,
-          providerId: agent.provider_id,
           responseContent,
           sessionId: session.id,
           toolResults,
+          useModelRouter,
           userId,
           workspaceDir: session.workspaceDir || undefined,
         });
@@ -1788,16 +1788,7 @@ async function handleChatTurn(
     allToolCalls
   );
   const assistantContent =
-    cleanContent.trim().length > 0
-      ? cleanContent
-      : allToolCalls.length > 0
-        ? buildToolExecutionFallbackMessage(
-            allToolCalls.map((toolCall) => ({
-              name: toolCall.name,
-              result: toolCall.result ?? null,
-            }))
-          )
-        : buildNoUsableAssistantResponseMessage();
+    cleanContent.trim().length > 0 ? cleanContent : buildNoUsableAssistantResponseMessage();
 
   const configuredModelMetadata = resolveSessionModelMetadata(agent?.id ?? session.agentId);
   const modelMetadata = executionModelMetadata

--- a/src/api/chat-tool-response.ts
+++ b/src/api/chat-tool-response.ts
@@ -1,8 +1,8 @@
-import { agentManager, type AgentExecutionFailure } from "../core/agent";
+import { agentManager, type AgentExecutionFailure, type AgentMessage } from "../core/agent";
 import { formatToolResultPromptBlock } from "../core/chat-token-optimization";
 import { config } from "../core/config";
-import { providerManager } from "../core/providers";
-import { buildToolExecutionFallbackMessage } from "./chat-tool-summary";
+import { INTERRUPTED_RESPONSE } from "./chat-interruption";
+import { buildNoUsableAssistantResponseMessage } from "./chat-tool-summary";
 
 interface ToolResponseResult {
   id?: string;
@@ -15,14 +15,15 @@ interface ResolveToolResponseOptions {
   agentId: string;
   channel?: string;
   executionFailure?: AgentExecutionFailure;
+  executionMessages: AgentMessage[];
   maxOutputTokens?: number;
   message: string;
-  model?: string;
+  modelOverride?: string;
   modelParamsOverride?: Record<string, unknown>;
-  providerId?: string;
   responseContent: string;
   sessionId: string;
   toolResults: ToolResponseResult[];
+  useModelRouter?: boolean;
   userId?: string;
   workspaceDir?: string;
 }
@@ -31,11 +32,9 @@ export async function resolveToolResponseContent(
   options: ResolveToolResponseOptions
 ): Promise<string> {
   if (options.responseContent.trim()) return options.responseContent;
-  const fallback = buildToolExecutionFallbackMessage(options.toolResults);
-  if (options.executionFailure) return fallback;
-  if (!options.providerId) return fallback;
-  const provider = providerManager.getWithCredentials(options.providerId);
-  if (!provider) return fallback;
+  const fallback = options.executionFailure
+    ? INTERRUPTED_RESPONSE
+    : buildNoUsableAssistantResponseMessage();
   const toonEnabled = config.getTokenOptimizationSettings().toonStructuredDataEnabled;
   const toolResultsText = options.toolResults
     .map((toolCall) =>
@@ -46,29 +45,34 @@ export async function resolveToolResponseContent(
       })
     )
     .join("\n\n");
+  const synthesisInstruction = [
+    "Write the final user-facing response for the latest request using the observed tool results below.",
+    "Do not call tools, mention internal tool counts, or claim anything the results do not establish.",
+    options.executionFailure
+      ? "The original execution was interrupted, so report verified progress and clearly identify anything that remains unfinished."
+      : "Answer directly and concisely with the verified result.",
+    `Latest request: ${options.message}`,
+    `Observed tool results:\n${toolResultsText}`,
+  ].join("\n\n");
   try {
-    const result = await agentManager.callLLM(
-      provider,
-      options.model,
-      [
-        {
-          role: "user",
-          content: `The user asked: "${options.message}"\n\nTools completed:\n${toolResultsText}\n\nAnswer the user from these results. Do not call tools.`,
-        },
-      ],
-      [],
+    const result = await agentManager.execute(
+      options.agentId,
+      [...options.executionMessages, { role: "user", content: synthesisInstruction }],
       {
-        agentId: options.agentId,
         sessionId: options.sessionId,
         channel: options.channel,
         userId: options.userId,
         workspaceDir: options.workspaceDir,
         abortSignal: options.abortSignal,
         maxOutputTokens: options.maxOutputTokens,
+        modelOverride: options.modelOverride,
         modelParamsOverride: options.modelParamsOverride,
+        useModelRouter: options.useModelRouter,
+        useMemory: false,
+        useTools: false,
       }
     );
-    return result.content || fallback;
+    return result.failure || !result.content.trim() ? fallback : result.content;
   } catch {
     return fallback;
   }

--- a/src/api/chat-tool-summary.ts
+++ b/src/api/chat-tool-summary.ts
@@ -37,14 +37,6 @@ function truncate(value: string, limit = TOOL_RESULT_PREVIEW_LIMIT): string {
   return `${compact.slice(0, Math.max(0, limit - 3))}...`;
 }
 
-function safeStringify(value: unknown): string {
-  try {
-    return JSON.stringify(value);
-  } catch {
-    return String(value);
-  }
-}
-
 export function classifyToolCallResult(result: unknown): ToolCallOutcome {
   if (!result || typeof result !== "object" || Array.isArray(result)) {
     return { status: "completed" };
@@ -126,54 +118,6 @@ export function suppressRecoveredWebFailureActivities<T extends ProcessActivityL
       activity.phase !== "error" ||
       (activity.toolName !== "web_search" && activity.toolName !== "web_fetch")
   );
-}
-
-function summarizeUnknownResult(value: unknown): string {
-  if (value === null || value === undefined) return "No output";
-  if (typeof value === "string") return truncate(value);
-  if (typeof value === "number" || typeof value === "boolean") return String(value);
-
-  if (typeof value === "object") {
-    const obj = value as Record<string, unknown>;
-    if (typeof obj.error === "string" && obj.error.trim()) {
-      return `Error: ${truncate(obj.error)}`;
-    }
-    if (typeof obj.message === "string" && obj.message.trim()) {
-      return truncate(obj.message);
-    }
-    if (typeof obj.path === "string" && typeof obj.content === "string") {
-      const lineCount = obj.content.split(/\r?\n/).length;
-      return `Read ${obj.path} (${lineCount} lines)`;
-    }
-    if (typeof obj.filePath === "string") {
-      return `Wrote ${obj.filePath}`;
-    }
-    if (typeof obj.output === "string" && obj.output.trim()) {
-      return truncate(obj.output);
-    }
-    if (typeof obj.status === "string" && typeof obj.txid === "string") {
-      return `${obj.status}: ${obj.txid}`;
-    }
-  }
-
-  return truncate(safeStringify(value));
-}
-
-export function buildToolExecutionFallbackMessage(toolCalls: ToolCallResultLike[]): string {
-  if (!toolCalls.length) {
-    return "No tool actions were executed.";
-  }
-
-  const heading = `Completed ${toolCalls.length} tool call${toolCalls.length === 1 ? "" : "s"}:`;
-  const bulletLines = toolCalls.slice(0, 8).map((toolCall) => {
-    const preview = summarizeUnknownResult(toolCall.result);
-    return `- \`${toolCall.name}\`: ${preview || "completed"}`;
-  });
-  const extraCount = toolCalls.length - bulletLines.length;
-  if (extraCount > 0) {
-    bulletLines.push(`- ...and ${extraCount} more tool call${extraCount === 1 ? "" : "s"}.`);
-  }
-  return `${heading}\n${bulletLines.join("\n")}`;
 }
 
 const NON_SUBSTANTIVE_COMPLETION_PATTERN =

--- a/src/api/session-transcript.ts
+++ b/src/api/session-transcript.ts
@@ -4,20 +4,50 @@ function messageIdentity(message: ChatMessage): string {
   return `${message.role}\u0000${message.run_id || ""}\u0000${message.content}`;
 }
 
+function removeSupersededInterruptedMessages(
+  persistedMessages: ChatMessage[],
+  activeMessages: ChatMessage[]
+): { persisted: ChatMessage[]; active: ChatMessage[] } {
+  const completedRunIds = new Set(
+    [...persistedMessages, ...activeMessages]
+      .filter(
+        (message) =>
+          message.role === "assistant" &&
+          message.interrupted !== true &&
+          typeof message.run_id === "string" &&
+          message.run_id.trim().length > 0
+      )
+      .map((message) => message.run_id?.trim())
+      .filter((runId): runId is string => !!runId)
+  );
+  const keep = (message: ChatMessage): boolean =>
+    !(
+      message.role === "assistant" &&
+      message.interrupted === true &&
+      typeof message.run_id === "string" &&
+      completedRunIds.has(message.run_id.trim())
+    );
+  return {
+    persisted: persistedMessages.filter(keep),
+    active: activeMessages.filter(keep),
+  };
+}
+
 export function mergeSessionTranscriptMessages(
   persistedMessages: ChatMessage[],
   activeMessages: ChatMessage[]
 ): ChatMessage[] {
-  if (persistedMessages.length === 0) return activeMessages;
+  const reconciled = removeSupersededInterruptedMessages(persistedMessages, activeMessages);
+  if (reconciled.persisted.length === 0) return reconciled.active;
 
-  const compacted = activeMessages.some(
+  const compacted = reconciled.active.some(
     (message) => message.role === "system" && message.content.includes("Context Summary")
   );
   if (compacted) {
-    return mergePersistedFirst(persistedMessages, activeMessages);
+    return mergePersistedFirst(reconciled.persisted, reconciled.active);
   }
 
-  return mergeActiveFirst(persistedMessages, activeMessages);
+  return mergeActiveFirst(reconciled.persisted, reconciled.active);
 }
 
 function mergePersistedFirst(

--- a/src/core/agent-internals.ts
+++ b/src/core/agent-internals.ts
@@ -1,3 +1,5 @@
+import { formatStructuredToolActivityDetail } from "../../shared/tool-activity-detail";
+
 export interface OpenAIToolCall {
   id: string;
   type: "function";
@@ -546,6 +548,9 @@ export function formatToolActivityDetail(
   phase: "start" | "result" | "error" | "blocked",
   result?: unknown
 ): string {
+  const structuredDetail = formatStructuredToolActivityDetail(toolName, args, phase, result);
+  if (structuredDetail) return structuredDetail;
+
   const key = toolName.toLowerCase();
   const path = readStringArg(args, ["path", "file_path", "filePath"]);
 

--- a/src/core/agent-provider-common-runtime.ts
+++ b/src/core/agent-provider-common-runtime.ts
@@ -1071,7 +1071,22 @@ export abstract class AgentProviderCommonRuntime {
         return assembled as unknown as OpenAIResponse;
       } catch (error) {
         watchdog.dispose();
-        throw watchdog.wrapError(error);
+        const normalized = watchdog.wrapError(error);
+        const retryDelayMs = providerExceptionRetryDelayMs(
+          normalized,
+          transientRetryCount,
+          signal,
+          Math.random,
+          retryPolicy.maxRetries
+        );
+        if (retryDelayMs === undefined) throw normalized;
+        transientRetryCount += 1;
+        this.logProviderRetryStatus(
+          streamContext,
+          `Provider stream interrupted; retrying (${transientRetryCount}/${retryPolicy.maxRetries})...`
+        );
+        await this.waitForRetryDelay(retryDelayMs, signal);
+        return post(body);
       }
     };
 

--- a/src/core/background-review.ts
+++ b/src/core/background-review.ts
@@ -23,6 +23,7 @@ export interface BackgroundReviewOptions {
   minIntervalMs?: number;
   timeoutSeconds?: number;
   disabled?: boolean;
+  spawn?: typeof handleSessionsSpawn;
 }
 
 function looksReviewable(lastAssistantText: string): boolean {
@@ -72,11 +73,15 @@ export async function maybeRunBackgroundReview(
   if (!release) return;
 
   try {
-    await handleSessionsSpawn(
+    const agentId = resolveBackgroundAgentId(context.agentId);
+    const model = agentId === context.agentId ? context.activeModel : undefined;
+    const spawn = options.spawn ?? handleSessionsSpawn;
+    await spawn(
       {
         task: prompt,
         label: "background-memory-review",
-        agentId: resolveBackgroundAgentId(context.agentId),
+        agentId,
+        model,
         _requesterSessionKey: context.sessionId,
         workspaceDir: context.workspaceDir,
         runTimeoutSeconds: options.timeoutSeconds ?? DEFAULT_REVIEW_TIMEOUT_S,

--- a/src/core/database.ts
+++ b/src/core/database.ts
@@ -936,6 +936,13 @@ const stmts = {
     latestSequence: prepare(
       "SELECT COALESCE(MAX(sequence), 0) AS sequence FROM session_events WHERE session_id = ?"
     ),
+    deleteRecoveryCompletion: prepare(
+      `DELETE FROM session_events
+       WHERE session_id = ?
+         AND run_id = ?
+         AND event_type = 'run_completed'
+         AND json_extract(payload, '$.source') = 'gateway_crash_recovery'`
+    ),
     deleteBySession: prepare("DELETE FROM session_events WHERE session_id = ?"),
   },
   systemLogs: {
@@ -1542,6 +1549,8 @@ export const tables = {
       const row = stmts.sessionEvents.latestSequence.get(sessionId) as { sequence?: number } | null;
       return typeof row?.sequence === "number" ? row.sequence : 0;
     },
+    deleteRecoveryCompletion: (sessionId: string, runId: string) =>
+      stmts.sessionEvents.deleteRecoveryCompletion.run(sessionId, runId),
     deleteBySession: (sessionId: string) => stmts.sessionEvents.deleteBySession.run(sessionId),
   },
   systemLogs: {

--- a/src/core/error-classifier.ts
+++ b/src/core/error-classifier.ts
@@ -120,7 +120,11 @@ export function classifyApiError(input: {
       message,
     };
   }
-  if (/econnreset|enotfound|econnrefused|fetch failed|network|socket hang up|epipe/.test(text)) {
+  if (
+    /econnreset|enotfound|econnrefused|fetch failed|network|socket hang up|socket connection.*closed|connection (?:was )?closed unexpectedly|epipe/.test(
+      text
+    )
+  ) {
     return {
       category: "network",
       retryable: true,

--- a/src/core/provider-retry.ts
+++ b/src/core/provider-retry.ts
@@ -17,11 +17,17 @@ const KIMI_PROVIDER_RETRY_POLICY: ProviderRetryPolicy = {
   maxDelayMs: 180_000,
 };
 
+const OPENAI_CODEX_PROVIDER_RETRY_POLICY: ProviderRetryPolicy = {
+  maxRetries: 5,
+  maxDelayMs: 180_000,
+};
+
 export function resolveProviderRetryPolicy(providerType?: string): ProviderRetryPolicy {
   const normalized = providerType?.trim().toLowerCase() || "";
   if (normalized === "kimi-code" || normalized === "kimi-code-oauth") {
     return KIMI_PROVIDER_RETRY_POLICY;
   }
+  if (normalized === "openai-codex") return OPENAI_CODEX_PROVIDER_RETRY_POLICY;
   return DEFAULT_PROVIDER_RETRY_POLICY;
 }
 

--- a/src/core/session-context.ts
+++ b/src/core/session-context.ts
@@ -11,7 +11,10 @@ import { sanitizeAssistantContent } from "./llm/text-tool-calls";
 import { createLogger } from "./logger";
 import { providerManager, providers } from "./providers";
 import { capSessionMessageMetadata } from "./session-message-metadata";
-import { clearSessionEventLedger } from "./session-event-ledger";
+import {
+  clearSessionEventLedger,
+  reconcileRecoveredSessionRunCompletion,
+} from "./session-event-ledger";
 import { deriveSessionTitleFromMessages, normalizeSessionTitle } from "./session-title";
 
 const log = createLogger("Session");
@@ -21,6 +24,7 @@ function sanitizePersistedMessageContent(role: string, content: string): string 
 }
 
 interface PersistedSessionMessage {
+  id: string;
   role: string;
   content: string;
   created_at: string;
@@ -49,6 +53,15 @@ type SessionMessageMetadata = Partial<
     | "client_pending_id"
   >
 >;
+
+interface PersistedSessionMessageMetadata extends SessionMessageMetadata {
+  source?: string;
+}
+
+const RECOVERY_MESSAGE_SOURCES = new Set([
+  "completed_empty_run_recovery",
+  "gateway_crash_recovery",
+]);
 
 function sessionMessageStableId(parts: unknown[]): string {
   const hash = createHash("sha256").update(JSON.stringify(parts)).digest("hex").slice(0, 32);
@@ -124,6 +137,14 @@ export async function upsertPersistedSessionMessage(
   options?: { stableKey?: string; createdAtOffsetMs?: number; metadata?: Record<string, unknown> }
 ): Promise<void> {
   tables.chatSessions.ensure(sessionId, agentId);
+  if (
+    message.role === "assistant" &&
+    message.interrupted !== true &&
+    typeof message.run_id === "string" &&
+    message.run_id.trim()
+  ) {
+    deleteRecoveryMessagesForRun(sessionId, message.run_id.trim());
+  }
   const id = sessionMessageStableId([
     sessionId,
     message.role,
@@ -152,16 +173,65 @@ export interface SessionModelMetadata {
   agent_type?: string;
 }
 
-function parseSessionMessageMetadata(metadata?: string): SessionMessageMetadata {
+function parseSessionMessageMetadata(metadata?: string): PersistedSessionMessageMetadata {
   if (!metadata) return {};
   try {
     const parsed = JSON.parse(metadata);
     return parsed && typeof parsed === "object" && !Array.isArray(parsed)
-      ? (parsed as SessionMessageMetadata)
+      ? (parsed as PersistedSessionMessageMetadata)
       : {};
   } catch {
     return {};
   }
+}
+
+function deleteRecoveryMessagesForRun(sessionId: string, runId: string): void {
+  db.prepare(
+    `DELETE FROM session_messages
+     WHERE session_id = ?
+       AND role = 'assistant'
+       AND json_extract(metadata, '$.run_id') = ?
+       AND json_extract(metadata, '$.source') IN ('completed_empty_run_recovery', 'gateway_crash_recovery')`
+  ).run(sessionId, runId);
+}
+
+function reconcilePersistedRecoveryMessages(
+  sessionId: string,
+  messages: PersistedSessionMessage[]
+): PersistedSessionMessage[] {
+  const parsed = messages.map((message) => ({
+    message,
+    metadata: parseSessionMessageMetadata(message.metadata),
+  }));
+  const completedRunIds = new Set(
+    parsed
+      .filter(
+        ({ message, metadata }) =>
+          message.role === "assistant" &&
+          metadata.interrupted !== true &&
+          typeof metadata.run_id === "string" &&
+          metadata.run_id.trim().length > 0
+      )
+      .map(({ metadata }) => metadata.run_id?.trim())
+      .filter((runId): runId is string => !!runId)
+  );
+  for (const runId of completedRunIds) {
+    reconcileRecoveredSessionRunCompletion(sessionId, runId);
+  }
+  const supersededIds = parsed
+    .filter(
+      ({ metadata }) =>
+        typeof metadata.run_id === "string" &&
+        completedRunIds.has(metadata.run_id.trim()) &&
+        typeof metadata.source === "string" &&
+        RECOVERY_MESSAGE_SOURCES.has(metadata.source)
+    )
+    .map(({ message }) => message.id);
+  if (supersededIds.length === 0) return messages;
+  const remove = db.prepare("DELETE FROM session_messages WHERE session_id = ? AND id = ?");
+  for (const id of supersededIds) remove.run(sessionId, id);
+  const superseded = new Set(supersededIds);
+  return messages.filter((message) => !superseded.has(message.id));
 }
 
 function nonEmptyString(value: unknown): string | undefined {
@@ -987,8 +1057,10 @@ export async function loadPersistedSession(sessionId: string): Promise<{
   title: string | null;
 } | null> {
   try {
-    const sessionMessages =
+    const storedSessionMessages =
       (tables.sessionMessages?.getBySession(sessionId) as PersistedSessionMessage[]) || [];
+
+    const sessionMessages = reconcilePersistedRecoveryMessages(sessionId, storedSessionMessages);
 
     if (sessionMessages.length === 0) {
       return null;

--- a/src/core/session-event-ledger.ts
+++ b/src/core/session-event-ledger.ts
@@ -328,6 +328,41 @@ export function latestSessionEventSequence(sessionId: string): number {
   return tables.sessionEvents.latestSequence(sessionId.trim());
 }
 
+function completionEventSource(event: SessionLedgerEvent): string | undefined {
+  if (event.type !== "run_completed" || !event.payload || typeof event.payload !== "object") {
+    return undefined;
+  }
+  const source = (event.payload as Record<string, unknown>).source;
+  return typeof source === "string" ? source : undefined;
+}
+
+export function removeSupersededRecoveryCompletion(sessionId: string, runId: string): void {
+  tables.sessionEvents.deleteRecoveryCompletion(sessionId.trim(), runId.trim());
+}
+
+export function reconcileRecoveredSessionRunCompletion(sessionId: string, runId: string): void {
+  const normalizedSessionId = sessionId.trim();
+  const normalizedRunId = runId.trim();
+  if (!normalizedSessionId || !normalizedRunId) return;
+  const events = listAllRunEvents(normalizedRunId);
+  const hasRecoveryCompletion = events.some(
+    (event) => completionEventSource(event) === "gateway_crash_recovery"
+  );
+  if (!hasRecoveryCompletion) return;
+  const hasCanonicalCompletion = events.some(
+    (event) =>
+      event.type === "run_completed" && completionEventSource(event) !== "gateway_crash_recovery"
+  );
+  removeSupersededRecoveryCompletion(normalizedSessionId, normalizedRunId);
+  if (hasCanonicalCompletion) return;
+  appendSessionEvent({
+    sessionId: normalizedSessionId,
+    runId: normalizedRunId,
+    type: "run_completed",
+    payload: { timestamp: Date.now(), source: "assistant_persistence_reconciliation" },
+  });
+}
+
 export function clearSessionEventLedger(sessionId: string): void {
   const normalizedSessionId = sessionId.trim();
   if (!normalizedSessionId) return;

--- a/src/core/status.ts
+++ b/src/core/status.ts
@@ -11,6 +11,7 @@ import {
   ensureSessionRunId,
   flushBufferedAssistantDeltas,
   getActiveSessionRunId,
+  removeSupersededRecoveryCompletion,
 } from "./session-event-ledger";
 
 export type AgentStatus =
@@ -563,7 +564,7 @@ export function broadcastStatus(status: StatusPayload): void {
           sessionId,
           runId,
           type: "run_started",
-          payload: { timestamp: Date.now() },
+          payload: { timestamp: Date.now(), processId: process.pid },
         });
       }
       sequence = appendSessionEvent({
@@ -597,6 +598,7 @@ export function broadcastStatus(status: StatusPayload): void {
           type: "run_completed",
           payload: { timestamp: Date.now() },
         });
+        removeSupersededRecoveryCompletion(sessionId, runId);
       } catch {
         void 0;
       }

--- a/src/core/system-prompt.ts
+++ b/src/core/system-prompt.ts
@@ -524,6 +524,7 @@ function buildWorkingAgreementSection(mode: SystemPromptExecutionMode): string[]
     "Plans and todos are working state. After planning, perform the work in the same turn unless this is Planning Mode.",
     "Inspect the actual environment before changing it. Follow existing conventions, preserve unrelated user changes, and fix the root cause within scope.",
     "Do not invent files, state, results, or tool output. Match every completion and verification claim to successful evidence from this turn; state anything you could not verify.",
+    "Before claiming something is absent, inspect likely paths, alternate names, and relevant working-tree changes. A narrow or empty search alone is not proof of absence.",
     "Batch independent tool calls. If a call fails or returns incomplete data, diagnose it and try a materially different approach before stopping.",
     "Do not narrate routine calls. For substantial work, give brief updates at the start and meaningful milestones, then keep working.",
     "Ask only when a requirement cannot be discovered or safely inferred, or before destructive, costly, security-sensitive, or external side effects not already authorized by the request.",

--- a/src/core/tools/handlers/file.ts
+++ b/src/core/tools/handlers/file.ts
@@ -616,7 +616,7 @@ export async function handleGrep(
       toolContext?.abortSignal
     );
   } else {
-    await searchDirectory(
+    truncated = await searchDirectory(
       searchDir,
       pattern,
       extensions,
@@ -627,7 +627,6 @@ export async function handleGrep(
       maxResults,
       toolContext?.abortSignal
     );
-    truncated = results.length >= maxResults;
   }
 
   trackMetric("file_operation", "search", 1, { pattern, resultCount: results.length });
@@ -666,7 +665,7 @@ async function searchWithRipgrep(
       "--json",
       "--no-messages",
       "--max-filesize=10M",
-      `--max-count=${maxResults}`,
+      `--max-count=${maxResults + 1}`,
       `--context=${context}`,
       "--glob=!node_modules/**",
       "--glob=!.git/**",
@@ -720,7 +719,7 @@ async function searchWithRipgrep(
         while (newline >= 0) {
           const line = buffered.slice(0, newline);
           buffered = buffered.slice(newline + 1);
-          if (appendRipgrepMatch(results, line, dir) && results.length >= maxResults) {
+          if (appendRipgrepMatch(results, line, dir) && results.length > maxResults) {
             truncated = true;
             stop();
             break;
@@ -730,6 +729,7 @@ async function searchWithRipgrep(
       }
       if (!truncated && buffered.trim()) {
         appendRipgrepMatch(results, buffered, dir);
+        truncated = results.length > maxResults;
       }
       await process.exited;
     } finally {
@@ -737,6 +737,7 @@ async function searchWithRipgrep(
       signal?.removeEventListener("abort", stop);
       if (truncated) await reader.cancel().catch(() => undefined);
     }
+    if (truncated) results.length = maxResults;
     return truncated;
   } catch (e) {
     console.error("[grep] ripgrep error:", e);
@@ -791,13 +792,17 @@ async function searchDirectory(
   results: Array<{ path: string; line: number; content: string }>,
   maxResults: number,
   signal?: AbortSignal
-): Promise<void> {
+): Promise<boolean> {
   try {
-    if (signal?.aborted) return;
+    if (signal?.aborted) return false;
     const entries = await fs.readdir(dir, { withFileTypes: true });
 
     for (const entry of entries) {
-      if (results.length >= maxResults || signal?.aborted) return;
+      if (results.length > maxResults) {
+        results.length = maxResults;
+        return true;
+      }
+      if (signal?.aborted) return false;
 
       const fullPath = join(dir, entry.name);
 
@@ -808,7 +813,7 @@ async function searchDirectory(
           entry.name !== "node_modules" &&
           entry.name !== ".git"
         ) {
-          await searchDirectory(
+          const truncated = await searchDirectory(
             fullPath,
             pattern,
             extensions,
@@ -819,6 +824,7 @@ async function searchDirectory(
             maxResults,
             signal
           );
+          if (truncated) return true;
         }
       } else if (entry.isFile()) {
         try {
@@ -848,7 +854,7 @@ async function searchDirectory(
             const endLine = Math.min(lines.length - 1, i + context);
 
             for (let j = startLine; j <= endLine; j++) {
-              if (results.length >= maxResults) break;
+              if (results.length > maxResults) break;
               results.push({
                 path: fullPath,
                 line: j + 1,
@@ -860,6 +866,11 @@ async function searchDirectory(
       }
     }
   } catch {}
+  if (results.length > maxResults) {
+    results.length = maxResults;
+    return true;
+  }
+  return false;
 }
 
 export async function handleApplyPatch(

--- a/src/core/tools/handlers/file.ts
+++ b/src/core/tools/handlers/file.ts
@@ -585,6 +585,7 @@ export async function handleGrep(
   pattern: string;
   count: number;
   source: string;
+  truncated: boolean;
 }> {
   const pattern = args.pattern as string;
   const path = args.path as string | undefined;
@@ -600,9 +601,10 @@ export async function handleGrep(
   const results: Array<{ path: string; line: number; content: string }> = [];
 
   const hasRipgrep = await checkRipgrepAvailable();
+  let truncated = false;
 
   if (hasRipgrep) {
-    await searchWithRipgrep(
+    truncated = await searchWithRipgrep(
       searchDir,
       pattern,
       extensions,
@@ -625,6 +627,7 @@ export async function handleGrep(
       maxResults,
       toolContext?.abortSignal
     );
+    truncated = results.length >= maxResults;
   }
 
   trackMetric("file_operation", "search", 1, { pattern, resultCount: results.length });
@@ -633,7 +636,13 @@ export async function handleGrep(
     source: hasRipgrep ? "ripgrep" : "javascript",
   });
 
-  return { results, pattern, count: results.length, source: hasRipgrep ? "ripgrep" : "javascript" };
+  return {
+    results,
+    pattern,
+    count: results.length,
+    source: hasRipgrep ? "ripgrep" : "javascript",
+    truncated,
+  };
 }
 
 async function checkRipgrepAvailable(): Promise<boolean> {
@@ -650,9 +659,9 @@ async function searchWithRipgrep(
   results: Array<{ path: string; line: number; content: string }>,
   maxResults: number,
   signal?: AbortSignal
-): Promise<void> {
+): Promise<boolean> {
   try {
-    if (signal?.aborted) return;
+    if (signal?.aborted) return false;
     const args = [
       "--json",
       "--no-messages",
@@ -698,35 +707,77 @@ async function searchWithRipgrep(
     const stop = (): void => process.kill();
     const timeout = setTimeout(stop, 30_000);
     signal?.addEventListener("abort", stop, { once: true });
-    let output = "";
+    const reader = process.stdout.getReader();
+    const decoder = new TextDecoder();
+    let buffered = "";
+    let truncated = false;
     try {
-      output = await new Response(process.stdout).text();
+      while (!signal?.aborted && !truncated) {
+        const chunk = await reader.read();
+        if (chunk.done) break;
+        buffered += decoder.decode(chunk.value, { stream: true });
+        let newline = buffered.indexOf("\n");
+        while (newline >= 0) {
+          const line = buffered.slice(0, newline);
+          buffered = buffered.slice(newline + 1);
+          if (appendRipgrepMatch(results, line, dir) && results.length >= maxResults) {
+            truncated = true;
+            stop();
+            break;
+          }
+          newline = buffered.indexOf("\n");
+        }
+      }
+      if (!truncated && buffered.trim()) {
+        appendRipgrepMatch(results, buffered, dir);
+      }
       await process.exited;
     } finally {
       clearTimeout(timeout);
       signal?.removeEventListener("abort", stop);
+      if (truncated) await reader.cancel().catch(() => undefined);
     }
-
-    for (const line of output.split("\n")) {
-      if (!line.trim()) continue;
-
-      try {
-        const match = JSON.parse(line);
-        if (match.type === "match") {
-          const matchedPath = match.data.path?.text || match.data.path;
-          if (!matchedPath || !isReadableSearchResult(dir, matchedPath)) continue;
-          results.push({
-            path: matchedPath,
-            line: match.data.line_number || 1,
-            content: match.data.lines?.text || "",
-          });
-        }
-      } catch {
-        void 0;
-      }
-    }
+    return truncated;
   } catch (e) {
     console.error("[grep] ripgrep error:", e);
+    return false;
+  }
+}
+
+function appendRipgrepMatch(
+  results: Array<{ path: string; line: number; content: string }>,
+  line: string,
+  dir: string
+): boolean {
+  if (!line.trim()) return false;
+  try {
+    const match = JSON.parse(line) as {
+      type?: unknown;
+      data?: {
+        path?: string | { text?: unknown };
+        line_number?: unknown;
+        lines?: { text?: unknown };
+      };
+    };
+    if (match.type !== "match") return false;
+    const matchedPath =
+      typeof match.data?.path === "string"
+        ? match.data.path
+        : typeof match.data?.path?.text === "string"
+          ? match.data.path.text
+          : "";
+    if (!matchedPath || !isReadableSearchResult(dir, matchedPath)) return false;
+    results.push({
+      path: matchedPath,
+      line:
+        typeof match.data?.line_number === "number" && Number.isFinite(match.data.line_number)
+          ? match.data.line_number
+          : 1,
+      content: typeof match.data?.lines?.text === "string" ? match.data.lines.text : "",
+    });
+    return true;
+  } catch {
+    return false;
   }
 }
 

--- a/tests/api/chat-interruption-persistence.test.ts
+++ b/tests/api/chat-interruption-persistence.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { deleteSession, handleChat } from "../../src/api/chat";
+import { agentManager } from "../../src/core/agent";
+import { providerManager } from "../../src/core/providers";
+import { broadcastStatus } from "../../src/core/status";
+import { waitForVisibleSessionMessages } from "./chat-session-test-helpers";
+
+const createdAgentIds: string[] = [];
+const createdProviderIds: string[] = [];
+const createdSessionIds: string[] = [];
+const originalFetch = globalThis.fetch;
+
+afterEach(async () => {
+  globalThis.fetch = originalFetch;
+  for (const sessionId of createdSessionIds.splice(0)) await deleteSession(sessionId);
+  for (const agentId of createdAgentIds.splice(0)) agentManager.delete(agentId);
+  for (const providerId of createdProviderIds.splice(0)) providerManager.delete(providerId);
+});
+
+describe("chat interruption persistence", () => {
+  test("external abort preserves in-progress activities as an interrupted assistant turn", async () => {
+    const provider = providerManager.create({
+      provider: "openai",
+      name: "External Abort Provider",
+      api_key: "sk-external-abort",
+      base_url: "https://api.openai.com/v1",
+    });
+    createdProviderIds.push(provider.id);
+    const agent = agentManager.create({
+      name: "External Abort Agent",
+      type: "main",
+      provider_id: provider.id,
+      model: "gpt-external-abort",
+      memory_enabled: false,
+    });
+    createdAgentIds.push(agent.id);
+    let markProviderStarted: (() => void) | undefined;
+    const providerStarted = new Promise<void>((resolve) => {
+      markProviderStarted = resolve;
+    });
+    globalThis.fetch = ((_url, init) =>
+      new Promise<Response>((_resolve, reject) => {
+        markProviderStarted?.();
+        init?.signal?.addEventListener(
+          "abort",
+          () => reject(new DOMException("client disconnected", "AbortError")),
+          { once: true }
+        );
+      })) as typeof fetch;
+
+    const sessionId = `external-abort-${crypto.randomUUID()}`;
+    createdSessionIds.push(sessionId);
+    const controller = new AbortController();
+    const activeTurn = handleChat({
+      message: "inspect the workspace",
+      agentId: agent.id,
+      sessionId,
+      tools: false,
+      abortSignal: controller.signal,
+    });
+    await providerStarted;
+
+    broadcastStatus({
+      status: "tool_executing",
+      timestamp: Date.now(),
+      detail: "Reading workspace",
+      sessionId,
+      agentId: agent.id,
+      toolName: "read",
+      toolCallId: "read-interrupted",
+      toolPhase: "start",
+    });
+    controller.abort(new DOMException("client disconnected", "AbortError"));
+    const response = await activeTurn;
+
+    expect(response.interrupted).toBe(true);
+    expect(response.stopped).toBeUndefined();
+    expect(response.message.interrupted).toBe(true);
+    expect(response.message.tool_calls).toEqual([
+      expect.objectContaining({
+        id: "read-interrupted",
+        status: "failed",
+        error: "Interrupted: Reading workspace",
+      }),
+    ]);
+    const messages = await waitForVisibleSessionMessages(sessionId, 2);
+    expect(messages.map((message) => message.role)).toEqual(["user", "assistant"]);
+    expect(messages[1]?.interrupted).toBe(true);
+    expect(messages[1]?.process_activities).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          phase: "blocked",
+          text: "Interrupted: Reading workspace",
+          toolCallId: "read-interrupted",
+        }),
+      ])
+    );
+  });
+});

--- a/tests/api/chat-process-activities.test.ts
+++ b/tests/api/chat-process-activities.test.ts
@@ -39,6 +39,26 @@ describe("chat process activities", () => {
     ).toBe(`Ran ${command}`);
   });
 
+  test("describes loaded skills and completed plan items", () => {
+    expect(
+      formatProcessActivityFromToolCall({
+        id: "skill-1",
+        name: "skill_load",
+        args: { name: "security-scan" },
+        status: "completed",
+        result: { name: "security-scan" },
+      })
+    ).toBe("Loaded security-scan skill");
+    expect(
+      formatProcessActivityFromToolCall({
+        id: "todo-1",
+        name: "todo",
+        args: { items: [{ content: "Verify release", status: "completed" }] },
+        status: "completed",
+      })
+    ).toBe('Completed "Verify release"');
+  });
+
   test("replaces a start activity with its later completion", () => {
     const activities: ProcessActivityInfo[] = [
       {

--- a/tests/api/chat-response-persistence.test.ts
+++ b/tests/api/chat-response-persistence.test.ts
@@ -23,7 +23,7 @@ describe("chat response persistence guards", () => {
   test("avoids blank assistant bubbles by using a content fallback", () => {
     const source = readFileSync(chatSourcePath, "utf8");
     expect(source).toContain("const assistantContent =");
-    expect(source).toContain("buildToolExecutionFallbackMessage(");
+    expect(source).not.toContain("Completed ${toolCalls.length} tool call");
     expect(source).toContain(": buildNoUsableAssistantResponseMessage()");
     expect(source).toContain("content: assistantContent");
   });

--- a/tests/api/chat-response-recovery.test.ts
+++ b/tests/api/chat-response-recovery.test.ts
@@ -154,24 +154,29 @@ describe("chat response recovery", () => {
     const sessionId = `partial-provider-failure-${crypto.randomUUID()}`;
     createdSessionIds.push(sessionId);
 
-    agentManager.execute = (async () => ({
-      content: "",
-      failure: { category: "overloaded", retryable: true },
-      tool_calls: [
-        {
-          name: "read",
-          args: { path: "/tmp/project.json" },
-          result: { path: "/tmp/project.json", content: "ok" },
-        },
-      ],
-    })) as typeof agentManager.execute;
-    let synthesisCalls = 0;
-    agentManager.callLLM = (async (_provider, _model, messages) => {
-      if (messages.some((message) => message.content.includes("Tools completed:"))) {
-        synthesisCalls += 1;
+    let executionCalls = 0;
+    agentManager.execute = (async (_agentId, messages, options) => {
+      executionCalls += 1;
+      if (executionCalls === 1) {
+        return {
+          content: "",
+          failure: { category: "overloaded", retryable: true },
+          tool_calls: [
+            {
+              name: "read",
+              args: { path: "/tmp/project.json" },
+              result: { path: "/tmp/project.json", content: "ok" },
+            },
+          ],
+        };
       }
-      return { content: "This redundant synthesis should not run." };
-    }) as typeof agentManager.callLLM;
+      expect(options?.useTools).toBe(false);
+      expect(messages.at(-1)?.content).toContain("Observed tool results:");
+      return {
+        content:
+          "I verified that `/tmp/project.json` is readable. The original turn was interrupted before any remaining inspection finished.",
+      };
+    }) as typeof agentManager.execute;
 
     const result = await handleChat({
       message: "inspect the project",
@@ -184,14 +189,57 @@ describe("chat response recovery", () => {
     expect(result.failure).toEqual({ category: "overloaded", retryable: true });
     expect(result.message.interrupted).toBe(true);
     expect(result.message.content).not.toContain("overloaded");
-    expect(result.message.content).toContain("Completed 1 tool call");
+    expect(result.message.content).toContain("verified that `/tmp/project.json` is readable");
+    expect(result.message.content).not.toMatch(/completed \d+ tool call/i);
     expect(result.message.tool_calls).toHaveLength(1);
-    expect(synthesisCalls).toBe(0);
+    expect(executionCalls).toBe(2);
     expect((await loadPersistedSession(sessionId))?.messages.at(-1)).toMatchObject({
       role: "assistant",
       interrupted: true,
       tool_calls: [expect.objectContaining({ name: "read" })],
     });
+  });
+
+  test("never promotes tool-count diagnostics when response synthesis also fails", async () => {
+    const agentId = createTestAgent("Failed Tool Response Synthesis Agent");
+    const sessionId = `failed-tool-synthesis-${crypto.randomUUID()}`;
+    createdSessionIds.push(sessionId);
+    let executionCalls = 0;
+
+    agentManager.execute = (async () => {
+      executionCalls += 1;
+      if (executionCalls === 1) {
+        return {
+          content: "",
+          failure: { category: "overloaded", retryable: true },
+          tool_calls: [
+            {
+              name: "read",
+              args: { path: "/tmp/project.json" },
+              result: { path: "/tmp/project.json", content: "ok" },
+            },
+          ],
+        };
+      }
+      return {
+        content: "",
+        failure: { category: "overloaded", retryable: true },
+      };
+    }) as typeof agentManager.execute;
+
+    const result = await handleChat({
+      message: "inspect the project",
+      agentId,
+      sessionId,
+      tools: true,
+    });
+
+    expect(executionCalls).toBe(2);
+    expect(result.message.content).toBe(
+      "Response interrupted before completion. Send the message again to retry."
+    );
+    expect(result.message.content).not.toMatch(/completed \d+ tool call/i);
+    expect(result.message.tool_calls).toHaveLength(1);
   });
 
   test("retries a bare completion under the action evidence contract", async () => {

--- a/tests/api/chat-run-recovery.test.ts
+++ b/tests/api/chat-run-recovery.test.ts
@@ -134,7 +134,9 @@ describe("chat run recovery", () => {
     expect(runId).toBeString();
     completeSessionRun(sessionId);
 
-    const recovered = await recoverInterruptedSessionMessages(sessionId, agentId, []);
+    const recovered = await recoverInterruptedSessionMessages(sessionId, agentId, [], {
+      processAlive: () => false,
+    });
 
     expect(recovered.some((message) => message.run_id === runId && message.interrupted)).toBe(true);
     expect(listIncompleteSessionRuns(sessionId)).toEqual([]);
@@ -161,7 +163,9 @@ describe("chat run recovery", () => {
     });
     broadcastStatus({ status: "idle", timestamp: timestamp + 2, sessionId, agentId });
 
-    const firstRecovery = await recoverInterruptedSessionMessages(sessionId, agentId, []);
+    const firstRecovery = await recoverInterruptedSessionMessages(sessionId, agentId, [], {
+      now: Date.now() + 31_000,
+    });
     const secondRecovery = await recoverInterruptedSessionMessages(
       sessionId,
       agentId,
@@ -219,5 +223,58 @@ describe("chat run recovery", () => {
       content: "Completed successfully.",
     });
     expect(recovered[0]?.interrupted).toBeUndefined();
+  });
+
+  test("does not recover a run while its owning gateway process is alive", async () => {
+    const { sessionId, agentId } = createSession("owned-live-run");
+    const timestamp = Date.now();
+    broadcastTool(sessionId, 0, timestamp);
+    completeSessionRun(sessionId);
+
+    const recovered = await recoverInterruptedSessionMessages(sessionId, agentId, [], {
+      now: timestamp + 60_000,
+    });
+
+    expect(recovered).toEqual([]);
+  });
+
+  test("removes a crash placeholder superseded by the real assistant response", async () => {
+    const { sessionId, agentId } = createSession("superseded-recovery");
+    const timestamp = Date.now();
+    broadcastTool(sessionId, 0, timestamp);
+    const runId = getActiveSessionRunId(sessionId);
+    expect(runId).toBeString();
+    completeSessionRun(sessionId);
+    await recoverInterruptedSessionMessages(sessionId, agentId, [], {
+      processAlive: () => false,
+    });
+    await upsertPersistedSessionMessage(
+      sessionId,
+      agentId,
+      {
+        role: "assistant",
+        content: "The requested work completed successfully.",
+        timestamp: new Date(timestamp + 2).toISOString(),
+        run_id: runId,
+      },
+      { stableKey: "real-assistant" }
+    );
+
+    const persisted = await loadPersistedSession(sessionId);
+    const completionEvents = listAllRunEvents(runId || "").filter(
+      (event) => event.type === "run_completed"
+    );
+
+    expect(persisted?.messages).toEqual([
+      expect.objectContaining({
+        role: "assistant",
+        content: "The requested work completed successfully.",
+        run_id: runId,
+      }),
+    ]);
+    expect(completionEvents).toHaveLength(1);
+    expect(completionEvents[0]?.payload).not.toMatchObject({
+      source: "gateway_crash_recovery",
+    });
   });
 });

--- a/tests/api/chat-tool-summary.test.ts
+++ b/tests/api/chat-tool-summary.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, test } from "bun:test";
 import {
   buildNoUsableAssistantResponseMessage,
   buildUnsupportedAssistantClaimMessage,
-  buildToolExecutionFallbackMessage,
   classifyToolCallResult,
   extractVisibleClarification,
   findAssistantEvidenceIssue,
@@ -35,21 +34,6 @@ describe("chat tool summary utilities", () => {
       status: "failed",
       error: "Tool finished with status blocked",
     });
-  });
-
-  test("builds concise fallback message from tool results", () => {
-    const message = buildToolExecutionFallbackMessage([
-      { name: "exec", result: { output: "updated 3 files successfully" } },
-      {
-        name: "read",
-        result: { path: "/tmp/a.ts", content: "line1\nline2\nline3" },
-      },
-    ]);
-
-    expect(message).toContain("Completed 2 tool calls:");
-    expect(message).toContain("- `exec`:");
-    expect(message).toContain("- `read`: Read /tmp/a.ts (3 lines)");
-    expect(message).not.toContain("Tool: exec");
   });
 
   test("recovers empty and bare success claims without overriding literal response requests", () => {

--- a/tests/api/session-transcript.test.ts
+++ b/tests/api/session-transcript.test.ts
@@ -102,4 +102,47 @@ describe("session transcript separation", () => {
     expect(merged.map((message) => message.role)).toEqual(["user", "assistant", "user"]);
     expect(merged.map((message) => message.content)).toEqual(["Initial request", "", "Steer now"]);
   });
+
+  test("removes a stale interrupted row when the same run has a completed response", () => {
+    const persisted: ChatMessage[] = [
+      {
+        role: "user",
+        content: "Read the package name",
+        timestamp: "2026-07-09T01:00:00.000Z",
+      },
+      {
+        role: "assistant",
+        content: "The package name is cybara.",
+        timestamp: "2026-07-09T01:00:43.000Z",
+        run_id: "run-1",
+      },
+    ];
+    const active: ChatMessage[] = [
+      persisted[0]!,
+      {
+        role: "assistant",
+        content: "",
+        timestamp: "2026-07-09T01:00:00.500Z",
+        run_id: "run-1",
+        interrupted: true,
+      },
+      persisted[1]!,
+    ];
+
+    const merged = mergeSessionTranscriptMessages(persisted, active);
+
+    expect(merged).toHaveLength(2);
+    expect(merged.filter((message) => message.role === "assistant")).toEqual([persisted[1]]);
+  });
+
+  test("preserves interrupted rows without a completed response for the same run", () => {
+    const interrupted: ChatMessage = {
+      role: "assistant",
+      content: "Partial verified progress",
+      run_id: "run-interrupted",
+      interrupted: true,
+    };
+
+    expect(mergeSessionTranscriptMessages([], [interrupted])).toEqual([interrupted]);
+  });
 });

--- a/tests/core/agent-provider-compatible-routing.test.ts
+++ b/tests/core/agent-provider-compatible-routing.test.ts
@@ -1478,7 +1478,7 @@ describe("Agent provider Google and compatible routing", () => {
 
     expect(result.content).toBe("");
     expect(result.failure).toEqual({ category: "rate_limit", retryable: true });
-    expect(calls).toBe(4);
+    expect(calls).toBe(6);
     const availability = getProviderAvailability(provider.id);
     expect(availability.inCooldown).toBe(true);
     expect(availability.available).toBe(false);

--- a/tests/core/agent-provider-openai-routing.test.ts
+++ b/tests/core/agent-provider-openai-routing.test.ts
@@ -234,4 +234,58 @@ describe("Agent provider OpenAI-compatible routing", () => {
     expect(usage.outputTokens).toBe(8);
     expect(usage.totalTokens).toBe(38);
   });
+
+  test("retries a socket reset while consuming an OpenAI-compatible stream", async () => {
+    let requestCount = 0;
+    globalThis.fetch = (async () => {
+      requestCount += 1;
+      if (requestCount === 1) {
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.error(new Error("The socket connection was closed unexpectedly."));
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "text/event-stream" } }
+        );
+      }
+      return Response.json({
+        id: "resp-zai-stream-recovery",
+        object: "chat.completion",
+        model: "glm-5.2",
+        choices: [
+          {
+            index: 0,
+            finish_reason: "stop",
+            message: { role: "assistant", content: "stream-recovered" },
+          },
+        ],
+        usage: { prompt_tokens: 9, completion_tokens: 2, total_tokens: 11 },
+      });
+    }) as typeof fetch;
+
+    const provider = providerManager.create({
+      provider: "z.ai-coding",
+      name: "Zai Stream Recovery Provider",
+      api_key: "zai-stream-recovery-key",
+    });
+    createdProviderIds.push(provider.id);
+    const agent = agentManager.create({
+      name: "Zai Stream Recovery Agent",
+      type: "main",
+      provider_id: provider.id,
+      model: "glm-5.2",
+      tools: [],
+    });
+    createdAgentIds.push(agent.id);
+
+    const result = await agentManager.execute(
+      agent.id,
+      [{ role: "user", content: "Verify stream recovery" }],
+      { useTools: false, sessionId: "zai-stream-recovery-session" }
+    );
+
+    expect(result.content).toBe("stream-recovered");
+    expect(requestCount).toBe(2);
+  });
 });

--- a/tests/core/agent-reliability.test.ts
+++ b/tests/core/agent-reliability.test.ts
@@ -16,6 +16,7 @@ describe("system prompt reliability guidance", () => {
     expect(prompt).toContain("Treat actionable requests as work to perform");
     expect(prompt).toContain("Do not invent files, state, results, or tool output");
     expect(prompt).toContain("Match every completion and verification claim");
+    expect(prompt).toContain("A narrow or empty search alone is not proof of absence");
     expect(prompt).toContain("fix the root cause within scope");
     expect(prompt).toContain("Validate the changed behavior with the narrowest useful check");
     expect(prompt).toContain("inspect and exercise the rendered result");

--- a/tests/core/background-review.test.ts
+++ b/tests/core/background-review.test.ts
@@ -3,6 +3,7 @@ import {
   BACKGROUND_REVIEW_TOOL_NAMES,
   maybeRunBackgroundReview,
 } from "../../src/core/background-review";
+import type { ToolContext } from "../../src/core/tools";
 
 describe("background review", () => {
   test("restricts review workers to memory tools", () => {
@@ -21,7 +22,42 @@ describe("background review", () => {
 
   test("maybeRunBackgroundReview skips when disabled", async () => {
     await expect(
-      maybeRunBackgroundReview({ agentId: "test", sessionId: "s1" }, "x".repeat(300))
+      maybeRunBackgroundReview({ agentId: "test", sessionId: "s1" }, "x".repeat(300), {
+        disabled: true,
+      })
     ).resolves.toBeUndefined();
+  });
+
+  test("uses the active turn model when the reviewer keeps the same agent", async () => {
+    let capturedArgs: Record<string, unknown> | undefined;
+    let capturedContext: ToolContext | undefined;
+
+    await maybeRunBackgroundReview(
+      {
+        agentId: "codex-agent",
+        sessionId: `background-model-${crypto.randomUUID()}`,
+        activeModel: "gpt-5.5",
+        activeProviderId: "codex-provider",
+      },
+      "A durable review candidate. ".repeat(20),
+      {
+        minIntervalMs: 0,
+        spawn: async (args, context) => {
+          capturedArgs = args;
+          capturedContext = context;
+          return {
+            status: "completed",
+            childSessionKey: "child",
+            runId: "run",
+            task: String(args.task),
+          };
+        },
+      }
+    );
+
+    expect(capturedArgs?.agentId).toBe("codex-agent");
+    expect(capturedArgs?.model).toBe("gpt-5.5");
+    expect(capturedContext?.activeModel).toBe("gpt-5.5");
+    expect(capturedContext?.allowedToolNames).toEqual(BACKGROUND_REVIEW_TOOL_NAMES);
   });
 });

--- a/tests/core/error-classifier.test.ts
+++ b/tests/core/error-classifier.test.ts
@@ -87,6 +87,11 @@ describe("classifyApiError", () => {
     expect(classifyApiError({ error: new Error("fetch failed: ECONNRESET") }).category).toBe(
       "network"
     );
+    expect(
+      classifyApiError({
+        error: new Error("The socket connection was closed unexpectedly."),
+      }).category
+    ).toBe("network");
     expect(classifyApiError({ error: new Error("Operation timed out") }).retryable).toBe(true);
   });
 

--- a/tests/core/file-search.test.ts
+++ b/tests/core/file-search.test.ts
@@ -41,6 +41,27 @@ describe("file search", () => {
     }
   });
 
+  test("limits grep results globally across files", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "cybara-grep-limit-"));
+    try {
+      for (let index = 0; index < 12; index += 1) {
+        writeFileSync(join(directory, `match-${index}.txt`), `needle ${index}`);
+      }
+
+      const result = await handleGrep({
+        pattern: "needle",
+        path: directory,
+        maxResults: 3,
+      });
+
+      expect(result.results).toHaveLength(3);
+      expect(result.count).toBe(3);
+      expect(result.truncated).toBe(true);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
   test("does not follow directory symlinks", async () => {
     const directory = mkdtempSync(join(tmpdir(), "cybara-file-search-symlink-"));
     const external = mkdtempSync(join(tmpdir(), "cybara-file-search-external-"));

--- a/tests/core/file-search.test.ts
+++ b/tests/core/file-search.test.ts
@@ -62,6 +62,77 @@ describe("file search", () => {
     }
   });
 
+  test("does not mark an exact grep boundary as truncated", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "cybara-grep-exact-limit-"));
+    try {
+      for (let index = 0; index < 3; index += 1) {
+        writeFileSync(join(directory, `match-${index}.txt`), `needle ${index}`);
+      }
+
+      const result = await handleGrep({
+        pattern: "needle",
+        path: directory,
+        maxResults: 3,
+      });
+
+      expect(result.results).toHaveLength(3);
+      expect(result.truncated).toBe(false);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("marks only omitted JavaScript fallback results as truncated", () => {
+    const directory = mkdtempSync(join(tmpdir(), "cybara-grep-fallback-limit-"));
+    const emptyPath = join(directory, "bin");
+    try {
+      mkdirSync(emptyPath);
+      for (let index = 0; index < 3; index += 1) {
+        writeFileSync(join(directory, `match-${index}.txt`), `needle ${index}`);
+      }
+
+      const handlerUrl = new URL("../../src/core/tools/handlers/file.ts", import.meta.url).href;
+      const worker = [
+        `const { handleGrep } = await import(${JSON.stringify(handlerUrl)});`,
+        'const exact = await handleGrep({ pattern: "needle", path: process.env.SEARCH_DIR, maxResults: 3 });',
+        'await Bun.write(process.env.EXTRA_FILE, "needle overflow");',
+        'const overflow = await handleGrep({ pattern: "needle", path: process.env.SEARCH_DIR, maxResults: 3 });',
+        'console.log("GREPFALLBACK:" + JSON.stringify({ exact, overflow }));',
+      ].join("\n");
+      const result = Bun.spawnSync([process.execPath, "-e", worker], {
+        cwd: directory,
+        env: {
+          ...process.env,
+          PATH: emptyPath,
+          SEARCH_DIR: directory,
+          EXTRA_FILE: join(directory, "match-3.txt"),
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const output = result.stdout.toString();
+      const marker = output.split("\n").find((line) => line.startsWith("GREPFALLBACK:"));
+      expect(result.exitCode).toBe(0);
+      expect(marker).toBeDefined();
+      const parsed = JSON.parse(marker?.slice("GREPFALLBACK:".length) || "{}") as {
+        exact?: { count: number; truncated: boolean; source: string };
+        overflow?: { count: number; truncated: boolean; source: string };
+      };
+      expect(parsed.exact).toMatchObject({
+        count: 3,
+        truncated: false,
+        source: "javascript",
+      });
+      expect(parsed.overflow).toMatchObject({
+        count: 3,
+        truncated: true,
+        source: "javascript",
+      });
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
   test("does not follow directory symlinks", async () => {
     const directory = mkdtempSync(join(tmpdir(), "cybara-file-search-symlink-"));
     const external = mkdtempSync(join(tmpdir(), "cybara-file-search-external-"));

--- a/tests/core/huggingface-workflows-plugin.test.ts
+++ b/tests/core/huggingface-workflows-plugin.test.ts
@@ -1,0 +1,113 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import {
+  listInstalledPlugins,
+  loadPluginFromRoot,
+  validatePluginAtPath,
+} from "../../src/core/plugins";
+import { clearSkillsCache } from "../../src/core/skills";
+import { loadAllSkills } from "../../src/core/skills/loader";
+import { handleSkillLoad } from "../../src/core/tools/handlers/skill";
+
+const root = join(process.cwd(), "plugins", "huggingface-workflows");
+const expectedSkills = [
+  "hf-cli",
+  "huggingface-community-evals",
+  "huggingface-datasets",
+  "huggingface-gradio",
+  "huggingface-jobs",
+  "huggingface-llm-trainer",
+  "huggingface-paper-publisher",
+  "huggingface-papers",
+  "huggingface-trackio",
+  "huggingface-vision-trainer",
+  "transformers-js",
+];
+const temporaryHomes: string[] = [];
+
+afterAll(() => {
+  clearSkillsCache();
+  for (const home of temporaryHomes) rmSync(home, { recursive: true, force: true });
+});
+
+async function withIsolatedPluginState<T>(operation: () => Promise<T>): Promise<T> {
+  const previousCybaraHome = process.env.CYBARA_HOME;
+  const cybaraHome = mkdtempSync(join(tmpdir(), "cybara-huggingface-plugin-"));
+  temporaryHomes.push(cybaraHome);
+  process.env.CYBARA_HOME = cybaraHome;
+  clearSkillsCache();
+  try {
+    return await operation();
+  } finally {
+    clearSkillsCache();
+    if (previousCybaraHome === undefined) delete process.env.CYBARA_HOME;
+    else process.env.CYBARA_HOME = previousCybaraHome;
+  }
+}
+
+describe("Hugging Face workflows plugin", () => {
+  test("ships a valid bundled plugin with the complete skill set", () => {
+    const validation = validatePluginAtPath(root);
+    expect(validation.valid).toBe(true);
+    expect(validation.errors).toEqual([]);
+
+    const plugin = loadPluginFromRoot(root, "bundled");
+    expect(plugin).not.toBeNull();
+    expect(plugin?.manifest.id).toBe("huggingface-workflows");
+    expect(plugin?.skillNames).toEqual(expectedSkills);
+  });
+
+  test("uses Cybara-safe commands and substantive instructions", () => {
+    for (const skillName of expectedSkills) {
+      const content = readFileSync(join(root, "skills", skillName, "SKILL.md"), "utf8");
+      expect(content.length).toBeGreaterThan(600);
+      expect(content).not.toMatch(/\b(?:npm|npx|pnpm|yarn)\b/);
+    }
+
+    const jobs = readFileSync(join(root, "skills", "huggingface-jobs", "SKILL.md"), "utf8");
+    const trainer = readFileSync(
+      join(root, "skills", "huggingface-llm-trainer", "SKILL.md"),
+      "utf8"
+    );
+    const datasets = readFileSync(join(root, "skills", "huggingface-datasets", "SKILL.md"), "utf8");
+    const transformers = readFileSync(join(root, "skills", "transformers-js", "SKILL.md"), "utf8");
+
+    expect(jobs).toContain("obtain confirmation before starting paid compute");
+    expect(trainer).toContain("Before launching paid compute");
+    expect(readFileSync(join(root, "skills", "hf-cli", "SKILL.md"), "utf8")).toContain(
+      "Do not use the deprecated `huggingface-cli` command"
+    );
+    expect(datasets).toContain("https://datasets-server.huggingface.co");
+    expect(datasets).toContain("Cybara's `http` tool");
+    expect(transformers).toContain("bun add @huggingface/transformers");
+  });
+
+  test("discovers and loads plugin skills for agents", async () => {
+    await withIsolatedPluginState(async () => {
+      const installed = listInstalledPlugins().find(
+        (plugin) => plugin.manifest.id === "huggingface-workflows"
+      );
+      expect(installed?.source).toBe("bundled");
+      expect(installed?.enabled).toBe(true);
+      expect(installed?.skillNames).toEqual(expectedSkills);
+
+      const loaded = await loadAllSkills({ workspaceDir: process.cwd() });
+      const pluginSkills = loaded
+        .filter((entry) => entry.plugin?.id === "huggingface-workflows")
+        .map((entry) => entry.skill.name)
+        .sort();
+      expect(pluginSkills).toEqual(expectedSkills);
+
+      const result = (await handleSkillLoad(
+        { name: "huggingface-datasets" },
+        { agentId: "huggingface-test", workspaceDir: process.cwd() }
+      )) as Record<string, unknown>;
+      expect(result.name).toBe("huggingface-datasets");
+      expect(result.source).toBe("plugin");
+      expect(result.instructions).toContain("Dataset Viewer API");
+    });
+  });
+});

--- a/tests/core/provider-retry.test.ts
+++ b/tests/core/provider-retry.test.ts
@@ -48,8 +48,12 @@ describe("provider retry policy", () => {
     expect(boundedPoolRetryDelayMs(3_000, 1_250)).toBe(3_000);
   });
 
-  test("gives Kimi coding sessions a longer bounded transient recovery budget", () => {
+  test("gives subscription coding sessions a longer bounded transient recovery budget", () => {
     expect(resolveProviderRetryPolicy("kimi-code-oauth")).toEqual({
+      maxRetries: 5,
+      maxDelayMs: 180_000,
+    });
+    expect(resolveProviderRetryPolicy("openai-codex")).toEqual({
       maxRetries: 5,
       maxDelayMs: 180_000,
     });

--- a/tests/core/tool-activity-detail.test.ts
+++ b/tests/core/tool-activity-detail.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import { formatToolActivityDetail } from "../../src/core/agent-internals";
+
+describe("tool activity detail", () => {
+  test("identifies the loaded skill", () => {
+    expect(
+      formatToolActivityDetail("skill_load", { name: "security-scan" }, "result", {
+        name: "Security Scan",
+      })
+    ).toBe("Loaded Security Scan skill");
+  });
+
+  test("identifies plan progress and the active item", () => {
+    expect(
+      formatToolActivityDetail(
+        "todo",
+        {
+          items: [
+            { content: "Inspect runtime", status: "completed" },
+            { content: "Verify UI", status: "in_progress" },
+          ],
+        },
+        "result"
+      )
+    ).toBe("Updated plan: Verify UI in progress (1/2 complete)");
+  });
+});

--- a/tests/e2e/nearby-transfer-smoke.test.ts
+++ b/tests/e2e/nearby-transfer-smoke.test.ts
@@ -27,6 +27,8 @@ interface ApiResult {
 
 const gateways: GatewayFixture[] = [];
 const GATEWAY_START_TIMEOUT_MS = process.env.CI ? 60_000 : 30_000;
+const NEARBY_ENABLE_ATTEMPTS = 5;
+const allocatedPorts = new Set<number>();
 let discoveryPort = 0;
 
 function asRecord(value: unknown): Record<string, unknown> {
@@ -44,22 +46,27 @@ function sleep(ms: number): Promise<void> {
 }
 
 async function getFreePort(): Promise<number> {
-  return await new Promise((resolve, reject) => {
-    const server = createServer();
-    server.once("error", reject);
-    server.listen(0, "127.0.0.1", () => {
-      const address = server.address();
-      if (!address || typeof address === "string") {
-        server.close();
-        reject(new Error("Failed to allocate a free port"));
-        return;
-      }
-      server.close((error) => {
-        if (error) reject(error);
-        else resolve(address.port);
+  while (true) {
+    const port = await new Promise<number>((resolve, reject) => {
+      const server = createServer();
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => {
+        const address = server.address();
+        if (!address || typeof address === "string") {
+          server.close();
+          reject(new Error("Failed to allocate a free port"));
+          return;
+        }
+        server.close((error) => {
+          if (error) reject(error);
+          else resolve(address.port);
+        });
       });
     });
-  });
+    if (allocatedPorts.has(port)) continue;
+    allocatedPorts.add(port);
+    return port;
+  }
 }
 
 async function createGateway(name: string): Promise<GatewayFixture> {
@@ -276,14 +283,23 @@ function insertSourceSession(fixture: GatewayFixture, marker: string): string {
 }
 
 async function enableNearby(fixture: GatewayFixture, displayName: string): Promise<void> {
-  const result = await api(fixture, "PUT", "/api/nearby/settings", {
-    enabled: true,
-    displayName,
-    port: fixture.nearbyPort,
-    discoveryMinutes: 1,
-  });
-  expect(result.status).toBe(200);
-  expect(asRecord(result.data).success).toBe(true);
+  let lastResult: ApiResult | null = null;
+  for (let attempt = 0; attempt < NEARBY_ENABLE_ATTEMPTS; attempt += 1) {
+    const result = await api(fixture, "PUT", "/api/nearby/settings", {
+      enabled: true,
+      displayName,
+      port: fixture.nearbyPort,
+      discoveryMinutes: 1,
+    });
+    if (result.status === 200 && asRecord(result.data).success === true) return;
+    lastResult = result;
+    if (result.status !== 500) break;
+    fixture.nearbyPort = await getFreePort();
+  }
+  throw await gatewayFailure(
+    fixture,
+    `Failed to enable Nearby at ${fixture.baseUrl}: ${JSON.stringify(lastResult)}`
+  );
 }
 
 beforeAll(async () => {
@@ -310,7 +326,18 @@ describe("Nearby two-gateway e2e", () => {
     expect(second).toBeDefined();
     if (!first || !second) throw new Error("Gateway fixtures were not created");
 
-    await enableNearby(first, "Nearby First");
+    const initiallySelectedPort = first.nearbyPort;
+    const portBlocker = Bun.serve({
+      hostname: "0.0.0.0",
+      port: initiallySelectedPort,
+      fetch: () => new Response("occupied"),
+    });
+    try {
+      await enableNearby(first, "Nearby First");
+    } finally {
+      portBlocker.stop(true);
+    }
+    expect(first.nearbyPort).not.toBe(initiallySelectedPort);
     await enableNearby(second, "Nearby Second");
 
     await waitFor(async () => {

--- a/tests/runtime/chat-tool-pass-boundary.test.ts
+++ b/tests/runtime/chat-tool-pass-boundary.test.ts
@@ -8,6 +8,7 @@ describe("chat tool pass boundary", () => {
     expect(source).not.toContain("If more actions are needed to fully complete");
     expect(source).not.toContain("summaryToolPolicy");
     expect(source).toContain("if (options.responseContent.trim()) return options.responseContent");
-    expect(source).toContain("Answer the user from these results. Do not call tools.");
+    expect(source).toContain("Write the final user-facing response for the latest request");
+    expect(source).toContain("useTools: false");
   });
 });

--- a/ui/src/lib/chatActivities.test.ts
+++ b/ui/src/lib/chatActivities.test.ts
@@ -204,6 +204,43 @@ describe("enrichActivitiesWithToolCallDetails", () => {
     expect(result[1].fullText).toContain("[x] Inspect runtime");
     expect(result[1].fullText).toContain("[~] Verify UI");
   });
+
+  test("consumes duplicate tool-call IDs only once", () => {
+    const result = enrichActivitiesWithToolCallDetails(
+      [
+        activity({
+          id: "live",
+          text: "Ran shortened command...",
+          toolName: "exec",
+          toolCallId: "shared-call",
+        }),
+        activity({
+          id: "recovered",
+          text: "Recovered command summary",
+          toolName: "exec",
+          toolCallId: "shared-call",
+        }),
+      ],
+      [
+        {
+          id: "shared-call",
+          name: "exec",
+          args: { command: "bun test tests/core/provider-retry.test.ts" },
+          status: "completed",
+        },
+      ]
+    );
+
+    expect(result[0].fullText).toBe("Ran bun test tests/core/provider-retry.test.ts");
+    expect(result[1]).toEqual(
+      activity({
+        id: "recovered",
+        text: "Recovered command summary",
+        toolName: "exec",
+        toolCallId: "shared-call",
+      })
+    );
+  });
 });
 
 describe("mergeActivityLists", () => {

--- a/ui/src/lib/chatActivities.test.ts
+++ b/ui/src/lib/chatActivities.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   buildActivitiesFromToolCalls,
+  enrichActivitiesWithToolCallDetails,
   mergeActivityLists,
   finalizeCompletedActivities,
   normalizeActivityTextForPhase,
@@ -129,6 +130,79 @@ describe("buildActivitiesFromToolCalls", () => {
     const result = buildActivitiesFromToolCalls(calls, identityIntent);
     expect(result[0].sandboxProvider).toBe("podman");
     expect(result[1].sandboxProvider).toBeUndefined();
+  });
+});
+
+describe("enrichActivitiesWithToolCallDetails", () => {
+  test("restores a complete command behind a shortened activity", () => {
+    const command =
+      "bun test tests/core/one.test.ts tests/core/two.test.ts tests/core/three.test.ts";
+    const result = enrichActivitiesWithToolCallDetails(
+      [
+        activity({
+          id: "command",
+          phase: "result",
+          text: "Ran bun test tests/core/one.test.ts tests/core/two.test.ts tests/core/...",
+          toolName: "exec",
+          toolCallId: "gateway-call-1",
+        }),
+      ],
+      [
+        {
+          id: "provider-call-1",
+          name: "exec",
+          args: { command },
+          status: "completed",
+        },
+      ]
+    );
+
+    expect(result[0].text).toContain("...");
+    expect(result[0].fullText).toBe(`Ran ${command}`);
+  });
+
+  test("replaces opaque skill and plan completions with useful summaries", () => {
+    const result = enrichActivitiesWithToolCallDetails(
+      [
+        activity({
+          id: "skill",
+          text: "skill_load complete",
+          toolName: "skill_load",
+          toolCallId: "gateway-skill-1",
+        }),
+        activity({
+          id: "todo",
+          text: "todo complete",
+          toolName: "todo",
+          toolCallId: "gateway-todo-1",
+        }),
+      ],
+      [
+        {
+          id: "skill-1",
+          name: "skill_load",
+          args: { name: "security-scan" },
+          result: { name: "security-scan" },
+          status: "completed",
+        },
+        {
+          id: "todo-1",
+          name: "todo",
+          args: {
+            items: [
+              { content: "Inspect runtime", status: "completed" },
+              { content: "Verify UI", status: "in_progress" },
+            ],
+          },
+          status: "completed",
+        },
+      ]
+    );
+
+    expect(result[0].text).toBe("Loaded security-scan skill");
+    expect(result[1].text).toBe("Updated plan: Verify UI in progress (1/2 complete)");
+    expect(result[1].fullText).toContain("[x] Inspect runtime");
+    expect(result[1].fullText).toContain("[~] Verify UI");
   });
 });
 

--- a/ui/src/lib/chatActivities.ts
+++ b/ui/src/lib/chatActivities.ts
@@ -327,7 +327,7 @@ export function enrichActivitiesWithToolCallDetails(
     const callByName = toolName
       ? callsByName.get(toolName)?.find((candidate) => !usedCalls.has(candidate))
       : undefined;
-    const call = callById || callByName;
+    const call = callById && !usedCalls.has(callById) ? callById : callByName;
     if (!call) return activity;
     usedCalls.add(call);
     const args = call.arguments || call.args || {};

--- a/ui/src/lib/chatActivities.ts
+++ b/ui/src/lib/chatActivities.ts
@@ -3,6 +3,10 @@ import {
   type SharedActivityDisplayEntry,
   type SharedActivityGroupKind,
 } from "../../../shared/chat-activity-groups";
+import {
+  formatExpandedToolActivityDetail,
+  formatStructuredToolActivityDetail,
+} from "../../../shared/tool-activity-detail";
 
 export type ActivityPhase = "start" | "result" | "error" | "blocked";
 
@@ -14,6 +18,7 @@ export interface LiveActivityItem {
   toolName?: string;
   toolCallId?: string;
   sandboxProvider?: string;
+  fullText?: string;
 }
 
 export interface ToolCallLike {
@@ -287,6 +292,58 @@ export function buildActivitiesFromToolCalls(
   }
 
   return activities;
+}
+
+function normalizedToolCallId(value: string | undefined): string {
+  return typeof value === "string" ? value.trim().toLowerCase() : "";
+}
+
+function equivalentActivityText(left: string, right: string): boolean {
+  return left.trim().replace(/\s+/g, " ") === right.trim().replace(/\s+/g, " ");
+}
+
+export function enrichActivitiesWithToolCallDetails(
+  activities: LiveActivityItem[],
+  toolCalls: ToolCallLike[] | undefined
+): LiveActivityItem[] {
+  if (!toolCalls || toolCalls.length === 0) return activities;
+  const callsById = new Map<string, ToolCallLike>();
+  const callsByName = new Map<string, ToolCallLike[]>();
+  for (const call of toolCalls) {
+    const callId = normalizedToolCallId(call.id);
+    if (callId) callsById.set(callId, call);
+    const name = call.name.trim().toLowerCase();
+    if (!name) continue;
+    const namedCalls = callsByName.get(name) || [];
+    namedCalls.push(call);
+    callsByName.set(name, namedCalls);
+  }
+  const usedCalls = new Set<ToolCallLike>();
+
+  return activities.map((activity) => {
+    const toolCallId = normalizedToolCallId(activity.toolCallId);
+    const callById = toolCallId ? callsById.get(toolCallId) : undefined;
+    const toolName = activity.toolName?.trim().toLowerCase() || "";
+    const callByName = toolName
+      ? callsByName.get(toolName)?.find((candidate) => !usedCalls.has(candidate))
+      : undefined;
+    const call = callById || callByName;
+    if (!call) return activity;
+    usedCalls.add(call);
+    const args = call.arguments || call.args || {};
+    const structuredText = formatStructuredToolActivityDetail(
+      call.name,
+      args,
+      activity.phase,
+      call.result
+    );
+    const text = structuredText || activity.text;
+    const fullText = formatExpandedToolActivityDetail(call.name, args, activity.phase, call.result);
+    if (!fullText || equivalentActivityText(text, fullText)) {
+      return text === activity.text ? activity : { ...activity, text };
+    }
+    return { ...activity, text, fullText };
+  });
 }
 
 export function mergeActivityLists(

--- a/ui/src/pages/chat/ActivityTimeline.tsx
+++ b/ui/src/pages/chat/ActivityTimeline.tsx
@@ -44,6 +44,7 @@ const GROUP_ICONS: Record<ActivityGroupKind, LucideIcon> = {
 };
 
 function ActivityRow({ activity }: { activity: LiveActivityItem }) {
+  const [expanded, setExpanded] = useState(false);
   if (isRawToolCallThought(activity)) return null;
   if (activity.toolName === "__thought") {
     return (
@@ -52,6 +53,32 @@ function ActivityRow({ activity }: { activity: LiveActivityItem }) {
       </div>
     );
   }
+  const fullText = activity.fullText?.trim();
+  const expandable = Boolean(fullText && fullText !== activity.text.trim());
+  const content = expanded && fullText ? fullText : activity.text;
+  const textContent = (
+    <>
+      {activity.phase === "start" ? (
+        <LiveStatusText>
+          <ActivityText text={content} />
+        </LiveStatusText>
+      ) : (
+        <ActivityText text={content} />
+      )}
+      {activity.toolName !== "__thought" && activity.sandboxProvider && (
+        <span className="chat-meta-text inline-flex items-center rounded border border-sky-400/30 bg-sky-400/10 px-1.5 py-0.5 leading-none text-sky-200">
+          {formatSandboxProviderLabel(activity.sandboxProvider)}
+        </span>
+      )}
+      {expandable &&
+        (expanded ? (
+          <ChevronDown className="h-3 w-3 shrink-0 text-current opacity-60" />
+        ) : (
+          <ChevronRight className="h-3 w-3 shrink-0 text-current opacity-60" />
+        ))}
+    </>
+  );
+
   return (
     <div className="chat-activity-text flex items-start gap-2 px-0.5 text-gray-400">
       <span className="flex h-[1.5em] shrink-0 items-center" data-testid="activity-row-icon">
@@ -65,20 +92,19 @@ function ActivityRow({ activity }: { activity: LiveActivityItem }) {
           <AlertTriangle className="h-3 w-3 text-current opacity-70" />
         )}
       </span>
-      <div className="min-w-0 flex-1 flex items-center gap-2">
-        {activity.phase === "start" ? (
-          <LiveStatusText>
-            <ActivityText text={activity.text} />
-          </LiveStatusText>
-        ) : (
-          <ActivityText text={activity.text} />
-        )}
-        {activity.toolName !== "__thought" && activity.sandboxProvider && (
-          <span className="chat-meta-text inline-flex items-center rounded border border-sky-400/30 bg-sky-400/10 px-1.5 py-0.5 leading-none text-sky-200">
-            {formatSandboxProviderLabel(activity.sandboxProvider)}
-          </span>
-        )}
-      </div>
+      {expandable ? (
+        <button
+          type="button"
+          onClick={() => setExpanded((value) => !value)}
+          className="min-w-0 flex-1 cursor-pointer text-left text-inherit"
+          aria-expanded={expanded}
+          title={expanded ? "Collapse tool call" : "Show full tool call"}
+        >
+          <span className="flex min-w-0 items-start gap-2">{textContent}</span>
+        </button>
+      ) : (
+        <div className="min-w-0 flex-1 flex items-center gap-2">{textContent}</div>
+      )}
     </div>
   );
 }

--- a/ui/src/pages/chat/ChatMessageTimeline.tsx
+++ b/ui/src/pages/chat/ChatMessageTimeline.tsx
@@ -2,6 +2,7 @@ import { User } from "lucide-react";
 import type { ReactElement } from "react";
 import {
   buildActivitiesFromToolCalls,
+  enrichActivitiesWithToolCallDetails,
   finalizeCompletedActivities,
   type LiveActivityItem,
   mergeActivityLists,
@@ -111,8 +112,13 @@ export function ChatMessageTimeline({
           mergeActivityLists(restoredProcessActivities, fallbackToolActivities),
           message.tool_calls
         );
-        const processActivities =
-          mergedActivities.length > 0 ? finalizeCompletedActivities(mergedActivities) : undefined;
+        const completedActivities =
+          mergedActivities.length > 0 ? finalizeCompletedActivities(mergedActivities) : [];
+        const detailedActivities = enrichActivitiesWithToolCallDetails(
+          completedActivities,
+          message.tool_calls
+        );
+        const processActivities = detailedActivities.length > 0 ? detailedActivities : undefined;
         return (
           <div
             key={`${message.timestamp || "msg"}-${originalIndex}`}


### PR DESCRIPTION


<!-- GITZILLA_SUMMARY -->
> [!NOTE]
> **Low Risk**
>
> **Overview**
> This release introduces a new `huggingface-workflows` plugin bundle containing eleven skill modules—HF CLI, datasets, jobs, paper publisher/papers, trackio, transformers.js, Hugging Face community evals, plus Gradio, LLM, and vision trainers—registered via a new `cybara-plugin.json` manifest with corresponding test coverage. A shared `shared/tool-activity-detail.ts` module centralizes schema, normalization, and rendering for per-tool activity entries (file edits, patches, commands, read outcomes), refactoring the existing `chat-tool-summary` and updating consumers across `src/api/`, `src/core/`, and `tests/`. Supporting changes wire this shared module through chat runtime, process activities, run recovery, session transcripts, and the agent internals, while the UI layer (`chatActivities.ts`, `ActivityTimeline.tsx`, `ChatMessageTimeline.tsx`) gains new helpers and timeline rendering for activity details. Additional hardening touches error classification, provider retry, background review, session context/ledger, and file-handler edits, accompanied by new tests for chat interruption persistence, response/run recovery, file search, and tool activity detail.
>
> <sup>Written by [Gitzilla](https://gitzilla.ai) for commit 1990d52. This will update automatically on new runs. Configure in the [Gitzilla dashboard](https://gitzilla.ai/dashboard).</sup>
<!-- /GITZILLA_SUMMARY -->