### PR TITLE
Release

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -25,5 +25,6 @@ jobs:
         --lockfile=bun.lock
         --lockfile=ui/bun.lock
         --lockfile=apps/mobile/bun.lock
+        --lockfile=site/bun.lock
         --lockfile=src-tauri/Cargo.lock
       fail-on-vuln: true

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -30,6 +30,7 @@
     },
     "android": {
       "package": "com.ck.cybara",
+      "softwareKeyboardLayoutMode": "resize",
       "permissions": [
         "android.permission.POST_NOTIFICATIONS"
       ],

--- a/apps/mobile/bun.lock
+++ b/apps/mobile/bun.lock
@@ -40,6 +40,7 @@
   "overrides": {
     "brace-expansion": "5.0.9",
     "js-yaml": "4.3.1",
+    "nanoid": "3.3.18",
     "postcss": "8.5.23",
     "uuid": "11.1.1",
   },
@@ -760,7 +761,7 @@
 
     "multitars": ["multitars@1.0.0", "", {}, "sha512-H/J4fMLedtudftaYMOg7ajzLYgT3/rwbWVJbqr/iUgB8DQztn38ys5HOqI1CzSxx8QhXXwOOnnBvd4v3jG5+Mg=="],
 
-    "nanoid": ["nanoid@3.3.17", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g=="],
+    "nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
 
     "negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
 

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -40,6 +40,7 @@
   },
   "overrides": {
     "brace-expansion": "5.0.9",
+    "nanoid": "3.3.18",
     "postcss": "8.5.23",
     "uuid": "11.1.1",
     "js-yaml": "4.3.1"

--- a/apps/mobile/src/components/MetricVisuals.tsx
+++ b/apps/mobile/src/components/MetricVisuals.tsx
@@ -1,13 +1,35 @@
 import type { ReactNode } from "react";
 import { StyleSheet, Text, View } from "react-native";
-import { formatMetricNumber, type MetricsAvailability, type MetricsSnapshot } from "../lib/metrics";
+import {
+  formatMetricNumber,
+  metricProgressPercent,
+  type MetricsAvailability,
+  type MetricsSnapshot,
+} from "../lib/metrics";
 import { colors, radius, spacing, subscribeColors, typography } from "../theme/liquidGlass";
 
+function MetricProgressFill({ percent, tone }: { percent: number; tone: string }) {
+  if (percent <= 0) return null;
+  return (
+    <View
+      style={[
+        styles.trackFill,
+        {
+          backgroundColor: tone,
+          width: `${percent}%`,
+        },
+      ]}
+    />
+  );
+}
+
 export function MetricSection({
+  available = true,
   children,
   detail,
   title,
 }: {
+  available?: boolean;
   children: ReactNode;
   detail?: string;
   title: string;
@@ -22,7 +44,7 @@ export function MetricSection({
           </Text>
         ) : null}
       </View>
-      {children}
+      {available ? children : <Text style={styles.detail}>Metric feed unavailable</Text>}
     </View>
   );
 }
@@ -58,14 +80,9 @@ export function MetricBreakdown({
             <Text style={styles.detail}>{formatMetricNumber(entry.value)}</Text>
           </View>
           <View style={styles.track}>
-            <View
-              style={[
-                styles.trackFill,
-                {
-                  backgroundColor: tone,
-                  width: `${Math.max(2, (entry.value / total) * 100)}%`,
-                },
-              ]}
+            <MetricProgressFill
+              percent={metricProgressPercent(entry.value, total, 2)}
+              tone={tone}
             />
           </View>
         </View>
@@ -86,15 +103,17 @@ export function MetricBarChart({
     <View style={styles.barChart}>
       {data.map((entry) => (
         <View key={entry.label} style={styles.barSlot}>
-          <View
-            style={[
-              styles.bar,
-              {
-                backgroundColor: tone,
-                height: Math.max(3, (entry.value / max) * 58),
-              },
-            ]}
-          />
+          {entry.value > 0 ? (
+            <View
+              style={[
+                styles.bar,
+                {
+                  backgroundColor: tone,
+                  height: Math.max(3, (entry.value / max) * 58),
+                },
+              ]}
+            />
+          ) : null}
           <Text numberOfLines={1} style={styles.barLabel}>
             {entry.label}
           </Text>
@@ -120,16 +139,18 @@ export function MetricAreaChart({
       <View style={styles.areaColumns}>
         {data.map((entry, index) => (
           <View key={`${entry.label}-${index}`} style={styles.areaSlot}>
-            <View
-              style={[
-                styles.areaColumn,
-                {
-                  backgroundColor: tone,
-                  height: Math.max(5, (entry.value / max) * 82),
-                  opacity: 0.16 + Math.min(0.68, (entry.value / max) * 0.68),
-                },
-              ]}
-            />
+            {entry.value > 0 ? (
+              <View
+                style={[
+                  styles.areaColumn,
+                  {
+                    backgroundColor: tone,
+                    height: Math.max(5, (entry.value / max) * 82),
+                    opacity: 0.16 + Math.min(0.68, (entry.value / max) * 0.68),
+                  },
+                ]}
+              />
+            ) : null}
           </View>
         ))}
       </View>
@@ -214,14 +235,13 @@ export function MetricShareRows({
           <View style={styles.shareValue}>
             <Text style={[styles.counter, { color: row.tone ?? tone }]}>{row.value}</Text>
             <View style={styles.trackSmall}>
-              <View
-                style={[
-                  styles.trackFill,
-                  {
-                    backgroundColor: row.tone ?? tone,
-                    width: `${Math.max(4, row.progress ?? (row.amount / max) * 100)}%`,
-                  },
-                ]}
+              <MetricProgressFill
+                percent={metricProgressPercent(
+                  row.progress ?? row.amount,
+                  row.progress === undefined ? max : 100,
+                  4
+                )}
+                tone={row.tone ?? tone}
               />
             </View>
           </View>

--- a/apps/mobile/src/lib/api-normalizers.ts
+++ b/apps/mobile/src/lib/api-normalizers.ts
@@ -31,6 +31,7 @@ import type {
   SessionTokenUsage,
   SessionToolCallSummary,
 } from "./api-types";
+import { createWebSocketAuthProtocol } from "cybara-shared/websocket-auth";
 import {
   asRecord,
   normalizeArrayResponse,
@@ -951,9 +952,15 @@ export function buildMobileStatusStreamUrl(profile: GatewayProfile): string {
   const rootPath = url.pathname.replace(/\/+$/, "");
   url.pathname = `${rootPath}/api/ws/status`;
   url.search = "";
-  url.searchParams.set("token", profile.apiKey);
   url.hash = "";
   return url.toString();
+}
+
+export function buildMobileStatusStreamAuthProtocol(profile: GatewayProfile): string | null {
+  return createWebSocketAuthProtocol({
+    token: profile.apiKey,
+    password: profile.gatewayPassword,
+  });
 }
 
 function normalizeAgentConfig(value: unknown): Record<string, unknown> {

--- a/apps/mobile/src/lib/api-types.ts
+++ b/apps/mobile/src/lib/api-types.ts
@@ -1074,7 +1074,10 @@ interface MobileWebSocket {
   close: () => void;
 }
 
-type MobileWebSocketConstructor = new (url: string) => MobileWebSocket;
+type MobileWebSocketConstructor = new (
+  url: string,
+  protocols?: string | string[]
+) => MobileWebSocket;
 
 export interface MobileStatusStreamOptions {
   reconnectDelayMs?: number;

--- a/apps/mobile/src/lib/api.ts
+++ b/apps/mobile/src/lib/api.ts
@@ -10,6 +10,7 @@ import {
 import { MobileStatusStreamClient } from "./mobileStatusStream";
 import {
   buildMobileMediaUrl,
+  buildMobileStatusStreamAuthProtocol,
   buildMobileStatusStreamUrl,
   emptyAvailability,
   normalizeActivityLogPage,
@@ -125,6 +126,7 @@ export type {
 } from "./apiProviderPlans";
 export {
   buildMobileMediaUrl,
+  buildMobileStatusStreamAuthProtocol,
   buildMobileStatusStreamUrl,
   normalizeActivityLogs,
   normalizeJourney,
@@ -164,7 +166,8 @@ export class CybaraMobileApi {
     this.profile = profile;
     this.statusStreamClient = new MobileStatusStreamClient(
       () => this.statusStreamUrl(),
-      normalizeMobileStatusStreamEvent
+      normalizeMobileStatusStreamEvent,
+      () => buildMobileStatusStreamAuthProtocol(this.profile)
     );
   }
 
@@ -177,6 +180,7 @@ export class CybaraMobileApi {
     this.profile = gatewayPassword?.trim()
       ? { ...this.profile, gatewayPassword: gatewayPassword.trim() }
       : { ...this.profile, gatewayPassword: undefined };
+    this.statusStreamClient.reset();
   }
 
   private headers(): Headers {
@@ -360,9 +364,14 @@ export class CybaraMobileApi {
     });
   }
 
-  async sessionList(): Promise<SessionListPage> {
+  async sessionList(options: { limit?: number; offset?: number } = {}): Promise<SessionListPage> {
+    const limit = Math.min(
+      500,
+      Math.max(1, Math.floor(options.limit ?? MOBILE_SESSION_LIST_LIMIT))
+    );
+    const offset = Math.max(0, Math.floor(options.offset ?? 0));
     return normalizeSessionListPage(
-      await this.request<unknown>(`/api/sessions?limit=${MOBILE_SESSION_LIST_LIMIT}&includeTotal=1`)
+      await this.request<unknown>(`/api/sessions?limit=${limit}&offset=${offset}&includeTotal=1`)
     );
   }
 

--- a/apps/mobile/src/lib/chat-format.ts
+++ b/apps/mobile/src/lib/chat-format.ts
@@ -29,8 +29,8 @@ export function mobileMediaSummaryLabel(images: MobileMessageImage[], maxImages:
 }
 
 export type MessageContentPart =
-  | { type: "text"; content: string }
-  | { type: "code"; language: string; content: string };
+  | { type: "text"; content: string; key: string }
+  | { type: "code"; language: string; content: string; key: string };
 
 export type UnicodeTextRun = {
   type: "text" | "emoji" | "unicode";
@@ -106,19 +106,24 @@ export function splitMessageContent(content: string): MessageContentPart[] {
   let match: RegExpExecArray | null;
   while ((match = regex.exec(content))) {
     if (match.index > cursor) {
-      parts.push({ type: "text", content: content.slice(cursor, match.index) });
+      parts.push({
+        type: "text",
+        content: content.slice(cursor, match.index),
+        key: `text-${cursor}`,
+      });
     }
     parts.push({
       type: "code",
       language: match[1]?.trim() || "code",
       content: match[2] || "",
+      key: `code-${match.index}`,
     });
     cursor = match.index + match[0].length;
   }
   if (cursor < content.length) {
-    parts.push({ type: "text", content: content.slice(cursor) });
+    parts.push({ type: "text", content: content.slice(cursor), key: `text-${cursor}` });
   }
-  return parts.length > 0 ? parts : [{ type: "text", content }];
+  return parts.length > 0 ? parts : [{ type: "text", content, key: "text-0" }];
 }
 
 const REASONING_MARKUP_TOKEN_PATTERN =
@@ -525,7 +530,13 @@ export type MarkdownInline =
 export type MarkdownBlock =
   | { type: "heading"; level: number; inline: MarkdownInline[] }
   | { type: "paragraph"; inline: MarkdownInline[] }
-  | { type: "listItem"; ordered: boolean; marker: string; inline: MarkdownInline[] }
+  | {
+      type: "listItem";
+      ordered: boolean;
+      marker: string;
+      inline: MarkdownInline[];
+      checked?: boolean;
+    }
   | { type: "quote"; inline: MarkdownInline[] }
   | { type: "rule" }
   | { type: "table"; header: MarkdownInline[][]; rows: MarkdownInline[][][] };
@@ -580,7 +591,10 @@ export function extractMobileMarkdownImages(input: string): MobileMarkdownImageE
 export function parseInlineMarkdown(input: string): MarkdownInline[] {
   const tokens: MarkdownInline[] = [];
   let rest = input;
-  const patterns: Array<{ re: RegExp; make: (m: RegExpExecArray) => MarkdownInline }> = [
+  const patterns: Array<{
+    re: RegExp;
+    make: (m: RegExpExecArray) => MarkdownInline;
+  }> = [
     { re: /`([^`]+)`/, make: (m) => ({ type: "code", text: m[1] }) },
     {
       re: /\[([^\]]+)\]\(([^)\s]+)[^)]*\)/,
@@ -589,8 +603,14 @@ export function parseInlineMarkdown(input: string): MarkdownInline[] {
     { re: /\*\*([^*]+)\*\*/, make: (m) => ({ type: "bold", text: m[1] }) },
     { re: /__([^_]+)__/, make: (m) => ({ type: "bold", text: m[1] }) },
     { re: /~~([^~]+)~~/, make: (m) => ({ type: "strike", text: m[1] }) },
-    { re: /(?<![*\w])\*([^*\n]+)\*(?![*\w])/, make: (m) => ({ type: "italic", text: m[1] }) },
-    { re: /(?<![_\w])_([^_\n]+)_(?![_\w])/, make: (m) => ({ type: "italic", text: m[1] }) },
+    {
+      re: /(?<![*\w])\*([^*\n]+)\*(?![*\w])/,
+      make: (m) => ({ type: "italic", text: m[1] }),
+    },
+    {
+      re: /(?<![_\w])_([^_\n]+)_(?![_\w])/,
+      make: (m) => ({ type: "italic", text: m[1] }),
+    },
   ];
 
   let guard = 0;
@@ -697,11 +717,13 @@ export function parseMarkdownBlocks(input: string): MarkdownBlock[] {
     const unordered = /^[-*+]\s+(.*)$/.exec(trimmed);
     if (unordered) {
       flushParagraph();
+      const task = /^\[([ xX])\]\s+(.*)$/.exec(unordered[1]);
       blocks.push({
         type: "listItem",
         ordered: false,
         marker: "•",
-        inline: parseInlineMarkdown(unordered[1]),
+        inline: parseInlineMarkdown(task?.[2] || unordered[1]),
+        checked: task ? task[1].toLowerCase() === "x" : undefined,
       });
       continue;
     }
@@ -710,6 +732,11 @@ export function parseMarkdownBlocks(input: string): MarkdownBlock[] {
   }
   flushParagraph();
   return blocks;
+}
+
+export function mobileCodeLineCount(content: string): number {
+  const normalized = content.replace(/\r\n/g, "\n").replace(/\n$/, "");
+  return normalized ? normalized.split("\n").length : 0;
 }
 
 const STREAM_REASONING_TAG =

--- a/apps/mobile/src/lib/dashboard.ts
+++ b/apps/mobile/src/lib/dashboard.ts
@@ -226,6 +226,7 @@ export const MOBILE_SETTINGS_DETAIL_CHROME = {
 } as const;
 
 export const MOBILE_SETTINGS_ROOT_CHROME = {
+  backgroundAgentSelector: true,
   dangerousToolPolicyToggle: true,
   destructiveDisconnectButton: true,
   gatewayConnectionDetails: true,
@@ -237,19 +238,29 @@ export const MOBILE_SETTINGS_ROOT_CHROME = {
   reasoningEffortSelector: true,
   settingsEdgeToEdgeContent: true,
   sandboxRuntimeControls: true,
+  skillLearningNudgeToggle: true,
+  subagentDefaultSelector: true,
   systemPromptFeatureToggles: true,
   migrationControls: true,
   nativeCategoryRail: true,
   speechControls: true,
   terminalToggle: true,
+  tokenOptimizationToggle: true,
   toolApprovalModeSelector: true,
   walletAccessShortcut: true,
 } as const;
 
 export const MOBILE_PLATFORM_SETTING_KEYS = [
+  "default_agent_id",
+  "subagent_agent_id",
+  "background_agent_id",
+  "vision_fallback_agent_id",
   "terminal_enabled",
   "tool_approval_mode",
   "follow_up_behavior_enabled",
+  "self_improving_skills_enabled",
+  "skill_learning_nudge_enabled",
+  "token_optimization",
   "chat_appearance",
   "reasoning_effort",
   "dangerous_tool_policy",

--- a/apps/mobile/src/lib/dashboard.ts
+++ b/apps/mobile/src/lib/dashboard.ts
@@ -86,6 +86,15 @@ export function mergeSessionDetailIntoSummary(
       ? { role: lastMessage.role, content: lastMessage.content }
       : current.last_message,
   };
+  if (
+    nextSession.title === current.title &&
+    nextSession.message_count === current.message_count &&
+    nextSession.updated_at === current.updated_at &&
+    nextSession.last_message?.role === current.last_message?.role &&
+    nextSession.last_message?.content === current.last_message?.content
+  ) {
+    return summary;
+  }
   const sessions = [...summary.sessions];
   sessions[sessionIndex] = nextSession;
   return { ...summary, sessions };
@@ -130,6 +139,23 @@ export const MOBILE_SETTINGS_TABS: Array<{
   { label: "System", value: "system" },
   { label: "Logs", value: "logs" },
 ];
+
+const MOBILE_SETTINGS_TAB_BY_SURFACE: Partial<Record<MobileSurfaceKey, MobileSettingsTab>> = {
+  agents: "agents",
+  approvals: "safety",
+  channels: "channels",
+  logs: "logs",
+  memory: "memory",
+  monitor: "system",
+  providers: "providers",
+  skills: "skills",
+  tools: "tools",
+  wallet: "wallet",
+};
+
+export function mobileSettingsTabForSurface(surface: MobileSurfaceKey): MobileSettingsTab | null {
+  return MOBILE_SETTINGS_TAB_BY_SURFACE[surface] ?? null;
+}
 
 export const MOBILE_HOME_CHROME = {
   firstSection: "recent_activity" as const,
@@ -669,8 +695,20 @@ export function mobileProviderAuthMode(
   return "api_key";
 }
 
-export function recentSessionStateLabel(session: SessionSummary): "Working" | "Recent" {
-  return session.last_message?.role === "user" ? "Working" : "Recent";
+export function mobileSessionIsActive(
+  session: Pick<SessionSummary, "id">,
+  activeSessionIds: readonly string[]
+): boolean {
+  const sessionId = session.id.trim();
+  if (!sessionId) return false;
+  return activeSessionIds.some((candidate) => candidate.trim() === sessionId);
+}
+
+export function recentSessionStateLabel(
+  session: SessionSummary,
+  activeSessionIds: readonly string[]
+): "Working" | "Recent" {
+  return mobileSessionIsActive(session, activeSessionIds) ? "Working" : "Recent";
 }
 
 export function lastUpdatedLabel(session: SessionSummary, nowMs = Date.now()): string {

--- a/apps/mobile/src/lib/metrics.ts
+++ b/apps/mobile/src/lib/metrics.ts
@@ -342,25 +342,54 @@ export function mergeMetricsOverview(
   };
 }
 
+export function reconcileMetricsSnapshot(
+  current: MetricsSnapshot | null,
+  incoming: MetricsSnapshot,
+  overviewGenerationAtRequest: number,
+  currentOverviewGeneration: number
+): MetricsSnapshot {
+  if (
+    currentOverviewGeneration <= overviewGenerationAtRequest ||
+    !current?.overview ||
+    !current.availability.overview.ok
+  ) {
+    return incoming;
+  }
+  return {
+    ...incoming,
+    overview: current.overview,
+    availability: {
+      ...incoming.availability,
+      overview: current.availability.overview,
+    },
+  };
+}
+
+export function hasMetricEndpoint(
+  snapshot: MetricsSnapshot | null,
+  key: MetricsEndpointKey
+): boolean {
+  return snapshot?.availability[key].ok === true && snapshot[key] !== null;
+}
+
 export function hasDetailedMetrics(snapshot: MetricsSnapshot | null): boolean {
   if (!snapshot) return false;
-  return (
-    snapshot.availability.timeSeries.ok ||
-    snapshot.availability.tokenAnalysis.ok ||
-    snapshot.availability.sessions.ok ||
-    snapshot.availability.storage.ok
+  return (Object.keys(snapshot.availability) as MetricsEndpointKey[]).some(
+    (key) => key !== "overview" && hasMetricEndpoint(snapshot, key)
   );
 }
 
 export function formatMetricNumber(value: number | undefined): string {
-  const num = Number.isFinite(value) ? Number(value) : 0;
+  if (!Number.isFinite(value)) return "--";
+  const num = Number(value);
   if (Math.abs(num) >= 1_000_000) return `${(num / 1_000_000).toFixed(2)}M`;
   if (Math.abs(num) >= 1_000) return `${(num / 1_000).toFixed(1)}K`;
   return String(Math.round(num));
 }
 
 export function formatMetricBytes(value: number | undefined): string {
-  const bytes = Number.isFinite(value) ? Number(value) : 0;
+  if (!Number.isFinite(value)) return "--";
+  const bytes = Number(value);
   if (bytes >= 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
   if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
   if (bytes >= 1024) return `${(bytes / 1024).toFixed(1)} KB`;
@@ -376,6 +405,7 @@ export function formatStorageBytes(value: number | undefined): string {
 }
 
 export function metricSuccessRate(overview: MetricsOverview | null): string {
+  if (!overview) return "--";
   const total = overview?.apiCalls.totalCalls || 0;
   if (total <= 0) return "0%";
   return `${(((overview?.apiCalls.successfulCalls || 0) / total) * 100).toFixed(1)}%`;
@@ -385,7 +415,8 @@ export function totalFileOperations(overview: MetricsOverview | null): number {
   return (
     (overview?.fileOperations.filesRead || 0) +
     (overview?.fileOperations.filesWritten || 0) +
-    (overview?.fileOperations.filesEdited || 0)
+    (overview?.fileOperations.filesEdited || 0) +
+    (overview?.fileOperations.filesSearched || 0)
   );
 }
 
@@ -472,6 +503,11 @@ export function tokenFlowBars(
     { label: "Output", value: overview?.tokenUsage.output || 0 },
     { label: "Cache", value: overview?.tokenUsage.cache || 0 },
   ];
+}
+
+export function metricProgressPercent(value: number, total: number, minimumVisible = 0): number {
+  if (!Number.isFinite(value) || !Number.isFinite(total) || value <= 0 || total <= 0) return 0;
+  return Math.min(100, Math.max(minimumVisible, (value / total) * 100));
 }
 
 export function tokenVelocityAreaRows(

--- a/apps/mobile/src/lib/mobileStatusStream.ts
+++ b/apps/mobile/src/lib/mobileStatusStream.ts
@@ -7,6 +7,7 @@ import type {
 type MobileWebSocketConstructor = NonNullable<MobileStatusStreamOptions["WebSocketImpl"]>;
 type MobileWebSocket = InstanceType<MobileWebSocketConstructor>;
 type MobileStatusEventNormalizer = (value: unknown) => MobileStatusStreamEvent | null;
+type MobileStatusAuthProtocolProvider = () => string | null;
 
 interface BufferedMobileStatusEvent {
   event: MobileStatusStreamEvent;
@@ -109,7 +110,8 @@ export class MobileStatusStreamClient {
 
   constructor(
     private readonly getUrl: () => string,
-    private readonly normalizeEvent: MobileStatusEventNormalizer
+    private readonly normalizeEvent: MobileStatusEventNormalizer,
+    private readonly getAuthProtocol: MobileStatusAuthProtocolProvider = () => null
   ) {}
 
   subscribe(
@@ -170,7 +172,10 @@ export class MobileStatusStreamClient {
     const generation = ++this.socketGeneration;
     let socket: MobileWebSocket;
     try {
-      socket = new this.WebSocketImpl(this.getUrl());
+      const authProtocol = this.getAuthProtocol();
+      socket = authProtocol
+        ? new this.WebSocketImpl(this.getUrl(), authProtocol)
+        : new this.WebSocketImpl(this.getUrl());
       this.socket = socket;
     } catch {
       this.notifyError();

--- a/apps/mobile/src/screens/DashboardScreen.tsx
+++ b/apps/mobile/src/screens/DashboardScreen.tsx
@@ -87,9 +87,11 @@ import {
   Network,
   Paperclip,
   Pencil,
+  Pin,
   Plus,
   Play,
   RefreshCw,
+  Search,
   Save,
   Send,
   Settings,
@@ -179,7 +181,9 @@ import {
   mobileBackRouteForDetail,
   mobileFirstNonEmptyString,
   mobileGatewayAuthStatus,
+  mobileSettingsTabForSurface,
   mobileProviderAuthMode,
+  mobileSessionIsActive,
   mergeSessionDetailIntoSummary,
   mobileSessionTitle,
   mobileThemeConfigPayload,
@@ -201,6 +205,7 @@ import {
   formatMetricBytes,
   formatStorageBytes,
   mergeMetricsOverview,
+  reconcileMetricsSnapshot,
   type MetricsSnapshot,
 } from "../lib/metrics";
 import { accentPalette, colors, spacing, type AccentKey } from "../theme/liquidGlass";
@@ -228,7 +233,6 @@ import {
   remoteItemEnabled,
   remoteTaskRunning,
   resolveAccentKey,
-  sessionMayBeInProgress,
   surfaceCount,
   type EndpointState,
   type MobileSpeechSettings,
@@ -310,8 +314,10 @@ export function DashboardScreen({
     null
   );
   const [providerPlanError, setProviderPlanError] = useState<string | null>(null);
+  const [activeSessionIds, setActiveSessionIds] = useState<string[]>([]);
   const [refreshing, setRefreshing] = useState(false);
   const [activeTab, setActiveTab] = useState<MobileTabKey>("overview");
+  const [selectedSettingsTab, setSelectedSettingsTab] = useState<MobileSettingsTab>("general");
   const [detailRoute, setDetailRoute] = useState<DetailRoute | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [metricsError, setMetricsError] = useState<string | null>(null);
@@ -328,13 +334,17 @@ export function DashboardScreen({
     hasMore: false,
   });
   const [loadingMoreLogs, setLoadingMoreLogs] = useState(false);
+  const [loadingMoreSessions, setLoadingMoreSessions] = useState(false);
+  const [sessionPageError, setSessionPageError] = useState<string | null>(null);
   const [logPageError, setLogPageError] = useState<string | null>(null);
   const refreshInFlight = useRef(false);
   const metricsRefreshInFlight = useRef(false);
   const metricsOverviewRefreshInFlight = useRef(false);
+  const metricsOverviewGenerationRef = useRef(0);
   const metricsLastLoadedAtRef = useRef(0);
   const metricsOverviewLastLoadedAtRef = useRef(0);
   const logPageInFlight = useRef(false);
+  const sessionPageInFlight = useRef(false);
   const appStateRef = useRef(AppState.currentState);
   const activeSurface =
     detailRoute?.kind === "surface" || detailRoute?.kind === "item" ? detailRoute.surface : null;
@@ -362,7 +372,7 @@ export function DashboardScreen({
     if (showRefreshing) setRefreshing(true);
     setError(null);
     try {
-      const [nextSummary, nextProviderPlans] = await Promise.all([
+      const [nextSummary, nextProviderPlans, nextActiveSessionIds] = await Promise.all([
         api.featureSummary(),
         api
           .providerPlanStatus()
@@ -371,11 +381,17 @@ export function DashboardScreen({
             data: null,
             error: providerError instanceof Error ? providerError.message : String(providerError),
           })),
+        api
+          .sessionStatus()
+          .then((status) => status.activeSessionIds)
+          .catch(() => []),
       ]);
       setSummary(nextSummary);
+      setActiveSessionIds(nextActiveSessionIds);
       if (nextProviderPlans.data) setProviderPlanStatus(nextProviderPlans.data);
       setProviderPlanError(nextProviderPlans.error);
     } catch (refreshError) {
+      setActiveSessionIds([]);
       setError(refreshError instanceof Error ? refreshError.message : String(refreshError));
     } finally {
       refreshInFlight.current = false;
@@ -395,6 +411,7 @@ export function DashboardScreen({
     metricsOverviewRefreshInFlight.current = true;
     try {
       const overview = await api.metricsOverview();
+      metricsOverviewGenerationRef.current += 1;
       setMetrics((current) => mergeMetricsOverview(current, overview));
       metricsOverviewLastLoadedAtRef.current = Date.now();
       setMetricsUpdatedAt(Date.now());
@@ -420,10 +437,19 @@ export function DashboardScreen({
       return;
     }
     metricsRefreshInFlight.current = true;
+    const overviewGenerationAtRequest = metricsOverviewGenerationRef.current;
     setMetricsRefreshing(true);
     setMetricsError(null);
     try {
-      setMetrics(await api.metricsSnapshot());
+      const snapshot = await api.metricsSnapshot();
+      setMetrics((current) =>
+        reconcileMetricsSnapshot(
+          current,
+          snapshot,
+          overviewGenerationAtRequest,
+          metricsOverviewGenerationRef.current
+        )
+      );
       metricsLastLoadedAtRef.current = Date.now();
       metricsOverviewLastLoadedAtRef.current = Date.now();
       setMetricsUpdatedAt(Date.now());
@@ -474,6 +500,38 @@ export function DashboardScreen({
     } finally {
       logPageInFlight.current = false;
       setLoadingMoreLogs(false);
+    }
+  };
+
+  const loadMoreSessions = async () => {
+    const currentSummary = summary;
+    const total = currentSummary?.sessionTotal ?? currentSummary?.sessions.length ?? 0;
+    if (sessionPageInFlight.current || !currentSummary || currentSummary.sessions.length >= total) {
+      return;
+    }
+    sessionPageInFlight.current = true;
+    setLoadingMoreSessions(true);
+    setSessionPageError(null);
+    try {
+      const page = await api.sessionList({
+        limit: 100,
+        offset: currentSummary.sessions.length,
+      });
+      setSummary((current) => {
+        if (!current) return current;
+        const sessionsById = new Map(current.sessions.map((session) => [session.id, session]));
+        for (const session of page.sessions) sessionsById.set(session.id, session);
+        return {
+          ...current,
+          sessions: sortSessionSummaries([...sessionsById.values()]),
+          sessionTotal: page.total,
+        };
+      });
+    } catch (loadError) {
+      setSessionPageError(loadError instanceof Error ? loadError.message : String(loadError));
+    } finally {
+      sessionPageInFlight.current = false;
+      setLoadingMoreSessions(false);
     }
   };
 
@@ -601,38 +659,48 @@ export function DashboardScreen({
   const openSurface = (surface: MobileSurfaceKey) => {
     setChatHeaderAction(null);
     setActiveTab("settings");
+    if (activeTab !== "settings") {
+      const settingsTab = mobileSettingsTabForSurface(surface);
+      if (settingsTab) setSelectedSettingsTab(settingsTab);
+    }
     setDetailRoute({ kind: "surface", surface });
   };
 
   const openSystemPrompt = () => {
     setChatHeaderAction(null);
     setActiveTab("settings");
+    setSelectedSettingsTab("ai");
     setDetailRoute({ kind: "systemPrompt" });
   };
 
   const openSpeech = () => {
     setChatHeaderAction(null);
     setActiveTab("settings");
+    setSelectedSettingsTab("voice");
     setDetailRoute({ kind: "speech" });
   };
   const openMemory = () => {
     setChatHeaderAction(null);
     setActiveTab("settings");
+    setSelectedSettingsTab("memory");
     setDetailRoute({ kind: "memory" });
   };
   const openMigration = () => {
     setChatHeaderAction(null);
     setActiveTab("settings");
+    setSelectedSettingsTab("migration");
     setDetailRoute({ kind: "migration" });
   };
   const openJourney = () => {
     setChatHeaderAction(null);
     setActiveTab("settings");
+    setSelectedSettingsTab("general");
     setDetailRoute({ kind: "journey" });
   };
   const openModelRouter = () => {
     setChatHeaderAction(null);
     setActiveTab("settings");
+    setSelectedSettingsTab("router");
     setDetailRoute({ kind: "modelRouter" });
   };
 
@@ -745,7 +813,6 @@ export function DashboardScreen({
           <View style={styles.headerText}>
             <Text
               ellipsizeMode="tail"
-              maxFontSizeMultiplier={1.05}
               numberOfLines={1}
               style={[styles.title, detailRoute && styles.detailTitle]}
             >
@@ -832,6 +899,7 @@ export function DashboardScreen({
           ) : activeTab === "overview" ? (
             <OverviewPanel
               accentColor={accentColor}
+              activeSessionIds={activeSessionIds}
               modules={modules}
               sessions={orderedSessions}
               logs={summary?.logs ?? []}
@@ -843,6 +911,7 @@ export function DashboardScreen({
           ) : null}
           {!detailRoute && activeTab === "sessions" ? (
             <SessionsPanel
+              activeSessionIds={activeSessionIds}
               sessions={orderedSessions}
               summary={summary}
               openSession={openSessionRoute}
@@ -851,6 +920,9 @@ export function DashboardScreen({
                 await api.deleteSession(id);
                 await refresh(false);
               }}
+              loadMoreSessions={loadMoreSessions}
+              loadingMoreSessions={loadingMoreSessions}
+              sessionPageError={sessionPageError}
               accentColor={accentColor}
             />
           ) : null}
@@ -902,6 +974,8 @@ export function DashboardScreen({
               openMemory={openMemory}
               openMigration={openMigration}
               openJourney={openJourney}
+              selectedSettingsTab={selectedSettingsTab}
+              onSelectSettingsTab={setSelectedSettingsTab}
             />
           ) : null}
         </ScrollView>
@@ -919,6 +993,8 @@ export function DashboardScreen({
             return (
               <Pressable
                 key={key}
+                accessibilityHint={`Show ${label.toLowerCase()}`}
+                accessibilityLabel={label}
                 accessibilityRole="tab"
                 accessibilityState={{ selected }}
                 onPress={() => selectTab(key)}
@@ -939,7 +1015,6 @@ export function DashboardScreen({
                   strokeWidth={2.2}
                 />
                 <Text
-                  maxFontSizeMultiplier={1.05}
                   numberOfLines={1}
                   style={[styles.tabLabel, selected && { color: accentColor }]}
                 >
@@ -956,6 +1031,7 @@ export function DashboardScreen({
 
 function OverviewPanel({
   accentColor,
+  activeSessionIds,
   modules,
   sessions,
   logs,
@@ -965,6 +1041,7 @@ function OverviewPanel({
   openSession,
 }: {
   accentColor: string;
+  activeSessionIds: readonly string[];
   modules: ModuleCard[];
   sessions: SessionSummary[];
   logs: ActivitySummary[];
@@ -976,7 +1053,7 @@ function OverviewPanel({
   const activityRows =
     sessions.length > 0
       ? sessions.slice(0, 3).map((session) => {
-          const state = recentSessionStateLabel(session);
+          const state = recentSessionStateLabel(session, activeSessionIds);
           return {
             id: session.id,
             Icon: MessageCircle,
@@ -1130,19 +1207,29 @@ function ActivityRow({
 
 function SessionsPanel({
   accentColor,
+  activeSessionIds,
   createChat,
   sessions,
   summary,
   openSession,
   deleteSession,
+  loadMoreSessions,
+  loadingMoreSessions,
+  sessionPageError,
 }: {
   accentColor: string;
+  activeSessionIds: readonly string[];
   createChat: () => void;
   sessions: SessionSummary[];
   summary: FeatureSummary | null;
   openSession: (id: string) => void;
   deleteSession: (id: string) => Promise<void>;
+  loadMoreSessions: () => Promise<void>;
+  loadingMoreSessions: boolean;
+  sessionPageError: string | null;
 }) {
+  const [query, setQuery] = useState("");
+  const [visibleCount, setVisibleCount] = useState(20);
   const runDelete = async (session: SessionSummary) => {
     try {
       haptics.warning();
@@ -1182,9 +1269,20 @@ function SessionsPanel({
   const latest = latestSessionSummary(sessions);
   const endpoint = summary?.availability.sessions;
   const totalChats = summary?.sessionTotal ?? sessions.length;
-  const visibleSessionCount = Math.min(sessions.length, 20);
-  const pageDetail =
-    totalChats > visibleSessionCount ? `showing ${visibleSessionCount} recent` : "total";
+  const normalizedQuery = query.trim().toLowerCase();
+  const filteredSessions = normalizedQuery
+    ? sessions.filter((session) =>
+        [
+          mobileSessionTitle(session),
+          sessionProviderModelLabel(session),
+          session.last_message?.content ?? "",
+        ].some((value) => value.toLowerCase().includes(normalizedQuery))
+      )
+    : sessions;
+  const visibleSessionCount = Math.min(filteredSessions.length, visibleCount);
+  const hasMoreLoadedSessions = visibleSessionCount < filteredSessions.length;
+  const hasMoreRemoteSessions = sessions.length < totalChats;
+  const pageDetail = totalChats > visibleSessionCount ? `showing ${visibleSessionCount}` : "total";
 
   return (
     <StableDetailPanel>
@@ -1205,7 +1303,7 @@ function SessionsPanel({
         />
       </View>
       <View style={styles.subsectionHeader}>
-        <Text style={styles.subsectionTitle}>Recent chats</Text>
+        <Text style={styles.subsectionTitle}>Pinned & recent</Text>
         <Pressable
           accessibilityRole="button"
           style={({ pressed }) => [
@@ -1224,7 +1322,36 @@ function SessionsPanel({
           <Text style={[styles.newChatButtonText, { color: accentColor }]}>New Chat</Text>
         </Pressable>
       </View>
-      {sessions.slice(0, visibleSessionCount).map((session) => (
+      <View style={styles.sessionSearchField}>
+        <Search color={colors.textMuted} size={18} strokeWidth={2.1} />
+        <TextInput
+          accessibilityLabel="Search chats"
+          autoCapitalize="none"
+          autoCorrect={false}
+          placeholder="Search loaded chats"
+          placeholderTextColor={colors.textDim}
+          style={styles.sessionSearchInput}
+          value={query}
+          onChangeText={(value) => {
+            setQuery(value);
+            setVisibleCount(20);
+          }}
+        />
+        {query ? (
+          <Pressable
+            accessibilityLabel="Clear chat search"
+            accessibilityRole="button"
+            hitSlop={10}
+            onPress={() => {
+              setQuery("");
+              setVisibleCount(20);
+            }}
+          >
+            <X color={colors.textMuted} size={18} strokeWidth={2.2} />
+          </Pressable>
+        ) : null}
+      </View>
+      {filteredSessions.slice(0, visibleSessionCount).map((session) => (
         <Pressable
           key={session.id}
           style={styles.listRow}
@@ -1233,7 +1360,7 @@ function SessionsPanel({
           accessibilityHint="Long press to delete"
         >
           <View style={styles.listIcon}>
-            {sessionMayBeInProgress(session) ? (
+            {mobileSessionIsActive(session, activeSessionIds) ? (
               <ActivityIndicator color={accentColor} size="small" />
             ) : (
               <MessageCircle color={accentColor} size={20} strokeWidth={2.1} />
@@ -1243,7 +1370,7 @@ function SessionsPanel({
             <View style={styles.sessionTitleRow}>
               {session.pinned ? (
                 <View style={styles.sessionPinnedDot}>
-                  <ShieldCheck color={colors.amber} size={12} strokeWidth={2.4} />
+                  <Pin color={colors.amber} size={12} strokeWidth={2.4} />
                 </View>
               ) : null}
               <Text numberOfLines={2} style={[styles.listTitle, styles.sessionListTitle]}>
@@ -1264,6 +1391,29 @@ function SessionsPanel({
           <ChevronRight color={colors.textMuted} size={20} strokeWidth={2} />
         </Pressable>
       ))}
+      {hasMoreLoadedSessions || hasMoreRemoteSessions ? (
+        <Pressable
+          accessibilityRole="button"
+          disabled={loadingMoreSessions}
+          style={[styles.loadMoreButton, loadingMoreSessions && styles.loadMoreButtonDisabled]}
+          onPress={() => {
+            if (hasMoreLoadedSessions) {
+              setVisibleCount((current) => current + 20);
+              return;
+            }
+            void loadMoreSessions();
+          }}
+        >
+          {loadingMoreSessions ? <ActivityIndicator color={accentColor} size="small" /> : null}
+          <Text style={styles.loadMoreButtonText}>
+            {hasMoreLoadedSessions ? "Show more chats" : "Load older chats"}
+          </Text>
+        </Pressable>
+      ) : null}
+      {sessionPageError ? <Text style={styles.errorText}>{sessionPageError}</Text> : null}
+      {normalizedQuery && filteredSessions.length === 0 ? (
+        <EmptyState label="No matching chats" detail="Try another title, model, or message." />
+      ) : null}
       {sessions.length === 0 ? (
         !summary ? (
           <LoadingState label="Loading chats" detail="Fetching sessions from the gateway." />

--- a/apps/mobile/src/screens/dashboardAdvancedSettingsPanels.tsx
+++ b/apps/mobile/src/screens/dashboardAdvancedSettingsPanels.tsx
@@ -30,14 +30,12 @@ import {
   readMobileLlmTimeoutSettings,
   readMobileMemoryBehaviorSettings,
   readMobileMemoryProviderSettings,
-  readMobileTokenOptimizationSettings,
   MOBILE_MEMORY_PROVIDER_CHOICES,
   type MobileIndexingSettings,
   type MobileLlmTimeoutSettings,
   type MobileMemoryBehaviorSettings,
   type MobileMemoryProviderChoice,
   type MobileMemoryProviderSettings,
-  type MobileTokenOptimizationSettings,
 } from "./dashboardHelpers";
 import {
   CybaraMobileApi,
@@ -460,13 +458,10 @@ export function MemorySettingsPanel({
   const memorySettings = readMobileMemoryBehaviorSettings(summary?.config);
   const providerSettings = readMobileMemoryProviderSettings(summary?.config);
   const indexingSettings = readMobileIndexingSettings(summary?.config);
-  const tokenOptimizationSettings = readMobileTokenOptimizationSettings(summary?.config);
   const [memoryDraft, setMemoryDraft] = useState(memorySettings);
   const [timeoutsDraft, setTimeoutsDraft] = useState(() =>
     readMobileLlmTimeoutSettings(summary?.config)
   );
-  const [tokenOptimizationDraft, setTokenOptimizationDraft] =
-    useState<MobileTokenOptimizationSettings>(tokenOptimizationSettings);
   const [providerDraft, setProviderDraft] = useState(providerSettings);
   const [indexingDraft, setIndexingDraft] = useState(indexingSettings);
   const [saving, setSaving] = useState(false);
@@ -477,7 +472,6 @@ export function MemorySettingsPanel({
     setMemoryDraft(memorySettings);
     setProviderDraft(providerSettings);
     setIndexingDraft(indexingSettings);
-    setTokenOptimizationDraft(tokenOptimizationSettings);
     setTimeoutsDraft(readMobileLlmTimeoutSettings(summary?.config));
   }, [configSignature, configAvailable]);
 
@@ -505,12 +499,6 @@ export function MemorySettingsPanel({
     const next = { ...timeoutsDraft, ...patch };
     setTimeoutsDraft(next);
     void persist({ llm_timeouts: next }, "Watchdog setting failed");
-  };
-
-  const saveTokenOptimization = (patch: Partial<MobileTokenOptimizationSettings>) => {
-    const next = { ...tokenOptimizationDraft, ...patch };
-    setTokenOptimizationDraft(next);
-    void persist({ token_optimization: next }, "Token optimization setting failed");
   };
 
   const saveProvider = (patch: Partial<MobileMemoryProviderSettings>) => {
@@ -666,47 +654,6 @@ export function MemorySettingsPanel({
           placeholder="1800"
           value={String(timeoutsDraft.nonStreamingSeconds || "")}
         />
-      </SettingsSection>
-      <SettingsSection title="Token optimization">
-        <SettingToggle
-          busy={saving}
-          detail="Use TOON for structured tool outputs when it is smaller than compact JSON."
-          label="Compact structured results"
-          onPress={() =>
-            saveTokenOptimization({
-              toonStructuredDataEnabled: !tokenOptimizationDraft.toonStructuredDataEnabled,
-            })
-          }
-          tone={accentColor}
-          value={tokenOptimizationDraft.toonStructuredDataEnabled}
-        />
-      </SettingsSection>
-      <SettingsSection title="Self-improvement">
-        <SettingSelector
-          disabled={saving}
-          label="Background model"
-          onSelect={(value) =>
-            void persist({ background_agent_id: value }, "Background model failed")
-          }
-          options={[
-            { label: "Same agent as the turn (default)", value: "" },
-            ...(summary?.agents ?? []).map((agent) => ({
-              label: agent.model ? `${agent.name} — ${agent.model}` : agent.name,
-              value: agent.id,
-            })),
-          ]}
-          selected={
-            typeof summary?.config?.background_agent_id === "string"
-              ? summary.config.background_agent_id
-              : ""
-          }
-          tone={accentColor}
-          variant="menu"
-        />
-        <Text style={styles.settingsFieldHelp}>
-          Memory and skill review run silently after most turns. Point them at a cheaper agent to
-          cut cost over time.
-        </Text>
       </SettingsSection>
       <SettingsSection title="Memory provider">
         <SettingSelector

--- a/apps/mobile/src/screens/dashboardChat.tsx
+++ b/apps/mobile/src/screens/dashboardChat.tsx
@@ -784,9 +784,6 @@ export function WorkActivityIcon({
   if (statusState) {
     return <MobileThinkingOrb reduceMotion={reduceMotion} state={statusState} />;
   }
-  if (toolName === "__thought") {
-    return <View style={styles.messageActivityDot} />;
-  }
   if (toolName === "sessions_transfer" || toolName === "__steering") {
     return <ArrowRightLeft color={colors.textMuted} size={13} strokeWidth={2.2} />;
   }
@@ -802,6 +799,32 @@ export function WorkActivityIcon({
   return <CheckCircle2 color={colors.textMuted} size={13} strokeWidth={2.2} />;
 }
 
+function MobileThoughtText({
+  activity,
+  appearance,
+}: {
+  activity: MobileWorkActivity;
+  appearance: ChatAppearanceSettings;
+}) {
+  const fontSize = getChatFontSizePixels(appearance.fontSize);
+  return (
+    <Text
+      numberOfLines={0}
+      selectable
+      style={[
+        styles.messageThoughtText,
+        {
+          color: appearance.highContrast ? colors.text : colors.textMuted,
+          fontSize,
+          lineHeight: Math.round(fontSize * getChatLineHeight(appearance.lineSpacing)),
+        },
+      ]}
+    >
+      <InlineMarkdown appearance={appearance} tokens={parseInlineMarkdown(activity.text)} />
+    </Text>
+  );
+}
+
 function MobileActivityRow({
   activity,
   appearance,
@@ -809,11 +832,13 @@ function MobileActivityRow({
   activity: MobileWorkActivity;
   appearance: ChatAppearanceSettings;
 }) {
+  if (activity.toolName === "__thought") {
+    return <MobileThoughtText activity={activity} appearance={appearance} />;
+  }
   const fontSize = Math.max(11, getChatFontSizePixels(appearance.fontSize) * 0.84);
   const statusState = mobileLiveStatusIndicatorState(activity.text);
   const textStyle = [
     styles.messageActivityText,
-    activity.toolName === "__thought" && styles.messageThoughtText,
     {
       color: appearance.highContrast ? colors.text : colors.textMuted,
       fontSize,
@@ -835,11 +860,7 @@ function MobileActivityRow({
           {activity.text}
         </MobileLiveStatusText>
       ) : (
-        <Text
-          numberOfLines={activity.toolName === "__thought" ? 0 : 2}
-          selectable
-          style={textStyle}
-        >
+        <Text numberOfLines={2} selectable style={textStyle}>
           <InlineMarkdown appearance={appearance} tokens={parseInlineMarkdown(activity.text)} />
         </Text>
       )}

--- a/apps/mobile/src/screens/dashboardChat.tsx
+++ b/apps/mobile/src/screens/dashboardChat.tsx
@@ -44,6 +44,7 @@ import {
   extractMobileMarkdownImages,
   groupMobileActivities,
   hasUnicodeTextFallback,
+  mobileCodeLineCount,
   type MarkdownInline,
   type MobileActivityGroupKind,
   type MobileWorkActivity,
@@ -76,7 +77,10 @@ interface MobileFileChangeItem {
   removed: number;
 }
 
-function mobileFilePathDisplay(path: string): { fileName: string; parentPath: string | null } {
+function mobileFilePathDisplay(path: string): {
+  fileName: string;
+  parentPath: string | null;
+} {
   const normalized = path.trim().replace(/\\/g, "/").replace(/\/+/g, "/");
   const segments = normalized.split("/").filter(Boolean);
   const fileName = segments.pop() || normalized || "file";
@@ -111,9 +115,11 @@ function mobileActivityFileChange(text: string, phase: string): MobileFileChange
   };
 }
 
-function collectMobileFileChanges(
-  message: SessionDetailSummary["messages"][number]
-): { files: MobileFileChangeItem[]; totalAdded: number; totalRemoved: number } | null {
+function collectMobileFileChanges(message: SessionDetailSummary["messages"][number]): {
+  files: MobileFileChangeItem[];
+  totalAdded: number;
+  totalRemoved: number;
+} | null {
   const byPath = new Map<string, MobileFileChangeItem>();
   for (const activity of message.processActivities || []) {
     const parsed = mobileActivityFileChange(activity.text || "", activity.phase || "result");
@@ -203,7 +209,9 @@ function InlineMarkdown({
                 selectable={selectable}
                 style={[
                   styles.mdInlineCode,
-                  { fontSize: getChatCodeFontSizePixels(appearance.codeFontSize) },
+                  {
+                    fontSize: getChatCodeFontSizePixels(appearance.codeFontSize),
+                  },
                 ]}
               >
                 {token.text}
@@ -216,7 +224,9 @@ function InlineMarkdown({
                 selectable={selectable}
                 style={[
                   styles.mdLink,
-                  { textDecorationLine: appearance.underlineLinks ? "underline" : "none" },
+                  {
+                    textDecorationLine: appearance.underlineLinks ? "underline" : "none",
+                  },
                 ]}
                 onPress={() => {
                   void openAllowedExternalUrl(token.href).catch(() => {});
@@ -259,7 +269,9 @@ function MarkdownText({
                 selectable
                 style={[
                   block.level === 1 ? styles.mdH1 : block.level === 2 ? styles.mdH2 : styles.mdH3,
-                  { fontSize: fontSize + (block.level === 1 ? 8 : block.level === 2 ? 5 : 2) },
+                  {
+                    fontSize: fontSize + (block.level === 1 ? 8 : block.level === 2 ? 5 : 2),
+                  },
                 ]}
               >
                 <InlineMarkdown appearance={appearance} tokens={block.inline} />
@@ -268,9 +280,21 @@ function MarkdownText({
           case "listItem":
             return (
               <View key={index} style={styles.mdListRow}>
-                <Text selectable style={[styles.mdListMarker, bodyStyle]}>
-                  {block.marker}
-                </Text>
+                {block.checked === undefined ? (
+                  <Text selectable style={[styles.mdListMarker, bodyStyle]}>
+                    {block.marker}
+                  </Text>
+                ) : (
+                  <View
+                    accessibilityRole="checkbox"
+                    accessibilityState={{ checked: block.checked }}
+                    style={[styles.mdTaskCheckbox, block.checked && styles.mdTaskCheckboxChecked]}
+                  >
+                    {block.checked ? (
+                      <Check color={colors.background} size={11} strokeWidth={3} />
+                    ) : null}
+                  </View>
+                )}
                 <Text selectable style={[styles.mdListText, bodyStyle]}>
                   <InlineMarkdown appearance={appearance} tokens={block.inline} />
                 </Text>
@@ -493,7 +517,11 @@ function MobilePlanStatusIcon({
 function MobileFileChangesCard({
   summary,
 }: {
-  summary: { files: MobileFileChangeItem[]; totalAdded: number; totalRemoved: number };
+  summary: {
+    files: MobileFileChangeItem[];
+    totalAdded: number;
+    totalRemoved: number;
+  };
 }) {
   return (
     <View style={styles.mobileFileChangesCard}>
@@ -944,33 +972,79 @@ export function MessageContent({
 }) {
   return (
     <View style={styles.messageContent}>
-      {splitMessageContent(content).map((part, index) =>
+      {splitMessageContent(content).map((part) =>
         part.type === "code" ? (
-          <View key={`code-${index}`} style={styles.codeBlock}>
-            <Text selectable style={styles.codeHeader}>
-              {part.language}
-            </Text>
-            <ScrollView horizontal showsHorizontalScrollIndicator>
-              <UnicodeText
-                content={part.content}
-                style={[
-                  styles.codeText,
-                  !hasUnicodeTextFallback(part.content) && styles.codeTextMonospace,
-                  {
-                    fontSize: getChatCodeFontSizePixels(appearance.codeFontSize),
-                    lineHeight: Math.round(
-                      getChatCodeFontSizePixels(appearance.codeFontSize) *
-                        getChatLineHeight(appearance.lineSpacing)
-                    ),
-                  },
-                ]}
-              />
-            </ScrollView>
-          </View>
+          <MobileCodeBlock
+            key={part.key}
+            appearance={appearance}
+            content={part.content}
+            language={part.language}
+          />
         ) : part.content.trim().length > 0 ? (
-          <MarkdownText key={`text-${index}`} appearance={appearance} content={part.content} />
+          <MarkdownText key={part.key} appearance={appearance} content={part.content} />
         ) : null
       )}
+    </View>
+  );
+}
+
+function MobileCodeBlock({
+  appearance,
+  content,
+  language,
+}: {
+  appearance: ChatAppearanceSettings;
+  content: string;
+  language: string;
+}) {
+  const [copied, setCopied] = useState(false);
+  const lineCount = mobileCodeLineCount(content);
+  return (
+    <View style={styles.codeBlock}>
+      <View style={styles.codeHeader}>
+        <Text selectable style={styles.codeLanguage}>
+          {language}
+        </Text>
+        <Text style={styles.codeLineCount}>
+          {lineCount} {lineCount === 1 ? "line" : "lines"}
+        </Text>
+        <Pressable
+          accessibilityLabel={copied ? "Code copied" : "Copy code"}
+          accessibilityRole="button"
+          hitSlop={8}
+          onPress={() => {
+            void Clipboard.setStringAsync(content)
+              .then(() => {
+                setCopied(true);
+                setTimeout(() => setCopied(false), 1500);
+              })
+              .catch(() => {});
+          }}
+          style={styles.codeCopyButton}
+        >
+          {copied ? (
+            <Check color={colors.green} size={13} strokeWidth={2.2} />
+          ) : (
+            <Copy color={colors.textMuted} size={13} strokeWidth={2.2} />
+          )}
+        </Pressable>
+      </View>
+      <ScrollView horizontal showsHorizontalScrollIndicator style={styles.codeScroll}>
+        <UnicodeText
+          content={content}
+          style={[
+            styles.codeText,
+            !hasUnicodeTextFallback(content) && styles.codeTextMonospace,
+            {
+              fontSize: getChatCodeFontSizePixels(appearance.codeFontSize),
+              lineHeight: Math.round(
+                getChatCodeFontSizePixels(appearance.codeFontSize) *
+                  getChatLineHeight(appearance.lineSpacing)
+              ),
+            },
+          ]}
+        />
+      </ScrollView>
     </View>
   );
 }

--- a/apps/mobile/src/screens/dashboardChatStyles.ts
+++ b/apps/mobile/src/screens/dashboardChatStyles.ts
@@ -203,13 +203,35 @@ export function createDashboardChatStyles() {
       overflow: "hidden",
     },
     codeHeader: {
+      alignItems: "center",
       backgroundColor: colors.surfaceLift,
+      borderBottomColor: colors.border,
+      borderBottomWidth: StyleSheet.hairlineWidth,
+      flexDirection: "row",
+      gap: spacing.xs,
+      minHeight: 30,
+      paddingHorizontal: spacing.sm,
+    },
+    codeLanguage: {
       color: colors.textMuted,
       fontSize: typography.tiny,
       fontWeight: "900",
-      paddingHorizontal: spacing.sm,
-      paddingVertical: 5,
       textTransform: "uppercase",
+    },
+    codeLineCount: {
+      color: colors.textDim,
+      flex: 1,
+      fontSize: 10,
+    },
+    codeCopyButton: {
+      alignItems: "center",
+      height: 28,
+      justifyContent: "center",
+      width: 28,
+    },
+    codeScroll: {
+      flexGrow: 0,
+      flexShrink: 1,
     },
     codeText: {
       color: colors.text,
@@ -218,7 +240,11 @@ export function createDashboardChatStyles() {
       padding: spacing.sm,
     },
     codeTextMonospace: {
-      fontFamily: Platform.select({ ios: "Menlo", android: "monospace", default: "monospace" }),
+      fontFamily: Platform.select({
+        ios: "Menlo",
+        android: "monospace",
+        default: "monospace",
+      }),
     },
     mdBlocks: {
       gap: spacing.sm,
@@ -264,7 +290,11 @@ export function createDashboardChatStyles() {
     mdInlineCode: {
       backgroundColor: colors.scrim,
       color: colors.text,
-      fontFamily: Platform.select({ ios: "Menlo", android: "monospace", default: "monospace" }),
+      fontFamily: Platform.select({
+        ios: "Menlo",
+        android: "monospace",
+        default: "monospace",
+      }),
       fontSize: 13,
     },
     mdListRow: {
@@ -278,6 +308,20 @@ export function createDashboardChatStyles() {
       fontSize: typography.body,
       lineHeight: 22,
       minWidth: 18,
+    },
+    mdTaskCheckbox: {
+      alignItems: "center",
+      borderColor: colors.textMuted,
+      borderRadius: 4,
+      borderWidth: 1,
+      height: 16,
+      justifyContent: "center",
+      marginTop: 3,
+      width: 16,
+    },
+    mdTaskCheckboxChecked: {
+      backgroundColor: colors.cyan,
+      borderColor: colors.cyan,
     },
     mdListText: {
       color: colors.text,

--- a/apps/mobile/src/screens/dashboardChatStyles.ts
+++ b/apps/mobile/src/screens/dashboardChatStyles.ts
@@ -410,13 +410,6 @@ export function createDashboardChatStyles() {
       marginTop: 1,
       width: 16,
     },
-    messageActivityDot: {
-      backgroundColor: colors.textMuted,
-      borderRadius: 3,
-      height: 6,
-      opacity: 0.75,
-      width: 6,
-    },
     messageAuthorRow: {
       alignItems: "flex-start",
       flexDirection: "row",
@@ -434,7 +427,10 @@ export function createDashboardChatStyles() {
       lineHeight: 18,
     },
     messageThoughtText: {
+      alignSelf: "stretch",
       color: colors.textMuted,
+      paddingHorizontal: 2,
+      paddingVertical: 2,
     },
     messageActivityGroupLabel: {
       color: colors.textMuted,

--- a/apps/mobile/src/screens/dashboardDetailPanels.tsx
+++ b/apps/mobile/src/screens/dashboardDetailPanels.tsx
@@ -607,6 +607,8 @@ export function SettingsPanel({
   openMemory,
   openMigration,
   openJourney,
+  selectedSettingsTab,
+  onSelectSettingsTab,
 }: {
   accentColor: string;
   accentKey: AccentKey;
@@ -625,11 +627,12 @@ export function SettingsPanel({
   openMemory: () => void;
   openMigration: () => void;
   openJourney: () => void;
+  selectedSettingsTab: MobileSettingsTab;
+  onSelectSettingsTab: (tab: MobileSettingsTab) => void;
 }) {
   const counts = summarizeFeatureCounts(summary);
   const { mode: appearanceMode, setMode: setAppearanceMode } = useThemeControls();
   const { enabled: hapticsEnabled, setEnabled: setHapticsEnabled } = useHapticsControls();
-  const [selectedSettingsTab, setSelectedSettingsTab] = useState<MobileSettingsTab>("general");
   const [savingAccent, setSavingAccent] = useState<AccentKey | null>(null);
   const [savingConfigKey, setSavingConfigKey] = useState<string | null>(null);
   const [savingAgentAccess, setSavingAgentAccess] = useState(false);
@@ -764,7 +767,7 @@ export function SettingsPanel({
         <SettingsTabRail
           onSelect={(value) => {
             if (MOBILE_SETTINGS_TABS.some((option) => option.value === value)) {
-              setSelectedSettingsTab(value as MobileSettingsTab);
+              onSelectSettingsTab(value as MobileSettingsTab);
             }
           }}
           options={MOBILE_SETTINGS_TABS}

--- a/apps/mobile/src/screens/dashboardDetailPanels.tsx
+++ b/apps/mobile/src/screens/dashboardDetailPanels.tsx
@@ -668,6 +668,22 @@ export function SettingsPanel({
   const selfImprovingSkillsEnabled = summary?.config.self_improving_skills_enabled !== false;
   const skillLearningNudgeEnabled = summary?.config.skill_learning_nudge_enabled === true;
   const tokenOptimization = readMobileTokenOptimizationSettings(summary?.config);
+  const agentOptions = (summary?.agents ?? []).map((agent) => ({
+    label: agent.model ? `${agent.name} — ${agent.model}` : agent.name,
+    value: agent.id,
+  }));
+  const imageAgentOptions = (summary?.agents ?? []).reduce<typeof agentOptions>(
+    (options, agent) => {
+      if (agent.supports_images) {
+        options.push({
+          label: agent.model ? `${agent.name} — ${agent.model}` : agent.name,
+          value: agent.id,
+        });
+      }
+      return options;
+    },
+    []
+  );
   const toolApprovalMode = readMobileToolApprovalMode(summary?.config);
   const followUpBehaviorEnabled = readMobileFollowUpBehaviorEnabled(summary?.config);
   const reasoningEffort = readMobileReasoningEffort(summary?.config);
@@ -1316,10 +1332,7 @@ export function SettingsPanel({
                     }}
                     options={[
                       { label: "First available agent (default)", value: "" },
-                      ...(summary?.agents ?? []).map((agent) => ({
-                        label: agent.model ? `${agent.name} — ${agent.model}` : agent.name,
-                        value: agent.id,
-                      })),
+                      ...agentOptions,
                     ]}
                     selected={
                       typeof summary?.config?.default_agent_id === "string"
@@ -1341,10 +1354,7 @@ export function SettingsPanel({
                     }}
                     options={[
                       { label: "First running agent (default)", value: "" },
-                      ...(summary?.agents ?? []).map((agent) => ({
-                        label: agent.model ? `${agent.name} — ${agent.model}` : agent.name,
-                        value: agent.id,
-                      })),
+                      ...agentOptions,
                     ]}
                     selected={
                       typeof summary?.config?.subagent_agent_id === "string"
@@ -1369,10 +1379,7 @@ export function SettingsPanel({
                     }}
                     options={[
                       { label: "Same agent as the turn (default)", value: "" },
-                      ...(summary?.agents ?? []).map((agent) => ({
-                        label: agent.model ? `${agent.name} — ${agent.model}` : agent.name,
-                        value: agent.id,
-                      })),
+                      ...agentOptions,
                     ]}
                     selected={
                       typeof summary?.config?.background_agent_id === "string"
@@ -1395,15 +1402,7 @@ export function SettingsPanel({
                         "Image fallback setting failed"
                       );
                     }}
-                    options={[
-                      { label: "None", value: "" },
-                      ...(summary?.agents ?? [])
-                        .filter((agent) => agent.supports_images)
-                        .map((agent) => ({
-                          label: agent.model ? `${agent.name} — ${agent.model}` : agent.name,
-                          value: agent.id,
-                        })),
-                    ]}
+                    options={[{ label: "None", value: "" }, ...imageAgentOptions]}
                     selected={
                       typeof summary?.config?.vision_fallback_agent_id === "string"
                         ? summary.config.vision_fallback_agent_id

--- a/apps/mobile/src/screens/dashboardDetailPanels.tsx
+++ b/apps/mobile/src/screens/dashboardDetailPanels.tsx
@@ -84,6 +84,7 @@ import {
   mobileSpeechProviderOptions,
   objectRecord,
   readMobileSpeechSettings,
+  readMobileTokenOptimizationSettings,
 } from "./dashboardHelpers";
 import { JourneyPanel } from "./dashboardJourneyPanel";
 import { MobileMcpSettingsPanel } from "./dashboardMcpPanel";
@@ -665,6 +666,8 @@ export function SettingsPanel({
   const terminalEnabled = summary?.config.terminal_enabled === true;
   const acpEnabled = summary?.config.acp_enabled !== false;
   const selfImprovingSkillsEnabled = summary?.config.self_improving_skills_enabled !== false;
+  const skillLearningNudgeEnabled = summary?.config.skill_learning_nudge_enabled === true;
+  const tokenOptimization = readMobileTokenOptimizationSettings(summary?.config);
   const toolApprovalMode = readMobileToolApprovalMode(summary?.config);
   const followUpBehaviorEnabled = readMobileFollowUpBehaviorEnabled(summary?.config);
   const reasoningEffort = readMobileReasoningEffort(summary?.config);
@@ -1297,160 +1300,257 @@ export function SettingsPanel({
         {showPluginsSettings ? <MobilePluginsPanel accentColor={accentColor} api={api} /> : null}
         {showEvalsSettings ? <MobileEvalsPanel accentColor={accentColor} api={api} /> : null}
         {showAiSettings ? (
-          <SettingsSection title="AI">
-            {configAvailable ? (
-              <SettingSelector
-                disabled={savingConfigKey !== null}
-                label="Default agent"
-                onSelect={(value) => {
-                  void saveConfigPatch(
-                    "default_agent_id",
-                    { default_agent_id: value },
-                    "Default agent setting failed"
-                  );
-                }}
-                options={[
-                  { label: "First available agent (default)", value: "" },
-                  ...(summary?.agents ?? []).map((agent) => ({
-                    label: agent.model ? `${agent.name} — ${agent.model}` : agent.name,
-                    value: agent.id,
-                  })),
-                ]}
-                selected={
-                  typeof summary?.config?.default_agent_id === "string"
-                    ? summary.config.default_agent_id
-                    : ""
-                }
-                tone={accentColor}
-                variant="menu"
-              />
-            ) : null}
-            {configAvailable && MOBILE_SETTINGS_ROOT_CHROME.reasoningEffortSelector ? (
-              <SettingSelector
-                disabled={savingConfigKey !== null}
-                label="Reasoning effort"
-                onSelect={(value) => {
-                  void saveConfigPatch(
-                    "reasoning_effort",
-                    { reasoning_effort: value },
-                    "Reasoning effort setting failed"
-                  );
-                }}
-                options={MOBILE_REASONING_EFFORT_OPTIONS.map((option) => ({
-                  label: option.label,
-                  value: option.value,
-                }))}
-                selected={reasoningEffort}
-                tone={accentColor}
-                variant="menu"
-              />
-            ) : null}
-            {configAvailable ? (
-              <SettingToggle
-                busy={savingConfigKey === "follow_up_behavior_enabled"}
-                detail="Allow messages sent during an active response to queue or steer the current run."
-                disabled={savingConfigKey !== null}
-                label="Queue / Steer follow-ups"
-                onPress={() => {
-                  void saveConfigPatch(
-                    "follow_up_behavior_enabled",
-                    { follow_up_behavior_enabled: !followUpBehaviorEnabled },
-                    "Follow-up behavior setting failed"
-                  );
-                }}
-                tone={accentColor}
-                value={followUpBehaviorEnabled}
-              />
-            ) : null}
-            {configAvailable ? (
-              <SettingToggle
-                busy={savingConfigKey === "self_improving_skills_enabled"}
-                detail="Let agents save reusable skills after complex tasks."
-                disabled={savingConfigKey !== null}
-                label="Self-improving skills"
-                onPress={() => {
-                  void saveConfigPatch(
-                    "self_improving_skills_enabled",
-                    { self_improving_skills_enabled: !selfImprovingSkillsEnabled },
-                    "Self-improving skills setting failed"
-                  );
-                }}
-                tone={accentColor}
-                value={selfImprovingSkillsEnabled}
-              />
-            ) : null}
-            {configAvailable ? (
-              <SettingSelector
-                disabled={savingConfigKey !== null}
-                label="Image fallback agent"
-                onSelect={(value) => {
-                  void saveConfigPatch(
-                    "vision_fallback_agent_id",
-                    { vision_fallback_agent_id: value },
-                    "Image fallback setting failed"
-                  );
-                }}
-                options={[
-                  { label: "None", value: "" },
-                  ...(summary?.agents ?? [])
-                    .filter((agent) => agent.supports_images)
-                    .map((agent) => ({
-                      label: agent.model ? `${agent.name} — ${agent.model}` : agent.name,
-                      value: agent.id,
-                    })),
-                ]}
-                selected={
-                  typeof summary?.config?.vision_fallback_agent_id === "string"
-                    ? summary.config.vision_fallback_agent_id
-                    : ""
-                }
-                tone={accentColor}
-                variant="menu"
-              />
-            ) : null}
-            <Pressable
-              accessibilityRole="button"
-              style={styles.settingsNavigationRow}
-              onPress={openSystemPrompt}
-            >
-              <View
-                style={[styles.settingsNavigationIcon, { backgroundColor: `${accentColor}18` }]}
-              >
-                <Sparkles color={accentColor} size={20} strokeWidth={2.1} />
-              </View>
-              <View style={styles.listText}>
-                <Text style={styles.listTitle}>System Prompt</Text>
-                <Text style={styles.listDetail} numberOfLines={1}>
-                  {systemPromptAvailable
-                    ? summary?.systemPrompt?.identity?.name
-                      ? `Identity: ${summary.systemPrompt.identity.name}`
-                      : "Identity, instructions, and behavior"
-                    : endpointStatusLabel(summary?.availability.systemPrompt)}
-                </Text>
-              </View>
-              <ChevronRight color={colors.textMuted} size={20} strokeWidth={2} />
-            </Pressable>
-            {MOBILE_SETTINGS_ROOT_CHROME.modelRouterControls ? (
+          <>
+            <SettingsSection title="Agent defaults">
+              {configAvailable ? (
+                <>
+                  <SettingSelector
+                    disabled={savingConfigKey !== null}
+                    label="Default agent"
+                    onSelect={(value) => {
+                      void saveConfigPatch(
+                        "default_agent_id",
+                        { default_agent_id: value },
+                        "Default agent setting failed"
+                      );
+                    }}
+                    options={[
+                      { label: "First available agent (default)", value: "" },
+                      ...(summary?.agents ?? []).map((agent) => ({
+                        label: agent.model ? `${agent.name} — ${agent.model}` : agent.name,
+                        value: agent.id,
+                      })),
+                    ]}
+                    selected={
+                      typeof summary?.config?.default_agent_id === "string"
+                        ? summary.config.default_agent_id
+                        : ""
+                    }
+                    tone={accentColor}
+                    variant="menu"
+                  />
+                  <SettingSelector
+                    disabled={savingConfigKey !== null}
+                    label="Sub-agent"
+                    onSelect={(value) => {
+                      void saveConfigPatch(
+                        "subagent_agent_id",
+                        { subagent_agent_id: value },
+                        "Sub-agent setting failed"
+                      );
+                    }}
+                    options={[
+                      { label: "First running agent (default)", value: "" },
+                      ...(summary?.agents ?? []).map((agent) => ({
+                        label: agent.model ? `${agent.name} — ${agent.model}` : agent.name,
+                        value: agent.id,
+                      })),
+                    ]}
+                    selected={
+                      typeof summary?.config?.subagent_agent_id === "string"
+                        ? summary.config.subagent_agent_id
+                        : ""
+                    }
+                    tone={accentColor}
+                    variant="menu"
+                  />
+                  <Text style={styles.settingsFieldHelp}>
+                    Used for delegated tasks when a spawn does not name an agent.
+                  </Text>
+                  <SettingSelector
+                    disabled={savingConfigKey !== null}
+                    label="Background model"
+                    onSelect={(value) => {
+                      void saveConfigPatch(
+                        "background_agent_id",
+                        { background_agent_id: value },
+                        "Background model setting failed"
+                      );
+                    }}
+                    options={[
+                      { label: "Same agent as the turn (default)", value: "" },
+                      ...(summary?.agents ?? []).map((agent) => ({
+                        label: agent.model ? `${agent.name} — ${agent.model}` : agent.name,
+                        value: agent.id,
+                      })),
+                    ]}
+                    selected={
+                      typeof summary?.config?.background_agent_id === "string"
+                        ? summary.config.background_agent_id
+                        : ""
+                    }
+                    tone={accentColor}
+                    variant="menu"
+                  />
+                  <Text style={styles.settingsFieldHelp}>
+                    Handles background memory and skill review after turns.
+                  </Text>
+                  <SettingSelector
+                    disabled={savingConfigKey !== null}
+                    label="Image fallback agent"
+                    onSelect={(value) => {
+                      void saveConfigPatch(
+                        "vision_fallback_agent_id",
+                        { vision_fallback_agent_id: value },
+                        "Image fallback setting failed"
+                      );
+                    }}
+                    options={[
+                      { label: "None", value: "" },
+                      ...(summary?.agents ?? [])
+                        .filter((agent) => agent.supports_images)
+                        .map((agent) => ({
+                          label: agent.model ? `${agent.name} — ${agent.model}` : agent.name,
+                          value: agent.id,
+                        })),
+                    ]}
+                    selected={
+                      typeof summary?.config?.vision_fallback_agent_id === "string"
+                        ? summary.config.vision_fallback_agent_id
+                        : ""
+                    }
+                    tone={accentColor}
+                    variant="menu"
+                  />
+                  {MOBILE_SETTINGS_ROOT_CHROME.reasoningEffortSelector ? (
+                    <SettingSelector
+                      disabled={savingConfigKey !== null}
+                      label="Reasoning effort"
+                      onSelect={(value) => {
+                        void saveConfigPatch(
+                          "reasoning_effort",
+                          { reasoning_effort: value },
+                          "Reasoning effort setting failed"
+                        );
+                      }}
+                      options={MOBILE_REASONING_EFFORT_OPTIONS.map((option) => ({
+                        label: option.label,
+                        value: option.value,
+                      }))}
+                      selected={reasoningEffort}
+                      tone={accentColor}
+                      variant="menu"
+                    />
+                  ) : null}
+                </>
+              ) : null}
+            </SettingsSection>
+            <SettingsSection title="Agent behavior">
+              {configAvailable ? (
+                <>
+                  <SettingToggle
+                    busy={savingConfigKey === "follow_up_behavior_enabled"}
+                    detail="Allow messages sent during an active response to queue or steer the current run."
+                    disabled={savingConfigKey !== null}
+                    label="Queue / Steer follow-ups"
+                    onPress={() => {
+                      void saveConfigPatch(
+                        "follow_up_behavior_enabled",
+                        { follow_up_behavior_enabled: !followUpBehaviorEnabled },
+                        "Follow-up behavior setting failed"
+                      );
+                    }}
+                    tone={accentColor}
+                    value={followUpBehaviorEnabled}
+                  />
+                  <SettingToggle
+                    busy={savingConfigKey === "self_improving_skills_enabled"}
+                    detail="Let agents save reusable skills after complex tasks."
+                    disabled={savingConfigKey !== null}
+                    label="Self-improving skills"
+                    onPress={() => {
+                      void saveConfigPatch(
+                        "self_improving_skills_enabled",
+                        { self_improving_skills_enabled: !selfImprovingSkillsEnabled },
+                        "Self-improving skills setting failed"
+                      );
+                    }}
+                    tone={accentColor}
+                    value={selfImprovingSkillsEnabled}
+                  />
+                  <SettingToggle
+                    busy={savingConfigKey === "skill_learning_nudge_enabled"}
+                    detail="Prompt agents to save a reusable skill after complex, tool-heavy tasks."
+                    disabled={savingConfigKey !== null || !selfImprovingSkillsEnabled}
+                    label="Auto-learn after complex tasks"
+                    onPress={() => {
+                      void saveConfigPatch(
+                        "skill_learning_nudge_enabled",
+                        { skill_learning_nudge_enabled: !skillLearningNudgeEnabled },
+                        "Auto-learn setting failed"
+                      );
+                    }}
+                    tone={accentColor}
+                    value={skillLearningNudgeEnabled}
+                  />
+                  <SettingToggle
+                    busy={savingConfigKey === "token_optimization"}
+                    detail="Use TOON for structured tool output when it is smaller than compact JSON."
+                    disabled={savingConfigKey !== null}
+                    label="Compact structured results"
+                    onPress={() => {
+                      void saveConfigPatch(
+                        "token_optimization",
+                        {
+                          token_optimization: {
+                            ...tokenOptimization,
+                            toonStructuredDataEnabled: !tokenOptimization.toonStructuredDataEnabled,
+                          },
+                        },
+                        "Token optimization setting failed"
+                      );
+                    }}
+                    tone={accentColor}
+                    value={tokenOptimization.toonStructuredDataEnabled}
+                  />
+                </>
+              ) : null}
+            </SettingsSection>
+            <SettingsSection title="AI tools">
               <Pressable
                 accessibilityRole="button"
                 style={styles.settingsNavigationRow}
-                onPress={openModelRouter}
+                onPress={openSystemPrompt}
               >
                 <View
                   style={[styles.settingsNavigationIcon, { backgroundColor: `${accentColor}18` }]}
                 >
-                  <Network color={accentColor} size={20} strokeWidth={2.1} />
+                  <Sparkles color={accentColor} size={20} strokeWidth={2.1} />
                 </View>
                 <View style={styles.listText}>
-                  <Text style={styles.listTitle}>Model Router</Text>
+                  <Text style={styles.listTitle}>System Prompt</Text>
                   <Text style={styles.listDetail} numberOfLines={1}>
-                    Provider routing, fallback, and spend caps
+                    {systemPromptAvailable
+                      ? summary?.systemPrompt?.identity?.name
+                        ? `Identity: ${summary.systemPrompt.identity.name}`
+                        : "Identity, instructions, and behavior"
+                      : endpointStatusLabel(summary?.availability.systemPrompt)}
                   </Text>
                 </View>
                 <ChevronRight color={colors.textMuted} size={20} strokeWidth={2} />
               </Pressable>
-            ) : null}
-          </SettingsSection>
+              {MOBILE_SETTINGS_ROOT_CHROME.modelRouterControls ? (
+                <Pressable
+                  accessibilityRole="button"
+                  style={styles.settingsNavigationRow}
+                  onPress={openModelRouter}
+                >
+                  <View
+                    style={[styles.settingsNavigationIcon, { backgroundColor: `${accentColor}18` }]}
+                  >
+                    <Network color={accentColor} size={20} strokeWidth={2.1} />
+                  </View>
+                  <View style={styles.listText}>
+                    <Text style={styles.listTitle}>Model Router</Text>
+                    <Text style={styles.listDetail} numberOfLines={1}>
+                      Provider routing, fallback, and spend caps
+                    </Text>
+                  </View>
+                  <ChevronRight color={colors.textMuted} size={20} strokeWidth={2} />
+                </Pressable>
+              ) : null}
+            </SettingsSection>
+          </>
         ) : null}
         {showMemorySettings ? (
           <SettingsSection title="Memory">

--- a/apps/mobile/src/screens/dashboardHelpers.ts
+++ b/apps/mobile/src/screens/dashboardHelpers.ts
@@ -11,7 +11,6 @@ import type {
   FeatureSummary,
   ProviderSummary,
   RemoteItemSummary,
-  SessionSummary,
   SystemMonitorSnapshot,
 } from "../lib/api";
 
@@ -420,10 +419,6 @@ export function surfaceCount(
   if (!endpoint.ok) return endpoint.status ? `Unavailable (${endpoint.status})` : "Unavailable";
   if (count === 0) return empty;
   return `${count} ${count === 1 ? singularSuffix : suffix}`;
-}
-
-export function sessionMayBeInProgress(session: SessionSummary): boolean {
-  return session.last_message?.role === "user";
 }
 
 export function displayFields(

--- a/apps/mobile/src/screens/dashboardLiveChat.ts
+++ b/apps/mobile/src/screens/dashboardLiveChat.ts
@@ -1,6 +1,7 @@
 import { isProviderRecoveryStatusLabel } from "cybara-shared/chat-status";
 import type { SessionEventIdentity } from "cybara-shared/session-event-order";
 import type {
+  MobileSessionStatusResponse,
   MobileStatusSessionSnapshot,
   MobileStatusStreamEvent,
   SessionDetailSummary,
@@ -116,6 +117,18 @@ export function isMobileSessionSnapshotCurrent(
 ): boolean {
   if (serverReportsActive) return true;
   return typeof timestamp === "number" && now - timestamp <= MOBILE_LIVE_ASSISTANT_STALE_MS;
+}
+
+export function isMobileSessionStatusActive(
+  sessionId: string | null | undefined,
+  status: MobileSessionStatusResponse
+): boolean {
+  const sessionKey = normalizeLiveSessionId(sessionId);
+  if (!sessionKey) return false;
+  if (status.active === true) return true;
+  return status.activeSessionIds.some(
+    (candidate) => normalizeLiveSessionId(candidate) === sessionKey
+  );
 }
 
 export function subscribeCachedMobileLiveAssistant(

--- a/apps/mobile/src/screens/dashboardMetricsPanels.tsx
+++ b/apps/mobile/src/screens/dashboardMetricsPanels.tsx
@@ -30,6 +30,7 @@ import {
   formatMetricBytes,
   formatMetricNumber,
   hasDetailedMetrics,
+  hasMetricEndpoint,
   metricSuccessRate,
   modelTokenShareRows,
   providerTokenShareRows,
@@ -40,7 +41,7 @@ import {
   totalFileOperations,
   type MetricsSnapshot,
 } from "../lib/metrics";
-import type { CybaraMobileApi, ProviderPlanStatusResponse } from "../lib/api";
+import type { CybaraMobileApi, FeatureSummary, ProviderPlanStatusResponse } from "../lib/api";
 import {
   MOBILE_RECENT_ACTIVITY_CHROME,
   formatMobileValue,
@@ -52,10 +53,13 @@ import { StableDetailPanel } from "./dashboardControls";
 import { endpointStatusLabel, relativeTimestamp } from "./dashboardHelpers";
 import { styles } from "./dashboardStyles";
 import { EmptyState, LoadingState, SummaryTile, type IconGlyph } from "./dashboardPrimitives";
-import type { FeatureSummary } from "../lib/api";
 
 const USAGE_ORDER_KEY = "cybara.mobile.usageOrder";
 type MobileMetricsSection = "activity" | "usage" | "runtime" | "system";
+
+function MetricFeedUnavailable() {
+  return <Text style={styles.settingsInfoText}>Metric feed unavailable</Text>;
+}
 
 function mobileMetricLatency(value: number | null | undefined): string {
   if (value === null || value === undefined || !Number.isFinite(value)) return "--";
@@ -130,6 +134,8 @@ function MetricsOverviewSection({
   const health = summary?.health;
   const healthy = health?.status === "healthy";
   const overview = metrics?.overview ?? null;
+  const overviewAvailable = hasMetricEndpoint(metrics, "overview");
+  const storageAvailable = hasMetricEndpoint(metrics, "storage");
   const availableMetrics = metrics
     ? Object.values(metrics.availability).filter((endpoint) => endpoint.ok).length
     : 0;
@@ -152,21 +158,29 @@ function MetricsOverviewSection({
         <SummaryTile
           Icon={Cpu}
           label="Tokens"
-          value={formatMetricNumber(overview?.tokenUsage.total)}
-          detail={`${formatMetricNumber(overview?.agentActivity.totalMessages)} messages`}
+          value={overviewAvailable ? formatMetricNumber(overview?.tokenUsage.total) : "--"}
+          detail={
+            overviewAvailable
+              ? `${formatMetricNumber(overview?.agentActivity.totalMessages)} messages`
+              : "Feed unavailable"
+          }
           tone={accentColor}
         />
         <SummaryTile
           Icon={Zap}
           label="API"
-          value={metricSuccessRate(overview)}
-          detail={`${formatMetricNumber(overview?.apiCalls.totalCalls)} calls`}
+          value={overviewAvailable ? metricSuccessRate(overview) : "--"}
+          detail={
+            overviewAvailable
+              ? `${formatMetricNumber(overview?.apiCalls.totalCalls)} calls`
+              : "Feed unavailable"
+          }
           tone={colors.blueText}
         />
         <SummaryTile
           Icon={Database}
           label="Storage"
-          value={metrics?.storage ? formatMetricBytes(metrics.storage.totalBytes) : "--"}
+          value={storageAvailable ? formatMetricBytes(metrics?.storage?.totalBytes) : "--"}
           detail={`${availableMetrics}/${metricFeedCount} feeds`}
           tone={colors.green}
         />
@@ -178,10 +192,16 @@ function MetricsOverviewSection({
         <Text style={styles.subsectionTitle}>Token flow</Text>
         <View style={styles.inlineButtonRow}>
           {metricsRefreshing ? <ActivityIndicator color={accentColor} size="small" /> : null}
-          <Text style={styles.counterText}>{metricsRefreshing ? "Updating" : freshness}</Text>
+          <Text style={styles.metricFreshnessText}>
+            {metricsRefreshing ? "Updating" : freshness}
+          </Text>
         </View>
       </View>
-      <MetricBreakdown data={tokenBars} tone={accentColor} />
+      {overviewAvailable ? (
+        <MetricBreakdown data={tokenBars} tone={accentColor} />
+      ) : (
+        <MetricFeedUnavailable />
+      )}
     </>
   );
 }
@@ -286,8 +306,22 @@ export function MetricsPanel({
   ).slice(0, 8);
   const sessionMetrics = sessionRuntime ?? metrics?.sessions;
   const sessionPagination = sessionMetrics?.pagination;
+  const overviewAvailable = hasMetricEndpoint(metrics, "overview");
+  const timeSeriesAvailable = hasMetricEndpoint(metrics, "timeSeries");
+  const tokenAnalysisAvailable = hasMetricEndpoint(metrics, "tokenAnalysis");
+  const insightsAvailable = hasMetricEndpoint(metrics, "insights");
+  const providerEfficiencyAvailable = insightsAvailable || hasMetricEndpoint(metrics, "providers");
+  const providerPlansAvailable =
+    providerPlanStatus !== null || hasMetricEndpoint(metrics, "providerPlans");
+  const modelsAvailable =
+    hasMetricEndpoint(metrics, "models") ||
+    (tokenAnalysisAvailable && metrics?.tokenAnalysis?.modelThoughtProfiles !== undefined);
+  const sessionsAvailable = hasMetricEndpoint(metrics, "sessions");
+  const toolsAvailable = hasMetricEndpoint(metrics, "tools");
+  const filesAvailable = hasMetricEndpoint(metrics, "files");
+  const storageAvailable = hasMetricEndpoint(metrics, "storage");
 
-  if (!hasDetailedMetrics(metrics)) {
+  if (!hasDetailedMetrics(metrics) && metricsRefreshing && !metricsError) {
     return (
       <StableDetailPanel>
         <MetricsOverviewSection
@@ -325,6 +359,8 @@ export function MetricsPanel({
           return (
             <Pressable
               key={key}
+              accessibilityHint={`Show ${label.toLowerCase()} metrics`}
+              accessibilityLabel={label}
               accessibilityRole="tab"
               accessibilityState={{ selected }}
               onPress={() => setActiveMetricsSection(key as MobileMetricsSection)}
@@ -353,17 +389,23 @@ export function MetricsPanel({
       {activeMetricsSection === "activity" ? (
         <>
           <MetricSection
+            available={timeSeriesAvailable}
             title="Activity trend"
             detail="Last 14 days across tokens, tools, API, files, and messages"
           >
             <MetricBarChart data={activitySeries} tone={accentColor} />
           </MetricSection>
 
-          <MetricSection title="Token velocity" detail="Last 24 hours by token volume and calls">
+          <MetricSection
+            available={tokenAnalysisAvailable}
+            title="Token velocity"
+            detail="Last 24 hours by token volume and calls"
+          >
             <MetricAreaChart data={velocityRows} tone={accentColor} />
           </MetricSection>
 
           <MetricSection
+            available={tokenAnalysisAvailable}
             title="Token heatmap"
             detail={
               tokenAnalysis?.tokenHeatmap?.hottestHour
@@ -378,7 +420,11 @@ export function MetricsPanel({
 
       {activeMetricsSection === "usage" ? (
         <>
-          <MetricSection title="Prompt vs output" detail="Ratio, median, and response balance">
+          <MetricSection
+            available={tokenAnalysisAvailable}
+            title="Prompt vs output"
+            detail="Ratio, median, and response balance"
+          >
             <View style={styles.metricMicroGrid}>
               <MetricMicro
                 label="Input:Output"
@@ -409,28 +455,35 @@ export function MetricsPanel({
           </MetricSection>
 
           <MetricSection
+            available={insightsAvailable}
             title="Token insights"
-            detail={`${insights?.tokenTrend24h.changePct ?? 0}% 24h trend - ${insights?.cacheEfficiency.cacheSharePct ?? 0}% cache`}
+            detail={
+              insightsAvailable && insights
+                ? `${insights.tokenTrend24h.changePct}% 24h trend - ${insights.cacheEfficiency.cacheSharePct}% cache`
+                : "Feed unavailable"
+            }
           >
             <View style={styles.metricMicroGrid}>
               <MetricMicro
                 label="Top model share"
-                value={`${insights?.topModel?.sharePct ?? 0}%`}
+                value={insights?.topModel ? `${insights.topModel.sharePct}%` : "--"}
               />
               <MetricMicro
                 label="Tool success"
-                value={`${insights?.toolReliability.successRatePct ?? 100}%`}
+                value={insights ? `${insights.toolReliability.successRatePct}%` : "--"}
               />
               <MetricMicro
                 label="Context warnings"
-                value={String(
-                  insights?.contextHealth24h.warnings ?? overview?.contextHealth?.warnings ?? 0
-                )}
+                value={formatMetricNumber(insights?.contextHealth24h.warnings)}
               />
             </View>
           </MetricSection>
 
-          <MetricSection title="Provider efficiency" detail="Tokens per provider call">
+          <MetricSection
+            available={providerEfficiencyAvailable}
+            title="Provider efficiency"
+            detail="Tokens per provider call"
+          >
             <MetricShareRows rows={providerRows} tone={colors.blueText} />
           </MetricSection>
         </>
@@ -439,23 +492,33 @@ export function MetricsPanel({
       {activeMetricsSection === "runtime" ? (
         <>
           <MetricSection
+            available={providerPlansAvailable}
             title="Provider plans"
-            detail={`${providerPlanStatus?.summary?.configured ?? metrics?.providerPlans?.summary?.configured ?? 0} configured - ${
-              providerPlanStatus?.summary?.warnings ??
-              metrics?.providerPlans?.summary?.warnings ??
-              0
-            } warnings`}
+            detail={
+              providerPlansAvailable
+                ? `${providerPlanStatus?.summary?.configured ?? metrics?.providerPlans?.summary?.configured ?? 0} configured - ${providerPlanStatus?.summary?.warnings ?? metrics?.providerPlans?.summary?.warnings ?? 0} warnings`
+                : "Feed unavailable"
+            }
           >
             <ProviderPlanMetricsGrid plans={providerPlanRows} />
           </MetricSection>
 
-          <MetricSection title="Models" detail="Throughput, latency, and token share">
+          <MetricSection
+            available={modelsAvailable}
+            title="Models"
+            detail="Throughput, latency, and token share"
+          >
             <MetricShareRows rows={modelRows} tone={colors.amber} />
           </MetricSection>
 
           <MetricSection
+            available={sessionsAvailable}
             title="Chat runtime"
-            detail={`${formatMetricNumber(sessionMetrics?.totals.callCount)} provider calls across ${formatMetricNumber(sessionMetrics?.totals.sessions)} chats`}
+            detail={
+              sessionsAvailable
+                ? `${formatMetricNumber(sessionMetrics?.totals.callCount)} provider calls across ${formatMetricNumber(sessionMetrics?.totals.sessions)} chats`
+                : "Feed unavailable"
+            }
           >
             <View style={styles.metricMicroGrid}>
               <MetricMicro
@@ -535,8 +598,13 @@ export function MetricsPanel({
           </MetricSection>
 
           <MetricSection
+            available={toolsAvailable}
             title="Tools"
-            detail={`${formatMetricNumber(overview?.toolCalls.totalCalls)} calls - ${formatMetricNumber(insights?.toolReliability.totalErrors)} errors`}
+            detail={
+              toolsAvailable
+                ? `${overviewAvailable ? formatMetricNumber(overview?.toolCalls.totalCalls) : "--"} calls - ${insightsAvailable ? formatMetricNumber(insights?.toolReliability.totalErrors) : "--"} errors`
+                : "Feed unavailable"
+            }
           >
             <MetricShareRows
               rows={(metrics?.tools?.mostUsed || []).slice(0, 7).map((tool) => ({
@@ -559,8 +627,13 @@ export function MetricsPanel({
           </MetricSection>
 
           <MetricSection
+            available={filesAvailable}
             title="Files"
-            detail={`${formatMetricNumber(totalFileOperations(overview))} read/write/edit operations`}
+            detail={
+              filesAvailable
+                ? `${overviewAvailable ? formatMetricNumber(totalFileOperations(overview)) : "--"} read/write/edit/search operations`
+                : "Feed unavailable"
+            }
           >
             <MetricShareRows
               rows={(metrics?.files?.mostRead || []).slice(0, 4).map((file) => ({
@@ -591,7 +664,15 @@ export function MetricsPanel({
 
       {activeMetricsSection === "system" ? (
         <>
-          <MetricSection title="Storage" detail={formatMetricBytes(metrics?.storage?.totalBytes)}>
+          <MetricSection
+            available={storageAvailable}
+            title="Storage"
+            detail={
+              storageAvailable
+                ? formatMetricBytes(metrics?.storage?.totalBytes)
+                : "Feed unavailable"
+            }
+          >
             <MetricShareRows
               rows={storageRows.map((entry) => ({
                 label: entry.label,
@@ -604,6 +685,7 @@ export function MetricsPanel({
           </MetricSection>
 
           <MetricSection
+            available={tokenAnalysisAvailable}
             title="Token cloud"
             detail="Models, providers, tools, and recurring output terms"
           >

--- a/apps/mobile/src/screens/dashboardSessionDetail.tsx
+++ b/apps/mobile/src/screens/dashboardSessionDetail.tsx
@@ -25,6 +25,7 @@ import {
 } from "lucide-react-native";
 import {
   type Dispatch,
+  type ReactNode,
   type SetStateAction,
   useCallback,
   useEffect,
@@ -38,6 +39,7 @@ import {
   Alert,
   Image,
   Keyboard,
+  KeyboardAvoidingView,
   Modal,
   type NativeScrollEvent,
   type NativeSyntheticEvent,
@@ -137,6 +139,27 @@ export interface ChatHeaderAction {
 const MOBILE_MODEL_ROUTER_SELECTOR_VALUE = "__model_router__";
 const ignoreSessionDetail = (_detail: SessionDetailSummary): void => {};
 
+function ChatKeyboardContainer({
+  children,
+  keyboardVerticalOffset,
+}: {
+  children: ReactNode;
+  keyboardVerticalOffset: number;
+}) {
+  if (Platform.OS === "android") {
+    return (
+      <KeyboardAvoidingView
+        behavior="height"
+        keyboardVerticalOffset={keyboardVerticalOffset}
+        style={styles.chatShell}
+      >
+        {children}
+      </KeyboardAvoidingView>
+    );
+  }
+  return <View style={styles.chatShell}>{children}</View>;
+}
+
 function pendingMessagesFromResponse(result: {
   pendingMessage?: MobilePendingChatMessage;
   pendingMessages?: MobilePendingChatMessage[];
@@ -183,13 +206,20 @@ export function SessionDetailPanel({
   const goldenTurnActionsEnabled =
     labConfig.enabled !== false && labConfig.goldenTurnsEnabled !== false;
   const navFootprint = insets.bottom + MOBILE_NAV_CHROME.floatingMargin + MOBILE_NAV_CHROME.height;
-  const [keyboardHeight, setKeyboardHeight] = useState(0);
+  const [keyboardVisible, setKeyboardVisible] = useState(Keyboard.isVisible());
+  const [keyboardHeight, setKeyboardHeight] = useState(() => Keyboard.metrics()?.height ?? 0);
   useEffect(() => {
-    if (Platform.OS !== "ios") return;
-    const showSub = Keyboard.addListener("keyboardWillShow", (event) => {
-      setKeyboardHeight(event.endCoordinates?.height ?? 0);
+    const showEvent = Platform.OS === "ios" ? "keyboardWillShow" : "keyboardDidShow";
+    const hideEvent = Platform.OS === "ios" ? "keyboardWillHide" : "keyboardDidHide";
+    const showSub = Keyboard.addListener(showEvent, (event) => {
+      const nextKeyboardHeight = event.endCoordinates.height;
+      setKeyboardVisible(nextKeyboardHeight > 0);
+      if (Platform.OS === "ios") setKeyboardHeight(nextKeyboardHeight);
     });
-    const hideSub = Keyboard.addListener("keyboardWillHide", () => setKeyboardHeight(0));
+    const hideSub = Keyboard.addListener(hideEvent, () => {
+      setKeyboardVisible(false);
+      if (Platform.OS === "ios") setKeyboardHeight(0);
+    });
     return () => {
       showSub.remove();
       hideSub.remove();
@@ -1421,11 +1451,11 @@ export function SessionDetailPanel({
     [renderMessages]
   );
   const waitingForAssistant = chatIsWaitingForAssistant(renderMessages, sending);
-  const composerBottom =
-    keyboardHeight > 0 ? keyboardHeight + spacing.xs : navFootprint + spacing.xs;
+  const keyboardOffset = Platform.OS === "ios" ? keyboardHeight : 0;
+  const composerBottom = keyboardVisible ? keyboardOffset + spacing.xs : navFootprint + spacing.xs;
   const composerReservedHeight = Math.max(composerBarHeight, MOBILE_CHAT_CHROME.composerHeight);
   return (
-    <View style={styles.chatShell}>
+    <ChatKeyboardContainer keyboardVerticalOffset={insets.top + spacing.xs}>
       <MobileBranchPicker
         branches={gitBranches}
         currentBranch={gitBranch}
@@ -1838,6 +1868,6 @@ export function SessionDetailPanel({
           </View>
         </View>
       </Modal>
-    </View>
+    </ChatKeyboardContainer>
   );
 }

--- a/apps/mobile/src/screens/dashboardStyles.ts
+++ b/apps/mobile/src/screens/dashboardStyles.ts
@@ -250,7 +250,12 @@ const makeStyles = () =>
     },
     overviewInset: {
       gap: spacing.sm,
-      paddingHorizontal: MOBILE_HOME_CHROME.managementGridEdgeToEdge ? 0 : spacing.lg,
+      paddingHorizontal:
+        Platform.OS === "android"
+          ? MOBILE_MAIN_TAB_CHROME.outerHorizontalPadding
+          : MOBILE_HOME_CHROME.managementGridEdgeToEdge
+            ? 0
+            : spacing.lg,
     },
     moduleGrid: {
       flexDirection: "row",
@@ -262,11 +267,12 @@ const makeStyles = () =>
       borderColor: colors.borderStrong,
       borderRadius: radius.lg,
       borderWidth: 1,
-      flexBasis: "48%",
+      flexBasis: "auto",
       flexGrow: 1,
       gap: spacing.sm,
       minHeight: 108,
       padding: spacing.md,
+      width: "48%",
     },
     moduleIcon: {
       alignItems: "center",
@@ -292,9 +298,10 @@ const makeStyles = () =>
     },
     monitorTile: {
       alignItems: "center",
-      flexBasis: "100%",
+      flexBasis: "auto",
       flexDirection: "row",
       minHeight: 72,
+      width: "100%",
     },
     monitorTilePrimary: {
       backgroundColor: colors.surface,
@@ -307,6 +314,8 @@ const makeStyles = () =>
       backgroundColor: colors.surface,
       borderColor: colors.borderStrong,
       gap: spacing.sm,
+      marginHorizontal:
+        Platform.OS === "android" ? MOBILE_MAIN_TAB_CHROME.outerHorizontalPadding : 0,
     },
     panelHeader: {
       alignItems: "center",

--- a/apps/mobile/src/screens/dashboardStyles.ts
+++ b/apps/mobile/src/screens/dashboardStyles.ts
@@ -372,6 +372,24 @@ const makeStyles = () =>
       fontSize: typography.label,
       fontWeight: "900",
     },
+    sessionSearchField: {
+      alignItems: "center",
+      backgroundColor: colors.inset,
+      borderColor: colors.borderStrong,
+      borderRadius: radius.lg,
+      borderWidth: 1,
+      flexDirection: "row",
+      gap: spacing.sm,
+      minHeight: 46,
+      paddingHorizontal: spacing.md,
+    },
+    sessionSearchInput: {
+      color: colors.text,
+      flex: 1,
+      fontSize: typography.body,
+      minHeight: 44,
+      paddingVertical: spacing.sm,
+    },
     logPageFooter: {
       alignItems: "center",
       borderTopColor: colors.border,
@@ -555,12 +573,17 @@ const makeStyles = () =>
       borderRadius: radius.md,
       borderWidth: 1,
       flex: 1,
-      minHeight: 34,
+      minHeight: 44,
       justifyContent: "center",
       paddingHorizontal: spacing.xs,
     },
     metricSectionTabText: {
       fontSize: typography.tiny,
+      fontWeight: "700",
+    },
+    metricFreshnessText: {
+      color: colors.textMuted,
+      fontSize: typography.label,
       fontWeight: "700",
     },
     metricSkeletonHero: {

--- a/apps/mobile/src/screens/useMobileSessionRuntime.ts
+++ b/apps/mobile/src/screens/useMobileSessionRuntime.ts
@@ -22,6 +22,7 @@ import { haptics } from "../lib/haptics";
 import {
   clearCachedMobileLiveAssistant,
   isMobileSessionSnapshotCurrent,
+  isMobileSessionStatusActive,
   liveActivityFromStatusEvent,
   liveAssistantFromStatusSnapshot,
   liveAssistantMessage,
@@ -255,8 +256,7 @@ export function useMobileSessionRuntime({
       const status = await api.sessionStatus(sessionId);
       const snapshot =
         status.session || status.activeSessions.find((entry) => entry.sessionId === sessionId);
-      const serverReportsActive =
-        status.active === true || status.activeSessionIds.includes(sessionId);
+      const serverReportsActive = isMobileSessionStatusActive(sessionId, status);
       const snapshotFresh = isMobileSessionSnapshotCurrent(
         snapshot?.timestamp,
         serverReportsActive
@@ -272,15 +272,7 @@ export function useMobileSessionRuntime({
           return;
         }
       }
-      const snapshotStatus = String(snapshot?.status || "").toLowerCase();
-      const active =
-        !!snapshot &&
-        snapshotFresh &&
-        (serverReportsActive ||
-          snapshotStatus === "thinking" ||
-          snapshotStatus === "generating" ||
-          snapshotStatus === "tool_executing" ||
-          snapshotStatus === "compacting");
+      const active = serverReportsActive;
       setSessionActive(active);
       const snapshotPendingMessages = snapshot?.pendingMessages ?? [];
       const preserveOptimisticPending = shouldPreserveOptimisticPending();

--- a/site/bun.lock
+++ b/site/bun.lock
@@ -19,6 +19,7 @@
     },
   },
   "overrides": {
+    "nanoid": "3.3.18",
     "postcss": "8.5.23",
   },
   "packages": {
@@ -146,7 +147,7 @@
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
 
-    "nanoid": ["nanoid@3.3.17", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g=="],
+    "nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 

--- a/site/package.json
+++ b/site/package.json
@@ -22,6 +22,7 @@
     "vite": "8.1.0"
   },
   "overrides": {
+    "nanoid": "3.3.18",
     "postcss": "8.5.23"
   }
 }

--- a/tests/core/llm-stream-watchdog.test.ts
+++ b/tests/core/llm-stream-watchdog.test.ts
@@ -251,7 +251,6 @@ describe("consumeOpenAIChatStream onTextDelta", () => {
     expect(deltas).toEqual(["Hel", "lo"]);
     expect(assembled.choices[0]?.message.content).toBe("Hello");
     expect(assembled.first_token_ms).toBeGreaterThanOrEqual(20);
-    expect(assembled.generation_duration_ms).toBeUndefined();
   });
 
   test("measures generation duration across distinct output events", async () => {

--- a/tests/core/reasoning-tag-leaks.test.ts
+++ b/tests/core/reasoning-tag-leaks.test.ts
@@ -139,7 +139,8 @@ describe("reasoning tag tokens never leak into visible chat state", () => {
     const mobileChat = read("apps/mobile/src/screens/dashboardChat.tsx");
     const macTimeline = read("apps/macos/Cybara/Sources/Cybara/NativeToolTimeline.swift");
 
-    expect(mobileChat).toContain('numberOfLines={activity.toolName === "__thought" ? 0 : 2}');
+    expect(mobileChat).toContain("function MobileThoughtText");
+    expect(mobileChat).toContain("numberOfLines={0}");
     expect(macTimeline).toContain('.lineLimit(activity.toolName == "__thought" ? nil : 3)');
   });
 });

--- a/tests/mobile/api-client-management.test.ts
+++ b/tests/mobile/api-client-management.test.ts
@@ -927,7 +927,7 @@ describe("mobile API client", () => {
         duration: "1.2s",
       });
       expect(calls.map((call) => `${call.method} ${call.path}${call.search}`)).toEqual([
-        "GET /api/sessions?limit=100&includeTotal=1",
+        "GET /api/sessions?limit=100&offset=0&includeTotal=1",
         "GET /api/sessions/s1",
         "POST /api/chat",
         "PUT /api/sessions/s1/agent",
@@ -1323,19 +1323,22 @@ describe("mobile API client", () => {
 
   test("keeps the mobile session list bounded while preserving the gateway total", async () => {
     const originalFetch = globalThis.fetch;
+    const sessionQueries: string[] = [];
     globalThis.fetch = (async (url) => {
       const parsedUrl = new URL(String(url));
       if (parsedUrl.pathname === "/api/sessions") {
+        sessionQueries.push(parsedUrl.search);
+        const offset = Number(parsedUrl.searchParams.get("offset") ?? 0);
         return Response.json({
           sessions: Array.from({ length: 100 }, (_, index) => ({
-            id: `s${index + 1}`,
-            title: `Session ${index + 1}`,
+            id: `s${offset + index + 1}`,
+            title: `Session ${offset + index + 1}`,
             message_count: index + 1,
             updated_at: `2026-06-30T08:${String(index % 60).padStart(2, "0")}:00.000Z`,
           })),
           total: 3407,
           limit: 100,
-          offset: 0,
+          offset,
           hasMore: true,
         });
       }
@@ -1345,13 +1348,20 @@ describe("mobile API client", () => {
     try {
       const api = new CybaraMobileApi(profile);
       const page = await api.sessionList();
+      const olderPage = await api.sessionList({ limit: 100, offset: 100 });
       const summary = await api.featureSummary();
 
       expect(page.sessions).toHaveLength(100);
       expect(page.total).toBe(3407);
       expect(page.hasMore).toBe(true);
+      expect(olderPage.sessions.some((session) => session.id === "s101")).toBe(true);
       expect(summary.sessions).toHaveLength(100);
       expect(summary.sessionTotal).toBe(3407);
+      expect(sessionQueries).toEqual([
+        "?limit=100&offset=0&includeTotal=1",
+        "?limit=100&offset=100&includeTotal=1",
+        "?limit=100&offset=0&includeTotal=1",
+      ]);
     } finally {
       globalThis.fetch = originalFetch;
     }

--- a/tests/mobile/api-client.test.ts
+++ b/tests/mobile/api-client.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { parseWebSocketAuthProtocol } from "../../shared/websocket-auth";
 import {
   buildMobileStatusStreamUrl,
   CybaraMobileApi,
@@ -196,9 +197,7 @@ describe("mobile API client", () => {
   });
 
   test("builds and normalizes the authenticated mobile status stream", () => {
-    expect(buildMobileStatusStreamUrl(profile)).toBe(
-      "ws://127.0.0.1:4269/api/ws/status?token=cybara_mobile_test"
-    );
+    expect(buildMobileStatusStreamUrl(profile)).toBe("ws://127.0.0.1:4269/api/ws/status");
     expect(
       normalizeMobileStatusStreamEvent({
         type: "snapshot",
@@ -317,7 +316,10 @@ describe("mobile API client", () => {
       onerror: (() => void) | null = null;
       onmessage: ((event: { data: unknown }) => void) | null = null;
 
-      constructor(public url: string) {
+      constructor(
+        public url: string,
+        public protocols?: string | string[]
+      ) {
         FakeWebSocket.instances.push(this);
       }
 
@@ -335,8 +337,11 @@ describe("mobile API client", () => {
       { closeGraceMs: 0, WebSocketImpl: FakeWebSocket as never }
     );
 
-    expect(FakeWebSocket.instances[0]?.url).toBe(
-      "ws://127.0.0.1:4269/api/ws/status?token=cybara_mobile_test"
+    expect(FakeWebSocket.instances[0]?.url).toBe("ws://127.0.0.1:4269/api/ws/status");
+    expect(parseWebSocketAuthProtocol(String(FakeWebSocket.instances[0]?.protocols))).toMatchObject(
+      {
+        token: "cybara_mobile_test",
+      }
     );
     FakeWebSocket.instances[0]?.onmessage?.({
       data: JSON.stringify({
@@ -365,6 +370,57 @@ describe("mobile API client", () => {
         durationMs: undefined,
       },
     ]);
+  });
+
+  test("reconnects the status stream with token and gateway password authentication", () => {
+    class CapturedWebSocket {
+      static instances: CapturedWebSocket[] = [];
+      onopen: (() => void) | null = null;
+      onclose: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      onmessage: ((event: { data: unknown }) => void) | null = null;
+      closed = false;
+
+      constructor(
+        readonly url: string,
+        readonly protocols?: string | string[]
+      ) {
+        CapturedWebSocket.instances.push(this);
+      }
+
+      close(): void {
+        if (this.closed) return;
+        this.closed = true;
+        this.onclose?.();
+      }
+    }
+
+    const api = new CybaraMobileApi(profile);
+    const disconnect = api.connectStatusStream(
+      { onEvent: () => {} },
+      { closeGraceMs: 0, heartbeatMs: 0, WebSocketImpl: CapturedWebSocket }
+    );
+
+    expect(CapturedWebSocket.instances).toHaveLength(1);
+    expect(parseWebSocketAuthProtocol(String(CapturedWebSocket.instances[0]?.protocols))).toEqual({
+      protocol: CapturedWebSocket.instances[0]?.protocols,
+      token: "cybara_mobile_test",
+      password: undefined,
+    });
+
+    api.setGatewayPassword(" manual-profile-password ");
+
+    expect(CapturedWebSocket.instances).toHaveLength(2);
+    expect(CapturedWebSocket.instances[0]?.closed).toBe(true);
+    expect(CapturedWebSocket.instances[1]?.url).toBe("ws://127.0.0.1:4269/api/ws/status");
+    expect(parseWebSocketAuthProtocol(String(CapturedWebSocket.instances[1]?.protocols))).toEqual({
+      protocol: CapturedWebSocket.instances[1]?.protocols,
+      token: "cybara_mobile_test",
+      password: "manual-profile-password",
+    });
+
+    disconnect();
+    expect(CapturedWebSocket.instances[1]?.closed).toBe(true);
   });
 
   test("sends bearer auth to gateway requests", async () => {

--- a/tests/mobile/chat-format.test.ts
+++ b/tests/mobile/chat-format.test.ts
@@ -102,9 +102,14 @@ describe("mobile chat formatting", () => {
 
   test("splits long assistant text around fenced code blocks", () => {
     expect(splitMessageContent("Before\n```typescript\nconst ok = true;\n```\nAfter")).toEqual([
-      { type: "text", content: "Before\n" },
-      { type: "code", language: "typescript", content: "const ok = true;\n" },
-      { type: "text", content: "\nAfter" },
+      { type: "text", content: "Before\n", key: "text-0" },
+      {
+        type: "code",
+        language: "typescript",
+        content: "const ok = true;\n",
+        key: "code-7",
+      },
+      { type: "text", content: "\nAfter", key: "text-41" },
     ]);
   });
 

--- a/tests/mobile/dashboard.test.ts
+++ b/tests/mobile/dashboard.test.ts
@@ -43,6 +43,7 @@ import {
   mobileGatewayAuthStatus,
   mobileProviderAuthMode,
   mobileReasoningLabel,
+  mobileSessionIsActive,
   mobileSessionTitle,
   mobileSupportedReasoningEfforts,
   mobileSupportsXHighReasoning,
@@ -316,6 +317,15 @@ describe("mobile dashboard model", () => {
     expect(MOBILE_MAIN_TAB_CHROME.edgeToEdge).toBe(false);
     expect(MOBILE_MAIN_TAB_CHROME.outerHorizontalPadding).toBeGreaterThan(0);
     expect(MOBILE_MAIN_TAB_CHROME.panelRadius).toBeGreaterThan(0);
+    expect(dashboardScreenSource).toContain("accessibilityLabel={label}");
+    expect(dashboardScreenSource).toContain("accessibilityHint={`Show ${label.toLowerCase()}`}");
+    expect(dashboardScreenSource).toContain("Pinned & recent");
+    expect(dashboardScreenSource).toContain('accessibilityLabel="Search chats"');
+    expect(dashboardScreenSource).toContain('"Show more chats"');
+    expect(dashboardScreenSource).toContain('"Load older chats"');
+    expect(dashboardScreenSource).toContain("api.sessionList({");
+    expect(dashboardScreenSource).toContain("offset: currentSummary.sessions.length");
+    expect(dashboardScreenSource).toContain("<Pin color={colors.amber}");
   });
 
   test("keeps the chat composer compact, dynamic, and icon driven", () => {
@@ -513,6 +523,11 @@ describe("mobile dashboard model", () => {
     expect(dashboardScreenSource).toContain("styles.providerPlanUsageTrack");
     expect(dashboardScreenSource).toContain('label: "5h"');
     expect(dashboardScreenSource).toContain('label: "Weekly"');
+    expect(dashboardScreenSource).toContain("styles.metricFreshnessText");
+    expect(dashboardScreenSource).toContain(
+      "accessibilityHint={`Show ${label.toLowerCase()} metrics`}"
+    );
+    expect(dashboardStylesSource).toContain("metricFreshnessText");
   });
 
   test("does not fetch all metrics on initial dashboard load before metrics opens", () => {
@@ -530,10 +545,18 @@ describe("mobile dashboard model", () => {
     expect(dashboardScreenSource).toContain('accessibilityLabel="Loading metrics"');
     expect(dashboardScreenSource).toContain("metricSkeletonBlock");
     expect(dashboardScreenSource).toContain("Loading detailed metrics");
-    expect(dashboardScreenSource).toContain(
-      'metrics?.storage ? formatMetricBytes(metrics.storage.totalBytes) : "--"'
-    );
+    expect(dashboardScreenSource).toContain("storageAvailable");
+    expect(dashboardScreenSource).toContain("formatMetricBytes(metrics?.storage?.totalBytes)");
     expect(dashboardScreenSource).toContain("Live signals are still available from Logs.");
+  });
+
+  test("keeps partial metric failures and overlapping refreshes honest", () => {
+    expect(dashboardScreenSource).toContain("function MetricFeedUnavailable");
+    expect(dashboardScreenSource).toContain('hasMetricEndpoint(metrics, "insights")');
+    expect(dashboardScreenSource).toContain('hasMetricEndpoint(metrics, "sessions")');
+    expect(dashboardScreenSource).not.toContain("successRatePct ?? 100");
+    expect(dashboardScreenSource).toContain("metricsOverviewGenerationRef.current += 1");
+    expect(dashboardScreenSource).toContain("reconcileMetricsSnapshot(");
   });
 
   test("previews chat accessibility settings using the shared appearance contract", () => {
@@ -804,13 +827,18 @@ describe("mobile dashboard model", () => {
     expect(MOBILE_RECENT_ACTIVITY_CHROME.chatsOpenSession).toBe(true);
     expect(MOBILE_RECENT_ACTIVITY_CHROME.truncateTitles).toBe(true);
     expect(MOBILE_RECENT_ACTIVITY_CHROME.useRecentStateForIdleChats).toBe(true);
-    expect(recentSessionStateLabel(summary.sessions[0])).toBe("Recent");
-    expect(
-      recentSessionStateLabel({
-        ...summary.sessions[0],
-        last_message: { role: "user", content: "continue" },
-      })
-    ).toBe("Working");
+    expect(recentSessionStateLabel(summary.sessions[0], [])).toBe("Recent");
+    const waitingSession = {
+      ...summary.sessions[0],
+      last_message: { role: "user", content: "continue" },
+    };
+    expect(recentSessionStateLabel(waitingSession, [])).toBe("Recent");
+    expect(mobileSessionIsActive(waitingSession, [])).toBe(false);
+    expect(recentSessionStateLabel(waitingSession, [` ${waitingSession.id} `])).toBe("Working");
+    expect(mobileSessionIsActive(waitingSession, [waitingSession.id])).toBe(true);
+    expect(dashboardScreenSource).toContain(".sessionStatus()");
+    expect(dashboardScreenSource).toContain("activeSessionIds={activeSessionIds}");
+    expect(dashboardScreenSource).toContain("mobileSessionIsActive(session, activeSessionIds)");
   });
 
   test("classifies stale mobile pairings as a pairing refresh instead of empty data", () => {

--- a/tests/mobile/dashboard.test.ts
+++ b/tests/mobile/dashboard.test.ts
@@ -317,6 +317,10 @@ describe("mobile dashboard model", () => {
     expect(MOBILE_MAIN_TAB_CHROME.edgeToEdge).toBe(false);
     expect(MOBILE_MAIN_TAB_CHROME.outerHorizontalPadding).toBeGreaterThan(0);
     expect(MOBILE_MAIN_TAB_CHROME.panelRadius).toBeGreaterThan(0);
+    expect(dashboardStylesSource).toContain('Platform.OS === "android"');
+    expect(dashboardStylesSource).toContain("? MOBILE_MAIN_TAB_CHROME.outerHorizontalPadding");
+    expect(dashboardStylesSource).toContain('width: "48%"');
+    expect(dashboardStylesSource).toContain('width: "100%"');
     expect(dashboardScreenSource).toContain("accessibilityLabel={label}");
     expect(dashboardScreenSource).toContain("accessibilityHint={`Show ${label.toLowerCase()}`}");
     expect(dashboardScreenSource).toContain("Pinned & recent");
@@ -682,8 +686,12 @@ describe("mobile dashboard model", () => {
     expect(MOBILE_SETTINGS_ROOT_CHROME.nativeGroupedSections).toBe(true);
     expect(MOBILE_SETTINGS_ROOT_CHROME.nativeSegmentedControls).toBe(true);
     expect(MOBILE_SETTINGS_ROOT_CHROME.nativeSwitchControls).toBe(true);
+    expect(MOBILE_SETTINGS_ROOT_CHROME.subagentDefaultSelector).toBe(true);
+    expect(MOBILE_SETTINGS_ROOT_CHROME.backgroundAgentSelector).toBe(true);
+    expect(MOBILE_SETTINGS_ROOT_CHROME.skillLearningNudgeToggle).toBe(true);
+    expect(MOBILE_SETTINGS_ROOT_CHROME.tokenOptimizationToggle).toBe(true);
     expect(dashboardScreenSource).toContain("readMobileTokenOptimizationSettings");
-    expect(dashboardScreenSource).toContain("token_optimization: next");
+    expect(dashboardScreenSource).toContain("...tokenOptimization");
     expect(readMobileTokenOptimizationSettings({}).toonStructuredDataEnabled).toBe(true);
     expect(
       readMobileTokenOptimizationSettings({
@@ -691,9 +699,16 @@ describe("mobile dashboard model", () => {
       }).toonStructuredDataEnabled
     ).toBe(false);
     expect(MOBILE_PLATFORM_SETTING_KEYS).toEqual([
+      "default_agent_id",
+      "subagent_agent_id",
+      "background_agent_id",
+      "vision_fallback_agent_id",
       "terminal_enabled",
       "tool_approval_mode",
       "follow_up_behavior_enabled",
+      "self_improving_skills_enabled",
+      "skill_learning_nudge_enabled",
+      "token_optimization",
       "chat_appearance",
       "reasoning_effort",
       "dangerous_tool_policy",
@@ -704,6 +719,15 @@ describe("mobile dashboard model", () => {
     expect(readMobileFollowUpBehaviorEnabled({})).toBe(true);
     expect(readMobileFollowUpBehaviorEnabled({ follow_up_behavior_enabled: false })).toBe(false);
     expect(dashboardScreenSource).toContain('label="Queue / Steer follow-ups"');
+    expect(dashboardScreenSource).toContain('label="Sub-agent"');
+    expect(dashboardScreenSource).toContain("{ subagent_agent_id: value }");
+    expect(dashboardScreenSource).toContain('label="Background model"');
+    expect(dashboardScreenSource).toContain("{ background_agent_id: value }");
+    expect(dashboardScreenSource).toContain('label="Auto-learn after complex tasks"');
+    expect(dashboardScreenSource).toContain(
+      "{ skill_learning_nudge_enabled: !skillLearningNudgeEnabled }"
+    );
+    expect(dashboardScreenSource).toContain('label="Compact structured results"');
     expect(dashboardScreenSource).toContain("chatBusy && !followUpBehaviorEnabled");
     expect(MOBILE_REASONING_EFFORT_OPTIONS.map((option) => option.value)).toEqual([
       "",

--- a/tests/mobile/dashboard.test.ts
+++ b/tests/mobile/dashboard.test.ts
@@ -374,9 +374,14 @@ describe("mobile dashboard model", () => {
     expect(dashboardScreenSource).not.toContain("ImagePlus");
   });
 
-  test("formats chat activity thoughts with markdown and neutral icons", () => {
+  test("formats thoughts as desktop-like chat text without activity bullets", () => {
     expect(dashboardChatSource).toContain("parseInlineMarkdown(activity.text)");
-    expect(dashboardChatSource).toContain("styles.messageActivityDot");
+    expect(dashboardChatSource).toContain('if (activity.toolName === "__thought")');
+    expect(dashboardChatSource).toContain("<MobileThoughtText");
+    expect(dashboardChatSource).toContain(
+      "const fontSize = getChatFontSizePixels(appearance.fontSize);"
+    );
+    expect(dashboardChatSource).not.toContain("styles.messageActivityDot");
     expect(dashboardChatSource).toContain("CheckCircle2 color={colors.textMuted}");
     expect(dashboardChatSource).toContain("Loader2 color={colors.textMuted}");
     expect(dashboardChatSource).not.toContain("Sparkles");
@@ -385,9 +390,9 @@ describe("mobile dashboard model", () => {
     expect(dashboardChatSource).toContain("search: Search");
     expect(dashboardChatSource).toContain("command: SquareTerminal");
     expect(dashboardChatSource).toContain("MOBILE_GROUP_ICONS[entry.kind]");
-    expect(dashboardStylesSource).toContain("messageActivityDot");
-    expect(dashboardStylesSource).toContain("backgroundColor: colors.textMuted");
+    expect(dashboardStylesSource).not.toContain("messageActivityDot");
     expect(dashboardStylesSource).toContain("messageThoughtText");
+    expect(dashboardStylesSource).toContain('alignSelf: "stretch"');
     expect(dashboardChatSource).toContain("appearance.highContrast ? colors.text");
     expect(dashboardChatSource).toContain("getChatLineHeight(appearance.lineSpacing)");
     expect(dashboardChatSource).toContain("getChatCodeFontSizePixels(appearance.codeFontSize)");

--- a/tests/mobile/live-chat-cache.test.ts
+++ b/tests/mobile/live-chat-cache.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test";
+import type { MobileSessionStatusResponse } from "../../apps/mobile/src/lib/api";
 import {
   clearCachedMobileLiveAssistant,
   isMobileSessionSnapshotCurrent,
+  isMobileSessionStatusActive,
   liveActivityFromStatusEvent,
   liveAssistantFromStatusSnapshot,
   liveAssistantMessage,
@@ -71,6 +73,36 @@ describe("mobile live chat cache", () => {
     expect(isMobileSessionSnapshotCurrent(oldTimestamp, true, now)).toBe(true);
     expect(isMobileSessionSnapshotCurrent(oldTimestamp, false, now)).toBe(false);
     expect(isMobileSessionSnapshotCurrent(now - 5_000, false, now)).toBe(true);
+  });
+
+  test("does not treat a recent stale generating snapshot as an active run", () => {
+    const sessionId = "completed-session";
+    const inactiveStatus = {
+      active: false,
+      activeSessionIds: [],
+      activeSessions: [],
+      count: 0,
+      session: {
+        sessionId,
+        status: "generating",
+        timestamp: Date.now(),
+        activities: [],
+      },
+    } satisfies MobileSessionStatusResponse;
+
+    expect(isMobileSessionStatusActive(sessionId, inactiveStatus)).toBe(false);
+    expect(
+      isMobileSessionStatusActive(sessionId, {
+        ...inactiveStatus,
+        activeSessionIds: [` ${sessionId} `],
+      })
+    ).toBe(true);
+    expect(
+      isMobileSessionStatusActive(sessionId, {
+        ...inactiveStatus,
+        active: true,
+      })
+    ).toBe(true);
   });
 
   test("replaces active compaction with its completed result", () => {

--- a/tests/mobile/markdown.test.ts
+++ b/tests/mobile/markdown.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { parseInlineMarkdown, parseMarkdownBlocks } from "../../apps/mobile/src/lib/chat-format";
+import {
+  mobileCodeLineCount,
+  parseInlineMarkdown,
+  parseMarkdownBlocks,
+} from "../../apps/mobile/src/lib/chat-format";
 
 describe("parseInlineMarkdown", () => {
   test("plain text is a single text token", () => {
@@ -13,7 +17,10 @@ describe("parseInlineMarkdown", () => {
       { type: "text", text: " c" },
     ]);
     expect(parseInlineMarkdown("*x*")).toEqual([{ type: "italic", text: "x" }]);
-    expect(parseInlineMarkdown("use `code` here")[1]).toEqual({ type: "code", text: "code" });
+    expect(parseInlineMarkdown("use `code` here")[1]).toEqual({
+      type: "code",
+      text: "code",
+    });
     expect(parseInlineMarkdown("~~gone~~")).toEqual([{ type: "strike", text: "gone" }]);
   });
 
@@ -52,6 +59,33 @@ describe("parseMarkdownBlocks", () => {
     expect(ordered).toBeDefined();
   });
 
+  test("GFM task lists expose checked state without rendering raw markers", () => {
+    const blocks = parseMarkdownBlocks("- [x] shipped\n- [ ] pending\n- ordinary");
+    expect(blocks).toEqual([
+      {
+        type: "listItem",
+        ordered: false,
+        marker: "•",
+        inline: [{ type: "text", text: "shipped" }],
+        checked: true,
+      },
+      {
+        type: "listItem",
+        ordered: false,
+        marker: "•",
+        inline: [{ type: "text", text: "pending" }],
+        checked: false,
+      },
+      {
+        type: "listItem",
+        ordered: false,
+        marker: "•",
+        inline: [{ type: "text", text: "ordinary" }],
+        checked: undefined,
+      },
+    ]);
+  });
+
   test("GFM table with header + rows", () => {
     const blocks = parseMarkdownBlocks(
       "| Layer | Stack |\n| --- | --- |\n| CLI | TSX |\n| Desktop | Tauri |"
@@ -70,5 +104,13 @@ describe("parseMarkdownBlocks", () => {
   test("does not treat a lone pipe line as a table without a separator", () => {
     const blocks = parseMarkdownBlocks("a | b is just text");
     expect(blocks[0].type).toBe("paragraph");
+  });
+});
+
+describe("mobileCodeLineCount", () => {
+  test("matches desktop code metadata for trailing fenced newlines", () => {
+    expect(mobileCodeLineCount("const ok = true;\n")).toBe(1);
+    expect(mobileCodeLineCount("one\r\ntwo\r\nthree")).toBe(3);
+    expect(mobileCodeLineCount("")).toBe(0);
   });
 });

--- a/tests/mobile/metrics.test.ts
+++ b/tests/mobile/metrics.test.ts
@@ -4,11 +4,14 @@ import {
   formatMetricNumber,
   formatStorageBytes,
   hasDetailedMetrics,
+  hasMetricEndpoint,
   mergeMetricsOverview,
+  metricProgressPercent,
   metricSuccessRate,
   metricsOverviewSnapshot,
   modelTokenShareRows,
   providerTokenShareRows,
+  reconcileMetricsSnapshot,
   storageCategoryEntries,
   timeSeriesTotals,
   tokenFlowBars,
@@ -21,7 +24,7 @@ import {
 
 const overview: MetricsOverview = {
   tokenUsage: { total: 1500, input: 900, output: 500, cache: 100 },
-  fileOperations: { filesRead: 4, filesWritten: 3, filesEdited: 2 },
+  fileOperations: { filesRead: 4, filesWritten: 3, filesEdited: 2, filesSearched: 5 },
   toolCalls: { totalCalls: 8 },
   apiCalls: { totalCalls: 10, successfulCalls: 9, failedCalls: 1 },
   agentActivity: { totalExecutions: 5, totalMessages: 6 },
@@ -39,15 +42,25 @@ const storage: MetricsStorage = {
 describe("mobile metrics helpers", () => {
   test("formats core web metrics for compact native cards", () => {
     expect(formatMetricNumber(1500)).toBe("1.5K");
+    expect(formatMetricNumber(undefined)).toBe("--");
     expect(formatMetricBytes(2048)).toBe("2.0 KB");
+    expect(formatMetricBytes(undefined)).toBe("--");
     expect(formatStorageBytes(77_279_809_536)).toBe("77.28 GB");
     expect(metricSuccessRate(overview)).toBe("90.0%");
-    expect(totalFileOperations(overview)).toBe(9);
+    expect(metricSuccessRate(null)).toBe("--");
+    expect(totalFileOperations(overview)).toBe(14);
     expect(tokenFlowBars(overview)).toEqual([
       { label: "Input", value: 900 },
       { label: "Output", value: 500 },
       { label: "Cache", value: 100 },
     ]);
+  });
+
+  test("keeps zero-value chart bars visually empty", () => {
+    expect(metricProgressPercent(0, 100, 4)).toBe(0);
+    expect(metricProgressPercent(1, 100, 4)).toBe(4);
+    expect(metricProgressPercent(150, 100, 4)).toBe(100);
+    expect(metricProgressPercent(Number.NaN, 100, 4)).toBe(0);
   });
 
   test("builds and refreshes a lightweight overview without losing detailed metrics", () => {
@@ -74,6 +87,51 @@ describe("mobile metrics helpers", () => {
     expect(refreshed.storage).toBe(storage);
     expect(refreshed.availability.storage.ok).toBe(true);
     expect(hasDetailedMetrics(refreshed)).toBe(true);
+  });
+
+  test("keeps partial metric endpoint failures unavailable instead of treating them as zero", () => {
+    const partial = {
+      ...metricsOverviewSnapshot(overview),
+      tools: {
+        mostUsed: [],
+        mostErrors: [],
+        recentCalls: [],
+      },
+      availability: {
+        ...metricsOverviewSnapshot(overview).availability,
+        tools: { ok: true },
+        insights: { ok: false, error: "insights offline" },
+        sessions: { ok: false, error: "sessions offline" },
+      },
+    } satisfies MetricsSnapshot;
+
+    expect(hasMetricEndpoint(partial, "tools")).toBe(true);
+    expect(hasMetricEndpoint(partial, "insights")).toBe(false);
+    expect(hasMetricEndpoint(partial, "sessions")).toBe(false);
+    expect(hasDetailedMetrics(partial)).toBe(true);
+  });
+
+  test("preserves an overview completed after an older full snapshot request began", () => {
+    const incoming = {
+      ...metricsOverviewSnapshot(overview),
+      storage,
+      availability: {
+        ...metricsOverviewSnapshot(overview).availability,
+        storage: { ok: true },
+      },
+    } satisfies MetricsSnapshot;
+    const newerOverview = {
+      ...overview,
+      tokenUsage: { ...overview.tokenUsage, total: 2400 },
+    };
+    const current = mergeMetricsOverview(incoming, newerOverview);
+
+    const reconciled = reconcileMetricsSnapshot(current, incoming, 4, 5);
+    expect(reconciled.overview?.tokenUsage.total).toBe(2400);
+    expect(reconciled.storage).toBe(storage);
+
+    const withoutOverlap = reconcileMetricsSnapshot(current, incoming, 5, 5);
+    expect(withoutOverlap.overview?.tokenUsage.total).toBe(1500);
   });
 
   test("builds storage and time-series chart rows deterministically", () => {

--- a/tests/mobile/session-summary.test.ts
+++ b/tests/mobile/session-summary.test.ts
@@ -67,4 +67,33 @@ describe("mobile session summary reconciliation", () => {
     expect(mergeSessionDetailIntoSummary(null, detail)).toBeNull();
     expect(mergeSessionDetailIntoSummary(summary, detail)).toBe(summary);
   });
+
+  test("preserves summary identity when hydrated detail has no visible changes", () => {
+    const summary = {
+      sessions: [
+        {
+          id: "session-1",
+          title: "Complete",
+          message_count: 1,
+          updated_at: "2026-08-13T12:00:00.000Z",
+          last_message: { role: "assistant", content: "Done" },
+        },
+      ],
+    } as FeatureSummary;
+    const detail = {
+      id: "session-1",
+      title: "Complete",
+      updatedAt: "2026-08-13T12:00:00.000Z",
+      messages: [
+        {
+          id: "message-1",
+          role: "assistant",
+          content: "Done",
+          timestamp: "2026-08-13T12:00:00.000Z",
+        },
+      ],
+    } as SessionDetailSummary;
+
+    expect(mergeSessionDetailIntoSummary(summary, detail)).toBe(summary);
+  });
 });

--- a/tests/mobile/sessions.test.ts
+++ b/tests/mobile/sessions.test.ts
@@ -171,6 +171,18 @@ describe("mobile: chat management", () => {
     expect(chat).toContain("content = markdown.content");
   });
 
+  test("mobile code blocks match desktop metadata without stretching message bubbles", () => {
+    const chat = read("screens/dashboardChat.tsx");
+    const styles = readStyles();
+
+    expect(chat).toContain("mobileCodeLineCount(content)");
+    expect(chat).toContain('accessibilityLabel={copied ? "Code copied" : "Copy code"}');
+    expect(chat).toContain("style={styles.codeScroll}");
+    expect(styles).toContain("codeScroll:");
+    expect(styles).toContain("flexGrow: 0");
+    expect(styles).toContain("flexShrink: 1");
+  });
+
   test("chat images open in an in-app preview without sending bearer URLs to another app", () => {
     const chat = read("screens/dashboardChat.tsx");
 

--- a/tests/mobile/sessions.test.ts
+++ b/tests/mobile/sessions.test.ts
@@ -123,14 +123,31 @@ describe("mobile: chat management", () => {
     expect(runtime).not.toContain("requestAnimationFrame");
   });
 
-  test("Android relies on the native resize layout instead of applying the keyboard height twice", () => {
+  test("chat composer uses measured keyboard avoidance on both mobile platforms", () => {
     const screen = read("screens/dashboardSessionDetail.tsx");
 
-    expect(screen).toContain('if (Platform.OS !== "ios") return;');
-    expect(screen).toContain('Keyboard.addListener("keyboardWillShow"');
-    expect(screen).toContain('Keyboard.addListener("keyboardWillHide"');
-    expect(screen).not.toContain('"keyboardDidShow"');
-    expect(screen).not.toContain('"keyboardDidHide"');
+    expect(screen).toContain("KeyboardAvoidingView");
+    expect(screen).toContain('if (Platform.OS === "android")');
+    expect(screen).toContain('behavior="height"');
+    expect(screen).toContain("keyboardVerticalOffset={keyboardVerticalOffset}");
+    expect(screen).toContain(
+      "<ChatKeyboardContainer keyboardVerticalOffset={insets.top + spacing.xs}>"
+    );
+    expect(screen).toContain("const [keyboardVisible, setKeyboardVisible]");
+    expect(screen).toContain("const [keyboardHeight, setKeyboardHeight]");
+    expect(screen).toContain(
+      'const showEvent = Platform.OS === "ios" ? "keyboardWillShow" : "keyboardDidShow"'
+    );
+    expect(screen).toContain(
+      'const hideEvent = Platform.OS === "ios" ? "keyboardWillHide" : "keyboardDidHide"'
+    );
+    expect(screen).toContain("Keyboard.addListener(showEvent");
+    expect(screen).toContain("Keyboard.addListener(hideEvent");
+    expect(screen).toContain("setKeyboardVisible(nextKeyboardHeight > 0)");
+    expect(screen).toContain('"keyboardDidShow"');
+    expect(screen).toContain('"keyboardDidHide"');
+    expect(screen).toContain('const keyboardOffset = Platform.OS === "ios" ? keyboardHeight : 0');
+    expect(screen).toContain("keyboardOffset + spacing.xs");
   });
 
   test("saved reduce-motion settings disable live indicators", () => {

--- a/tests/mobile/sessions.test.ts
+++ b/tests/mobile/sessions.test.ts
@@ -354,6 +354,7 @@ describe("mobile: chat management", () => {
 
   test("uses authoritative active state for queueing and live timing", () => {
     const detail = read("screens/dashboardSessionDetail.tsx");
+    const runtime = read("screens/useMobileSessionRuntime.ts");
     expect(detail).toContain(
       "const chatBusy = sending || sessionActive || pendingMessages.length > 0;"
     );
@@ -362,5 +363,7 @@ describe("mobile: chat management", () => {
     expect(detail).not.toContain(
       "const chatBusy = sending || !!liveAssistant || pendingMessages.length > 0;"
     );
+    expect(runtime).toContain("const active = serverReportsActive;");
+    expect(runtime).not.toContain("snapshotStatus ===");
   });
 });

--- a/tests/mobile/settings-navigation.test.ts
+++ b/tests/mobile/settings-navigation.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import {
+  mobileBackRouteForDetail,
+  mobileSettingsTabForSurface,
+} from "../../apps/mobile/src/lib/dashboard";
+
+const dashboard = readFileSync(
+  new URL("../../apps/mobile/src/screens/DashboardScreen.tsx", import.meta.url),
+  "utf8"
+);
+const settingsPanel = readFileSync(
+  new URL("../../apps/mobile/src/screens/dashboardDetailPanels.tsx", import.meta.url),
+  "utf8"
+);
+
+function sourceBetween(source: string, start: string, end: string): string {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  return source.slice(startIndex, endIndex);
+}
+
+describe("mobile settings category navigation", () => {
+  test("Providers -> provider -> back retains the Providers category", () => {
+    expect(mobileSettingsTabForSurface("providers")).toBe("providers");
+    expect(mobileBackRouteForDetail({ kind: "item", surface: "providers" })).toEqual({
+      kind: "surface",
+      surface: "providers",
+    });
+    expect(dashboard).toContain('useState<MobileSettingsTab>("general")');
+    expect(dashboard).toContain('if (activeTab !== "settings") {');
+    expect(dashboard).toContain("const settingsTab = mobileSettingsTabForSurface(surface);");
+    expect(dashboard).toContain("if (settingsTab) setSelectedSettingsTab(settingsTab);");
+    expect(dashboard).toContain("selectedSettingsTab={selectedSettingsTab}");
+    expect(dashboard).toContain("onSelectSettingsTab={setSelectedSettingsTab}");
+    expect(settingsPanel).not.toContain(
+      "const [selectedSettingsTab, setSelectedSettingsTab] = useState"
+    );
+    expect(settingsPanel).toContain("onSelectSettingsTab(value as MobileSettingsTab)");
+  });
+
+  test("AI -> system prompt -> back retains the AI category", () => {
+    const openSystemPrompt = sourceBetween(
+      dashboard,
+      "const openSystemPrompt = () => {",
+      "const openSpeech = () => {"
+    );
+
+    expect(openSystemPrompt).toContain('setSelectedSettingsTab("ai");');
+    expect(openSystemPrompt).toContain('setDetailRoute({ kind: "systemPrompt" });');
+    expect(mobileBackRouteForDetail({ kind: "systemPrompt" })).toBeNull();
+    expect(settingsPanel).toContain("selectedSettingsTab: MobileSettingsTab;");
+  });
+});

--- a/tests/mobile/status-stream.test.ts
+++ b/tests/mobile/status-stream.test.ts
@@ -18,7 +18,10 @@ class FakeMobileWebSocket {
   sent: string[] = [];
   closed = false;
 
-  constructor(readonly url: string) {
+  constructor(
+    readonly url: string,
+    readonly protocols?: string | string[]
+  ) {
     FakeMobileWebSocket.instances.push(this);
   }
 
@@ -150,6 +153,63 @@ describe("mobile status stream", () => {
     expect(buffer.size).toBe(1);
     expect(buffer.consume(3, "s2")).toEqual([event("s2", 2)]);
     expect(buffer.size).toBe(0);
+  });
+
+  test("session subscribers consume only their buffered events from the shared socket", () => {
+    FakeMobileWebSocket.instances = [];
+    const client = new MobileStatusStreamClient(() => "ws://gateway/status", normalizeEvent);
+    const firstEvents: MobileStatusStreamEvent[] = [];
+    const secondEvents: MobileStatusStreamEvent[] = [];
+    const disconnectInitial = client.subscribe({ onEvent: () => {} }, streamOptions());
+    const socket = FakeMobileWebSocket.instances[0];
+    socket?.open();
+    disconnectInitial();
+    socket?.emit({
+      type: "assistant_token",
+      sessionId: "s1",
+      sequence: 1,
+      delta: "first",
+      timestamp: 1,
+    });
+    socket?.emit({
+      type: "assistant_token",
+      sessionId: "s2",
+      sequence: 2,
+      delta: "second",
+      timestamp: 2,
+    });
+
+    const disconnectFirst = client.subscribe(
+      { onEvent: (event) => firstEvents.push(event) },
+      streamOptions({ replayBufferedEvents: true, replaySessionId: "s1" })
+    );
+    const disconnectSecond = client.subscribe(
+      { onEvent: (event) => secondEvents.push(event) },
+      streamOptions({ closeGraceMs: 0, replayBufferedEvents: true, replaySessionId: "s2" })
+    );
+
+    expect(FakeMobileWebSocket.instances).toHaveLength(1);
+    expect(firstEvents).toEqual([
+      {
+        type: "assistant_token",
+        sessionId: "s1",
+        sequence: 1,
+        delta: "first",
+        timestamp: 1,
+      },
+    ]);
+    expect(secondEvents).toEqual([
+      {
+        type: "assistant_token",
+        sessionId: "s2",
+        sequence: 2,
+        delta: "second",
+        timestamp: 2,
+      },
+    ]);
+    disconnectFirst();
+    disconnectSecond();
+    expect(socket?.closed).toBe(true);
   });
 
   test("reconnects an unexpectedly closed active stream", async () => {

--- a/tests/runtime/app-release-surfaces.test.ts
+++ b/tests/runtime/app-release-surfaces.test.ts
@@ -285,7 +285,11 @@ describe("app release surface wiring", () => {
             NSAppTransportSecurity?: { NSAllowsLocalNetworking?: boolean };
           };
         };
-        android?: { package?: string; versionCode?: number };
+        android?: {
+          package?: string;
+          softwareKeyboardLayoutMode?: string;
+          versionCode?: number;
+        };
         plugins?: Array<string | [string, Record<string, unknown>]>;
         extra?: { gatewayContract?: string };
       };
@@ -317,6 +321,7 @@ describe("app release surface wiring", () => {
       true
     );
     expect(appJson.expo?.android?.package).toBe("com.ck.cybara");
+    expect(appJson.expo?.android?.softwareKeyboardLayoutMode).toBe("resize");
     expect(appJson.expo?.android?.versionCode).toBe(expectedVersionCode);
     expect(appJson.expo?.plugins).toContain("./plugins/with-android-lan-cleartext");
     expect(read("apps/mobile/plugins/with-android-lan-cleartext.js")).toContain(

--- a/tests/runtime/dependency-pin-policy.test.ts
+++ b/tests/runtime/dependency-pin-policy.test.ts
@@ -48,4 +48,16 @@ describe("JavaScript dependency pin policy", () => {
 
     expect(violations).toEqual([]);
   });
+
+  test("web and mobile lockfiles resolve the patched Nano ID release", () => {
+    for (const directory of ["ui", "apps/mobile"] as const) {
+      const pkg = readJson(`${directory}/package.json`);
+      const overrides = pkg.overrides as Record<string, unknown>;
+      const lockfile = readFileSync(join(ROOT_DIR, directory, "bun.lock"), "utf8");
+
+      expect(overrides.nanoid).toBe("3.3.18");
+      expect(lockfile).toContain('"nanoid": ["nanoid@3.3.18"');
+      expect(lockfile).not.toContain('"nanoid": ["nanoid@3.3.17"');
+    }
+  });
 });

--- a/tests/runtime/dependency-pin-policy.test.ts
+++ b/tests/runtime/dependency-pin-policy.test.ts
@@ -49,8 +49,8 @@ describe("JavaScript dependency pin policy", () => {
     expect(violations).toEqual([]);
   });
 
-  test("web and mobile lockfiles resolve the patched Nano ID release", () => {
-    for (const directory of ["ui", "apps/mobile"] as const) {
+  test("web, mobile, and site lockfiles resolve the patched Nano ID release", () => {
+    for (const directory of ["ui", "apps/mobile", "site"] as const) {
       const pkg = readJson(`${directory}/package.json`);
       const overrides = pkg.overrides as Record<string, unknown>;
       const lockfile = readFileSync(join(ROOT_DIR, directory, "bun.lock"), "utf8");

--- a/tests/runtime/github-actions-security.test.ts
+++ b/tests/runtime/github-actions-security.test.ts
@@ -63,6 +63,7 @@ describe("GitHub Actions security posture", () => {
     expect(workflow).toContain("--lockfile=bun.lock");
     expect(workflow).toContain("--lockfile=ui/bun.lock");
     expect(workflow).toContain("--lockfile=apps/mobile/bun.lock");
+    expect(workflow).toContain("--lockfile=site/bun.lock");
     expect(workflow).toContain("--lockfile=src-tauri/Cargo.lock");
   });
 

--- a/tests/ui/chat-finish-handoff.test.ts
+++ b/tests/ui/chat-finish-handoff.test.ts
@@ -44,7 +44,9 @@ describe("chat completion handoff (no blank chat when a run finishes)", () => {
       "prunePersistedMobileLiveAssistant(current, reconciledDetail.messages)"
     );
     expect(source).toContain("const cached = readCachedMobileLiveAssistant(sessionId);");
-    expect(source).toContain('snapshotStatus === "compacting"');
+    expect(source).toContain("isMobileSessionStatusActive(sessionId, status)");
+    expect(source).toContain("const active = serverReportsActive;");
+    expect(source).not.toContain('snapshotStatus === "compacting"');
     expect(source).not.toContain('snapshotStatus === "tool_completed"');
     expect(source).not.toMatch(
       /if \(event\.status === "idle"\) \{\s*\n\s*if \(!sendingRef\.current\) \{\s*\n\s*commitLiveAssistant\(\(\) => null, event\.timestamp\);/

--- a/ui/bun.lock
+++ b/ui/bun.lock
@@ -51,6 +51,7 @@
   "overrides": {
     "brace-expansion": "5.0.9",
     "dompurify": "3.4.13",
+    "nanoid": "3.3.18",
     "postcss": "8.5.23",
   },
   "packages": {
@@ -804,7 +805,7 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "nanoid": ["nanoid@3.3.17", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g=="],
+    "nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -55,6 +55,7 @@
   "overrides": {
     "brace-expansion": "5.0.9",
     "dompurify": "3.4.13",
+    "nanoid": "3.3.18",
     "postcss": "8.5.23"
   }
 }


### PR DESCRIPTION
## Summary

- keep the mobile chat composer above docked software keyboards
- preserve the stable iOS keyboard path to avoid chat scroll shaking
- handle Android hardware-keyboard and zero-height IME events safely
- lock Android release builds to resize keyboard layout behavior

## Verification

- Android emulator: docked Gboard, composer measured 7 px above the IME
- iOS Simulator: composer remains above the software keyboard with stable header and scroll position
- bun run check:ci
- 2,311 smoke tests passed

<!-- GITZILLA_SUMMARY -->
> [!NOTE]
> **Low Risk**
>
> **Overview**
> This release focuses on mobile chat composer keyboard handling, restructuring the dashboard to use new chat/format/metrics modules while removing the legacy advanced-settings panel, and adjusting Android configuration for stable keyboard layout behavior. iOS preserves its existing keyboard path to avoid scroll shaking, and Android adds guards for hardware-keyboard and zero-height IME edge cases. Supporting infrastructure updates include OSV scanning, dependency pinning enforcement, API type/normalizer alignment, runtime test coverage, and a new settings-navigation test suite. All formatters, tests, and CI checks pass per `bun run check:ci`.
>
> <sup>Written by [Gitzilla](https://gitzilla.ai) for commit 4476ace. This will update automatically on new runs. Configure in the [Gitzilla dashboard](https://gitzilla.ai/dashboard).</sup>
<!-- /GITZILLA_SUMMARY -->