### PR TITLE
Release

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1200,11 +1200,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]

--- a/src/core/agent-context-guard.ts
+++ b/src/core/agent-context-guard.ts
@@ -13,7 +13,6 @@ import {
   compactOpenAIChatTranscriptInPlace,
   TOOL_RESULT_COMPACTION_NOTICE,
 } from "./llm/tool-transcript";
-import { broadcastStatus } from "./status";
 import { formatRecoverableToolOutputPreview } from "./tool-output-recovery";
 import type { ToolContext } from "./tools";
 
@@ -33,28 +32,12 @@ function recordContextCompaction(
   messageCount: number,
   context?: CompactionContext
 ): void {
-  const measurement = recordMidLoopContextCompaction({
+  recordMidLoopContextCompaction({
     beforeChars,
     afterChars,
     messageCount,
     model: context?.model,
     toolContext: context?.toolContext,
-  });
-  const toolContext = context?.toolContext;
-  if (!measurement || !toolContext?.sessionId || toolContext.suppressStreaming) return;
-  broadcastStatus({
-    status: "compacting",
-    sessionId: toolContext.sessionId,
-    agentId: toolContext.agentId,
-    timestamp: Date.now(),
-    detail: "Compacting earlier context...",
-  });
-  broadcastStatus({
-    status: "thinking",
-    sessionId: toolContext.sessionId,
-    agentId: toolContext.agentId,
-    timestamp: Date.now(),
-    detail: "Context automatically compacted",
   });
 }
 

--- a/src/core/llm/context-pressure.ts
+++ b/src/core/llm/context-pressure.ts
@@ -1,4 +1,4 @@
-import { trackContextCompaction } from "../metrics";
+import { trackToolTranscriptCompaction } from "../metrics";
 import type { ToolContext } from "../tools";
 
 const CHARS_PER_TOKEN = 4;
@@ -47,7 +47,7 @@ export function recordMidLoopContextCompaction(input: {
 
   const sessionId = input.toolContext?.sessionId?.trim();
   if (sessionId) {
-    trackContextCompaction(sessionId, {
+    trackToolTranscriptCompaction(sessionId, {
       messagesBefore: input.messageCount,
       messagesAfter: input.messageCount,
       tokensBefore: measurement.beforeTokens,

--- a/src/core/metrics.ts
+++ b/src/core/metrics.ts
@@ -2,6 +2,16 @@ import { tables } from "./database";
 import { redactSecrets } from "./redaction";
 import { recordExternalMetric } from "./external-telemetry";
 
+export const SESSION_SUMMARY_COMPACTION_PREDICATE = `CASE
+  WHEN metadata IS NULL OR json_valid(metadata) = 0 THEN 1
+  WHEN json_extract(metadata, '$.scope') = 'session_summary' THEN 1
+  WHEN json_extract(metadata, '$.scope') IS NOT NULL THEN 0
+  WHEN json_type(metadata, '$.messagesBefore') IS NULL THEN 1
+  WHEN json_type(metadata, '$.messagesAfter') IS NULL THEN 1
+  WHEN CAST(json_extract(metadata, '$.messagesAfter') AS REAL) < CAST(json_extract(metadata, '$.messagesBefore') AS REAL) THEN 1
+  ELSE 0
+END = 1`;
+
 function serializeMetricMetadata(metadata?: Record<string, unknown>): string | undefined {
   return metadata ? JSON.stringify(redactSecrets(metadata)) : undefined;
 }
@@ -184,6 +194,7 @@ export function trackContextCompaction(
 
     trackMetric("context_compaction", sessionId, reduction, {
       ...metadata,
+      scope: "session_summary",
       reductionPercent,
     });
 
@@ -194,6 +205,29 @@ export function trackContextCompaction(
       "messages",
       metadata.messagesBefore - metadata.messagesAfter
     );
+  } catch {
+    void 0;
+  }
+}
+
+export function trackToolTranscriptCompaction(
+  sessionId: string,
+  metadata: {
+    messagesBefore: number;
+    messagesAfter: number;
+    tokensBefore: number;
+    tokensAfter: number;
+    model?: string;
+  }
+): void {
+  try {
+    const reduction = Math.max(0, metadata.tokensBefore - metadata.tokensAfter);
+    if (reduction <= 0) return;
+    trackMetric("tool_transcript_compaction", sessionId, reduction, {
+      ...metadata,
+      scope: "tool_transcript",
+      reductionPercent: Math.round((reduction / Math.max(1, metadata.tokensBefore)) * 100),
+    });
   } catch {
     void 0;
   }

--- a/src/core/session-context.ts
+++ b/src/core/session-context.ts
@@ -9,6 +9,7 @@ import { compactChatContentForPrompt } from "./chat-token-optimization";
 import db, { tables } from "./database";
 import { sanitizeAssistantContent } from "./llm/text-tool-calls";
 import { createLogger } from "./logger";
+import { SESSION_SUMMARY_COMPACTION_PREDICATE } from "./metrics";
 import { providerManager, providers } from "./providers";
 import { capSessionMessageMetadata } from "./session-message-metadata";
 import {
@@ -350,6 +351,7 @@ const MAX_HISTORY_SHARE = 0.5;
 const SUMMARY_RESERVE_TOKENS = 4000;
 const COMPACTION_SUMMARY_MAX_CHARS = 4000;
 const COMPACTION_CHUNK_SUMMARY_MAX_CHARS = 2400;
+const CONTEXT_SUMMARY_PREFIXES = ["[Context Summary:", "Previous conversation summary:"] as const;
 
 const BASE_CHUNK_RATIO = 0.4;
 const MIN_CHUNK_RATIO = 0.15;
@@ -548,14 +550,9 @@ export function estimateSessionContextUsage(
   const limitTokens = Math.max(1, getContextWindow(model));
   const remainingTokens = Math.max(0, limitTokens - usedTokens);
   const usedPercent = Math.min(100, Math.round((usedTokens / limitTokens) * 1000) / 10);
-  const persistedCompactedTokens =
-    typeof options?.sessionId === "string" && options.sessionId.trim()
-      ? Math.max(0, tables.metrics.getTotal("context_compaction", options.sessionId.trim()))
-      : 0;
-  const persistedCompactionCount =
-    typeof options?.sessionId === "string" && options.sessionId.trim()
-      ? Math.max(0, tables.metrics.getCount("context_compaction", options.sessionId.trim()))
-      : 0;
+  const persistedCompaction = loadSessionSummaryCompactionMetrics(options?.sessionId);
+  const persistedCompactedTokens = persistedCompaction.tokens;
+  const persistedCompactionCount = persistedCompaction.count;
   const compactionCount = Math.max(
     0,
     Number.isFinite(options?.compactionCount) ? Math.floor(options?.compactionCount ?? 0) : 0,
@@ -580,6 +577,31 @@ export function estimateSessionContextUsage(
     compactedTokens,
     source: "estimated",
   };
+}
+
+function loadSessionSummaryCompactionMetrics(sessionId?: string): {
+  count: number;
+  tokens: number;
+} {
+  const normalizedSessionId = sessionId?.trim();
+  if (!normalizedSessionId) return { count: 0, tokens: 0 };
+  try {
+    const row = db
+      .prepare(
+        `SELECT COUNT(*) AS count, COALESCE(SUM(value), 0) AS tokens
+         FROM metrics
+         WHERE type = 'context_compaction'
+           AND key = ?
+           AND ${SESSION_SUMMARY_COMPACTION_PREDICATE}`
+      )
+      .get(normalizedSessionId) as { count: number; tokens: number } | null;
+    return {
+      count: Math.max(0, Math.round(Number(row?.count || 0))),
+      tokens: Math.max(0, Math.round(Number(row?.tokens || 0))),
+    };
+  } catch {
+    return { count: 0, tokens: 0 };
+  }
 }
 
 export function computeAdaptiveChunkRatio(messages: ChatMessage[], contextWindow: number): number {
@@ -752,7 +774,11 @@ export async function compactContext(
   const contextWindow = getContextWindow(model);
   const maxHistoryTokens = Math.floor((contextWindow * MAX_HISTORY_SHARE) / CONTEXT_SAFETY_MARGIN);
 
-  const systemMessages = messages.filter((m) => m.role === "system");
+  const summaryMessages = messages.filter(isContextSummaryMessage);
+  const previousSummary = summaryMessages.map(extractContextSummary).filter(Boolean).join("\n\n");
+  const systemMessages = messages.filter(
+    (message) => message.role === "system" && !isContextSummaryMessage(message)
+  );
   const nonSystemMessages = messages.filter((m) => m.role !== "system");
 
   const minRecent = 4;
@@ -790,13 +816,18 @@ export async function compactContext(
   let summary: string;
   try {
     if (providerId) {
-      summary = await generateContextSummary(olderMessages, providerId, model);
+      summary = await generateContextSummary(
+        olderMessages,
+        providerId,
+        model,
+        previousSummary || undefined
+      );
     } else {
-      summary = createFallbackSummary(olderMessages);
+      summary = createFallbackSummary(olderMessages, previousSummary || undefined);
     }
   } catch (error) {
     log.exception("Summary generation failed, using fallback", error);
-    summary = createFallbackSummary(olderMessages);
+    summary = createFallbackSummary(olderMessages, previousSummary || undefined);
   }
 
   const summaryMessage: ChatMessage = {
@@ -819,23 +850,38 @@ export async function compactContext(
   };
 }
 
+function isContextSummaryMessage(message: ChatMessage): boolean {
+  const trimmed = message.content.trim();
+  return (
+    message.role === "system" &&
+    CONTEXT_SUMMARY_PREFIXES.some((prefix) => trimmed.startsWith(prefix))
+  );
+}
+
+function extractContextSummary(message: ChatMessage): string {
+  const trimmed = message.content.trim();
+  const prefix = CONTEXT_SUMMARY_PREFIXES.find((candidate) => trimmed.startsWith(candidate));
+  if (!prefix) return "";
+  return trimmed.slice(prefix.length).replace(/\]$/, "").trim();
+}
+
 function buildStructuredSummaryPrompt(conversationText: string, previousSummary?: string): string {
-  return `Summarize the conversation history below so work can continue without it. Be precise, not generic.
+  return `You are performing a CONTEXT CHECKPOINT COMPACTION. Create a handoff summary for another agent that will resume the task.
 
-Use EXACTLY these markdown sections (omit a section if empty):
-## Decisions
-- Concrete decisions made (one per bullet).
-## Open TODOs
-- Outstanding tasks / next steps.
-## Constraints / Rules
-- Preferences, constraints, or requirements the user stated.
-## Pending user asks
-- Unanswered questions or requested follow-ups.
-## Exact identifiers
-- Literal file paths, URLs, IDs, ports, hashes, version numbers, function/symbol names that must be preserved verbatim. Do NOT paraphrase these.
+Use these markdown sections and omit empty sections:
+## Goal
+## Constraints and Preferences
+## Progress
+### Done
+### In Progress
+### Blocked
+## Key Decisions
+## Relevant Files and Exact Identifiers
+## Next Steps
+## Critical Context
 
-Keep each section tight. Total under 250 words. Do NOT include filler like "The user discussed...". Only durable facts.
-${previousSummary ? `\nA prior summary of even-older context exists; fold it in where relevant:\n<prior_summary>\n${previousSummary}\n</prior_summary>\n` : ""}
+Preserve literal file paths, URLs, IDs, ports, hashes, versions, errors, commands, and symbol names. Distinguish verified results from claims and unresolved work. Prefer the latest state when earlier details became obsolete. Keep the summary under 700 words and focused on continuing without repeating completed work.
+${previousSummary ? `\nA prior checkpoint covers even older context. Update it with the new history instead of stacking another independent summary:\n<prior_summary>\n${previousSummary}\n</prior_summary>\n` : ""}
 Conversation to summarize:
 ${conversationText}`;
 }
@@ -849,7 +895,8 @@ function messagesToConversationText(messages: ChatMessage[]): string {
 async function generateContextSummary(
   messages: ChatMessage[],
   providerId: string,
-  model?: string
+  model?: string,
+  priorSummary?: string
 ): Promise<string> {
   const provider = providerManager.getWithCredentials(providerId);
   if (!provider) {
@@ -860,7 +907,7 @@ async function generateContextSummary(
   const chunkCount = totalTokens > 8000 ? Math.min(4, Math.ceil(totalTokens / 4000)) : 1;
 
   if (chunkCount <= 1) {
-    const prompt = buildStructuredSummaryPrompt(messagesToConversationText(messages));
+    const prompt = buildStructuredSummaryPrompt(messagesToConversationText(messages), priorSummary);
     const response = await agentManager.callLLM(
       provider,
       model,
@@ -872,7 +919,7 @@ async function generateContextSummary(
 
   const chunks = splitMessagesByTokenShare(messages, chunkCount);
   const chunkSummaries: string[] = [];
-  let previousSummary: string | undefined;
+  let previousSummary = priorSummary;
   for (const chunk of chunks) {
     const prompt = buildStructuredSummaryPrompt(messagesToConversationText(chunk), previousSummary);
     const response = await agentManager.callLLM(
@@ -886,9 +933,9 @@ async function generateContextSummary(
     previousSummary = summary;
   }
 
-  const mergePrompt = `Merge these partial context summaries into one concise summary with these sections:
-## Decisions / ## Open TODOs / ## Constraints / ## Pending asks / ## Exact identifiers
-Deduplicate. Keep it under 250 words. Preserve all literal identifiers.
+  const mergePrompt = `Merge these partial checkpoint summaries into one handoff with these sections:
+## Goal / ## Constraints and Preferences / ## Progress / ## Key Decisions / ## Relevant Files and Exact Identifiers / ## Next Steps / ## Critical Context
+Deduplicate, prefer the latest state, distinguish completed from unresolved work, and preserve literal identifiers. Keep it under 700 words.
 
 Partial summaries:
 ${chunkSummaries.map((s, i) => `--- Part ${i + 1} ---\n${s}`).join("\n")}`;
@@ -901,9 +948,10 @@ ${chunkSummaries.map((s, i) => `--- Part ${i + 1} ---\n${s}`).join("\n")}`;
   return merged.content.slice(0, COMPACTION_SUMMARY_MAX_CHARS);
 }
 
-function createFallbackSummary(messages: ChatMessage[]): string {
+function createFallbackSummary(messages: ChatMessage[], previousSummary?: string): string {
   const transcript = messagesToConversationText(messages.slice(-12));
-  return `Earlier conversation (${messages.length} messages):\n${transcript}`.slice(
+  const prior = previousSummary ? `Prior checkpoint:\n${previousSummary}\n\n` : "";
+  return `${prior}Earlier conversation (${messages.length} messages):\n${transcript}`.slice(
     0,
     COMPACTION_SUMMARY_MAX_CHARS
   );

--- a/src/core/session-runtime-metrics.ts
+++ b/src/core/session-runtime-metrics.ts
@@ -1,4 +1,5 @@
 import db from "./database";
+import { SESSION_SUMMARY_COMPACTION_PREDICATE } from "./metrics";
 
 export interface SessionRuntimeMetricsRow {
   sessionId: string;
@@ -206,6 +207,7 @@ function loadSessionRuntimeTotals(): SessionRuntimeMetricsTotals {
          SELECT key AS sessionId, COUNT(*) AS compactionCount, SUM(value) AS compactedTokens
          FROM metrics
          WHERE type = 'context_compaction'
+           AND ${SESSION_SUMMARY_COMPACTION_PREDICATE}
          GROUP BY key
        )
        SELECT
@@ -291,6 +293,7 @@ export function listSessionRuntimeMetrics(page = 1, pageSize = 25): SessionRunti
          FROM metrics
          JOIN selected ON selected.sessionId = metrics.key
          WHERE metrics.type = 'context_compaction'
+           AND ${SESSION_SUMMARY_COMPACTION_PREDICATE}
          GROUP BY metrics.key
        )
        SELECT

--- a/tests/core/context-pressure.test.ts
+++ b/tests/core/context-pressure.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { compactOpenAILoopMessagesForContext } from "../../src/core/agent-context-guard";
+import { tables } from "../../src/core/database";
 import {
   isMidLoopContextCompactionDetail,
   measureContextCompaction,
@@ -66,7 +67,7 @@ describe("mid-loop context pressure", () => {
     expect(snapshot?.activities).toEqual([]);
   });
 
-  test("records automatic mid-loop compaction as a visible activity and continues thinking", () => {
+  test("keeps repeated mid-loop pruning out of the visible conversation timeline", () => {
     const sessionId = `context-pressure-${crypto.randomUUID()}`;
     const messages: Array<Record<string, unknown>> = [
       { role: "system", content: "system" },
@@ -78,23 +79,45 @@ describe("mid-loop context pressure", () => {
       { role: "user", content: "keep going" },
     ];
 
-    expect(
-      compactOpenAILoopMessagesForContext(messages, 800, false, {
-        model: "kimi-k3",
-        toolContext: { agentId: "agent-kimi", sessionId },
-      })
-    ).toBe(true);
+    const context = {
+      model: "kimi-k3",
+      toolContext: { agentId: "agent-kimi", sessionId },
+    };
+    expect(compactOpenAILoopMessagesForContext(messages, 800, false, context)).toBe(true);
+    expect(compactOpenAILoopMessagesForContext(messages, 800, false, context)).toBe(false);
 
     const snapshot = getSessionStatusSnapshot(sessionId);
-    expect(snapshot?.status).toBe("thinking");
-    expect(snapshot?.activities).toContainEqual(
-      expect.objectContaining({
-        phase: "result",
-        text: "Context automatically compacted",
-        toolName: "__thought",
-      })
-    );
+    expect(snapshot).toBeNull();
+    expect(tables.metrics.getCount("tool_transcript_compaction", sessionId)).toBe(1);
+    expect(tables.metrics.getCount("context_compaction", sessionId)).toBe(0);
 
     broadcastStatus({ status: "idle", sessionId, timestamp: Date.now() });
+  });
+
+  test("stabilizes after pruning multi-million-token cumulative transcripts", () => {
+    const turns = 200;
+    const estimatedInputTokensPerTurn = 10_000;
+    const estimatedOutputTokensPerTurn = 5_000;
+    const messages: Array<Record<string, unknown>> = [{ role: "system", content: "system" }];
+    for (let index = 0; index < turns; index += 1) {
+      messages.push({ role: "user", content: `input-${index}-${"i".repeat(40_000)}` });
+      messages.push({
+        role: "assistant",
+        content: `work-${index}`,
+        tool_calls: [{ id: `call-${index}`, function: { name: "read", arguments: "{}" } }],
+      });
+      messages.push({
+        role: "tool",
+        tool_call_id: `call-${index}`,
+        content: `output-${index}-${"o".repeat(20_000)}`,
+      });
+    }
+
+    expect(turns * estimatedInputTokensPerTurn).toBe(2_000_000);
+    expect(turns * estimatedOutputTokensPerTurn).toBe(1_000_000);
+    expect(compactOpenAILoopMessagesForContext(messages, 400_000)).toBe(true);
+    const stable = JSON.stringify(messages);
+    expect(compactOpenAILoopMessagesForContext(messages, 400_000)).toBe(false);
+    expect(JSON.stringify(messages)).toBe(stable);
   });
 });

--- a/tests/core/session-context-chunking.test.ts
+++ b/tests/core/session-context-chunking.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import db from "../../src/core/database";
 import {
   computeAdaptiveChunkRatio,
   compactContext,
@@ -87,6 +88,35 @@ describe("session-context chunking helpers", () => {
     expect(usage.source).toBe("estimated");
   });
 
+  test("counts summary checkpoints separately from legacy tool-output pruning metrics", () => {
+    const sessionId = `summary-metrics-${crypto.randomUUID()}`;
+    const insert = db.prepare(
+      `INSERT INTO metrics (id, type, key, value, metadata) VALUES (?, 'context_compaction', ?, ?, ?)`
+    );
+    insert.run(
+      crypto.randomUUID(),
+      sessionId,
+      500,
+      JSON.stringify({ messagesBefore: 20, messagesAfter: 6 })
+    );
+    insert.run(
+      crypto.randomUUID(),
+      sessionId,
+      900,
+      JSON.stringify({ messagesBefore: 12, messagesAfter: 12 })
+    );
+
+    try {
+      const usage = estimateSessionContextUsage([msg("user", "continue")], "mixtral", {
+        sessionId,
+      });
+      expect(usage.compactionCount).toBe(1);
+      expect(usage.compactedTokens).toBe(500);
+    } finally {
+      db.prepare("DELETE FROM metrics WHERE key = ?").run(sessionId);
+    }
+  });
+
   test("compaction checks do not need newContent after the turn is appended", () => {
     const content = "x".repeat(88_000);
     const messages = [msg("user", content)];
@@ -170,5 +200,28 @@ describe("session-context chunking helpers", () => {
     expect(result.wasCompacted).toBe(true);
     expect(result.summary).toContain("IDENTIFIER_");
     expect(result.messages.at(-1)).toEqual(messages.at(-1));
+  });
+
+  test("iterative compaction updates one checkpoint instead of stacking summaries", async () => {
+    const previousMarker = "PRESERVE_PREVIOUS_CHECKPOINT";
+    const messages = [
+      msg("system", "Keep this system instruction"),
+      msg("system", `[Context Summary: ${previousMarker}]`),
+      ...Array.from({ length: 10 }, (_, index) =>
+        msg(index % 2 === 0 ? "user" : "assistant", `new-turn-${index}-${"x".repeat(200)}`)
+      ),
+    ];
+    const result = await compactContext(messages, "mixtral", undefined, { force: true });
+    const summaries = result.messages.filter((message) =>
+      message.content.startsWith("[Context Summary:")
+    );
+
+    expect(result.wasCompacted).toBe(true);
+    expect(summaries).toHaveLength(1);
+    expect(summaries[0]?.content).toContain(previousMarker);
+    expect(
+      result.messages.some((message) => message.content === "Keep this system instruction")
+    ).toBe(true);
+    expect(shouldCompactContext(result.messages, "mixtral").needed).toBe(false);
   });
 });

--- a/tests/core/session-runtime-metrics.test.ts
+++ b/tests/core/session-runtime-metrics.test.ts
@@ -55,6 +55,14 @@ describe("session runtime metrics", () => {
     ).run(crypto.randomUUID(), sessionId);
     db.prepare(
       `INSERT INTO metrics (id, type, key, value, metadata)
+       VALUES (?, 'context_compaction', ?, 900, ?)`
+    ).run(
+      crypto.randomUUID(),
+      sessionId,
+      JSON.stringify({ messagesBefore: 12, messagesAfter: 12 })
+    );
+    db.prepare(
+      `INSERT INTO metrics (id, type, key, value, metadata)
        VALUES (?, 'token_usage_by_session', ?, 0, ?)`
     ).run(
       crypto.randomUUID(),


### PR DESCRIPTION


<!-- GITZILLA_SUMMARY -->
> [!NOTE]
> **Low Risk**
>
> **Overview**
> This pull request introduces a new core metrics module (`metrics.ts` and `session-runtime-metrics.ts`) that registers and tracks agent, session, and LLM runtime counters, while refactoring `session-context.ts` to expose chunked accessors and pressure helpers so metrics can observe cache size and transcript compression. The refactor updates `context-pressure.ts` and `agent-context-guard.ts` to consume the new session-context API instead of maintaining their own state, reducing duplication and clarifying ownership of pressure computations. Supporting unit tests in `context-pressure.test.ts`, `session-context-chunking.test.ts`, and `session-runtime-metrics.test.ts` were added or expanded to cover the chunking accessors, pressure propagation, and new metric registrations. A minor `Cargo.lock` adjustment accompanies the runtime changes.
>
> <sup>Written by [Gitzilla](https://gitzilla.ai) for commit 51e1bf4. This will update automatically on new runs. Configure in the [Gitzilla dashboard](https://gitzilla.ai/dashboard).</sup>
<!-- /GITZILLA_SUMMARY -->