### PR TITLE
Fix Windows LAN pairing and refresh provider models

### DIFF
--- a/shared/chat-status.ts
+++ b/shared/chat-status.ts
@@ -11,6 +11,11 @@ export function isProviderRecoveryStatusLabel(value: unknown): boolean {
   return PROVIDER_RECOVERY_PREFIXES.some((prefix) => normalized.startsWith(prefix));
 }
 
+export function isDelegatedWaitStatusLabel(value: unknown): boolean {
+  if (typeof value !== "string") return false;
+  return /^waiting for \d+ delegated tasks?\.\.\.$/i.test(value.trim());
+}
+
 export function isVisibleActivityText(value: unknown): value is string {
   return (
     typeof value === "string" &&

--- a/src/api/chat-runtime.ts
+++ b/src/api/chat-runtime.ts
@@ -1634,7 +1634,7 @@ async function handleChatTurn(
         responseContent = recoveredResponse.responseContent;
         toolResults = recoveredResponse.toolResults;
       }
-
+      let automaticWaitCompleted = false;
       if (!executionFailure) {
         const automaticWait = await awaitSpawnedSubagentResults({
           abortSignal: turnAbortController.signal,
@@ -1654,6 +1654,7 @@ async function handleChatTurn(
         if (automaticWait) {
           toolResults = [...toolResults, automaticWait];
           responseContent = "";
+          automaticWaitCompleted = true;
         }
       }
 
@@ -1675,8 +1676,27 @@ async function handleChatTurn(
           timeoutSeconds: memorySettings.backgroundReviewTimeoutSeconds,
         }
       ).catch(() => undefined);
-
       if (toolResults.length > 0) {
+        const resolvedToolResponse = await resolveToolResponseContent({
+          abortSignal: turnAbortController.signal,
+          agentId: agent.id,
+          channel,
+          executionFailure,
+          executionMessages,
+          maxOutputTokens: request.maxOutputTokens,
+          message,
+          modelOverride: activeModelOverride,
+          modelParamsOverride: request.modelParamsOverride,
+          responseContent,
+          reconcileTodo: automaticWaitCompleted,
+          sessionId: session.id,
+          toolResults,
+          useModelRouter,
+          userId,
+          workspaceDir: session.workspaceDir || undefined,
+        });
+        responseContent = resolvedToolResponse.responseContent;
+        toolResults.push(...resolvedToolResponse.toolResults);
         for (const tc of toolResults) {
           const timelineIndex = allToolCalls.length;
           const outcome = classifyToolCallResult(tc.result);
@@ -1700,23 +1720,6 @@ async function handleChatTurn(
             timeline_index: timelineIndex,
           });
         }
-        responseContent = await resolveToolResponseContent({
-          abortSignal: turnAbortController.signal,
-          agentId: agent.id,
-          channel,
-          executionFailure,
-          executionMessages,
-          maxOutputTokens: request.maxOutputTokens,
-          message,
-          modelOverride: activeModelOverride,
-          modelParamsOverride: request.modelParamsOverride,
-          responseContent,
-          sessionId: session.id,
-          toolResults,
-          useModelRouter,
-          userId,
-          workspaceDir: session.workspaceDir || undefined,
-        });
       }
 
       if (provider) {

--- a/src/api/chat-runtime.ts
+++ b/src/api/chat-runtime.ts
@@ -104,6 +104,7 @@ import {
 } from "./chat-provider-failure";
 import { appendToolImageReferences, maybeSaveAutomaticMemory } from "./chat-response-enrichment";
 import { recoverAssistantResponse } from "./chat-response-recovery";
+import { awaitSpawnedSubagentResults } from "./chat-subagent-completion";
 import {
   interruptActiveChatTurnForSteering,
   isChatTurnInterrupted,
@@ -1632,6 +1633,28 @@ async function handleChatTurn(
         }
         responseContent = recoveredResponse.responseContent;
         toolResults = recoveredResponse.toolResults;
+      }
+
+      if (!executionFailure) {
+        const automaticWait = await awaitSpawnedSubagentResults({
+          abortSignal: turnAbortController.signal,
+          agentId: agent.id,
+          sessionId: session.id,
+          toolResults,
+          onWaiting: (pendingCount) => {
+            broadcastStatus({
+              status: "thinking",
+              timestamp: Date.now(),
+              detail: `Waiting for ${pendingCount} delegated ${pendingCount === 1 ? "task" : "tasks"}...`,
+              sessionId: session.id,
+              agentId: agent?.id,
+            });
+          },
+        });
+        if (automaticWait) {
+          toolResults = [...toolResults, automaticWait];
+          responseContent = "";
+        }
       }
 
       const memorySettings = config.getMemoryBehaviorSettings();

--- a/src/api/chat-subagent-completion.ts
+++ b/src/api/chat-subagent-completion.ts
@@ -1,0 +1,99 @@
+import type { AgentToolCallResult } from "../core/agent-internals";
+import { handleSessionsWait } from "../core/tools/handlers/channel";
+
+interface SpawnResult {
+  runId?: unknown;
+  status?: unknown;
+}
+
+interface WaitRunResult {
+  runId?: unknown;
+  status?: unknown;
+}
+
+interface WaitResult {
+  runs?: unknown;
+}
+
+interface AwaitSpawnedSubagentsOptions {
+  abortSignal: AbortSignal;
+  agentId: string;
+  sessionId: string;
+  toolResults: AgentToolCallResult[];
+  onWaiting: (pendingCount: number) => void;
+}
+
+const TERMINAL_RUN_STATUSES = new Set(["completed", "failed", "timeout", "killed"]);
+
+function objectValue(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function acceptedSpawnRunIds(toolResults: AgentToolCallResult[]): string[] {
+  return toolResults.flatMap((toolCall) => {
+    if (toolCall.name !== "sessions_spawn") return [];
+    const result = objectValue(toolCall.result) as SpawnResult | undefined;
+    return result?.status === "accepted" && typeof result.runId === "string" && result.runId.trim()
+      ? [result.runId.trim()]
+      : [];
+  });
+}
+
+function retrievedTerminalRunIds(toolResults: AgentToolCallResult[]): Set<string> {
+  const runIds = new Set<string>();
+  for (const toolCall of toolResults) {
+    if (toolCall.name !== "sessions_wait") continue;
+    const result = objectValue(toolCall.result) as WaitResult | undefined;
+    if (!Array.isArray(result?.runs)) continue;
+    for (const candidate of result.runs) {
+      const run = objectValue(candidate) as WaitRunResult | undefined;
+      if (
+        typeof run?.runId === "string" &&
+        typeof run.status === "string" &&
+        TERMINAL_RUN_STATUSES.has(run.status)
+      ) {
+        runIds.add(run.runId);
+      }
+    }
+  }
+  return runIds;
+}
+
+export function unresolvedSpawnRunIds(toolResults: AgentToolCallResult[]): string[] {
+  const retrieved = retrievedTerminalRunIds(toolResults);
+  return [...new Set(acceptedSpawnRunIds(toolResults))].filter((runId) => !retrieved.has(runId));
+}
+
+export async function awaitSpawnedSubagentResults(
+  options: AwaitSpawnedSubagentsOptions
+): Promise<AgentToolCallResult | undefined> {
+  const runIds = unresolvedSpawnRunIds(options.toolResults);
+  if (runIds.length === 0) return undefined;
+
+  const startedAt = Date.now();
+  let pendingRunIds = runIds;
+  let result: Awaited<ReturnType<typeof handleSessionsWait>> | undefined;
+
+  while (pendingRunIds.length > 0) {
+    options.onWaiting(pendingRunIds.length);
+    result = await handleSessionsWait(
+      { runIds, timeoutSeconds: 60 },
+      {
+        abortSignal: options.abortSignal,
+        agentId: options.agentId,
+        sessionId: options.sessionId,
+      }
+    );
+    pendingRunIds = result.pendingRunIds;
+  }
+
+  return {
+    id: `auto-wait-${crypto.randomUUID()}`,
+    name: "sessions_wait",
+    args: { runIds },
+    result,
+    duration: Math.max(0, Date.now() - startedAt),
+  };
+}

--- a/src/api/chat-tool-response.ts
+++ b/src/api/chat-tool-response.ts
@@ -1,4 +1,5 @@
 import { agentManager, type AgentExecutionFailure, type AgentMessage } from "../core/agent";
+import type { AgentToolCallResult } from "../core/agent-internals";
 import { formatToolResultPromptBlock } from "../core/chat-token-optimization";
 import { config } from "../core/config";
 import { INTERRUPTED_RESPONSE } from "./chat-interruption";
@@ -21,6 +22,7 @@ interface ResolveToolResponseOptions {
   modelOverride?: string;
   modelParamsOverride?: Record<string, unknown>;
   responseContent: string;
+  reconcileTodo?: boolean;
   sessionId: string;
   toolResults: ToolResponseResult[];
   useModelRouter?: boolean;
@@ -28,10 +30,29 @@ interface ResolveToolResponseOptions {
   workspaceDir?: string;
 }
 
+export interface ResolvedToolResponse {
+  responseContent: string;
+  toolResults: AgentToolCallResult[];
+}
+
+function hasIncompleteTodo(toolResults: ToolResponseResult[]): boolean {
+  const latestTodo = [...toolResults].reverse().find((toolCall) => toolCall.name === "todo");
+  if (!latestTodo?.result || typeof latestTodo.result !== "object") return false;
+  const items = (latestTodo.result as { items?: unknown }).items;
+  if (!Array.isArray(items)) return false;
+  return items.some((item) => {
+    if (!item || typeof item !== "object") return false;
+    const status = (item as { status?: unknown }).status;
+    return status === "pending" || status === "in_progress";
+  });
+}
+
 export async function resolveToolResponseContent(
   options: ResolveToolResponseOptions
-): Promise<string> {
-  if (options.responseContent.trim()) return options.responseContent;
+): Promise<ResolvedToolResponse> {
+  if (options.responseContent.trim()) {
+    return { responseContent: options.responseContent, toolResults: [] };
+  }
   const fallback = options.executionFailure
     ? INTERRUPTED_RESPONSE
     : buildNoUsableAssistantResponseMessage();
@@ -53,7 +74,12 @@ export async function resolveToolResponseContent(
       : "Answer directly and concisely with the verified result.",
     `Latest request: ${options.message}`,
     `Observed tool results:\n${toolResultsText}`,
+    options.reconcileTodo && hasIncompleteTodo(options.toolResults)
+      ? "Use the todo tool once to reconcile the full plan with the completed delegated results before answering. Mark only work established by the results as completed and preserve genuinely unfinished work."
+      : "",
   ].join("\n\n");
+  const shouldReconcileTodo =
+    options.reconcileTodo === true && hasIncompleteTodo(options.toolResults);
   try {
     const result = await agentManager.execute(
       options.agentId,
@@ -69,11 +95,17 @@ export async function resolveToolResponseContent(
         modelParamsOverride: options.modelParamsOverride,
         useModelRouter: options.useModelRouter,
         useMemory: false,
-        useTools: false,
+        useTools: shouldReconcileTodo,
+        allowedToolNames: shouldReconcileTodo ? ["todo"] : undefined,
+        requireToolUse: shouldReconcileTodo,
+        requiredToolName: shouldReconcileTodo ? "todo" : undefined,
       }
     );
-    return result.failure || !result.content.trim() ? fallback : result.content;
+    return {
+      responseContent: result.failure || !result.content.trim() ? fallback : result.content,
+      toolResults: result.tool_calls || [],
+    };
   } catch {
-    return fallback;
+    return { responseContent: fallback, toolResults: [] };
   }
 }

--- a/src/api/gateway-network.ts
+++ b/src/api/gateway-network.ts
@@ -37,6 +37,20 @@ export function readRuntimeGatewayHost(): string {
   return readConfiguredGatewayHost();
 }
 
+function validGatewayPort(value: unknown): number | undefined {
+  const port = Number(value);
+  return Number.isInteger(port) && port > 0 && port < 65536 ? port : undefined;
+}
+
+export function readRuntimeGatewayPort(): number {
+  return (
+    validGatewayPort(process.env.CYBARA_RUNTIME_PORT) ??
+    validGatewayPort(process.env.PORT) ??
+    validGatewayPort(config.get<unknown>("port")) ??
+    4269
+  );
+}
+
 export function normalizeGatewayBindHost(value: unknown): string {
   if (typeof value !== "string") {
     throw new Error("host must be a string");
@@ -73,7 +87,7 @@ export function gatewayAuthSettingsResponse() {
     success: true,
     ...getGatewayAuthSettings(),
     ...gatewayNetworkSettings(),
-    port: Number(process.env.PORT) || config.get<number>("port") || 4269,
+    port: readRuntimeGatewayPort(),
     configuredPort: config.get<number>("port") || 4269,
     portForced: Boolean(Number(process.env.PORT)),
   };
@@ -299,7 +313,7 @@ export function updateGatewayHostSetting(
     hostApplyError: apply.error,
     gatewayFirewall: ensureWindowsGatewayFirewallRule({
       host: nextHost,
-      port: options.port || Number(process.env.PORT) || config.get<number>("port") || 4269,
+      port: options.port || readRuntimeGatewayPort(),
     }),
   };
 }

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -372,9 +372,7 @@ const routes: Record<string, RouteHandler> = {
     }
 
     if (data.host !== undefined) {
-      const hostApply = updateGatewayHostSetting(data.host, data.applyHostNow, {
-        port: Number(process.env.PORT) || config.get<number>("port") || 4269,
-      });
+      const hostApply = updateGatewayHostSetting(data.host, data.applyHostNow);
       if (data.applyHostNow === true) return { ...gatewayAuthSettingsResponse(), ...hostApply };
     }
 

--- a/src/cli/commands/chat.ts
+++ b/src/cli/commands/chat.ts
@@ -113,6 +113,11 @@ interface CliProcessActivity {
 interface CliChatResponse {
   sessionId?: string;
   queued?: boolean;
+  interrupted?: boolean;
+  failure?: {
+    category?: string;
+    retryable?: boolean;
+  };
   agent?: { id?: string };
   message?: {
     content?: unknown;
@@ -619,10 +624,21 @@ export async function rawAgent(rawArgs: string[]): Promise<void> {
 
   const content = extractTextContent(res.message?.content || "");
   if (json) {
-    console.log(JSON.stringify({ sessionId: res.sessionId, content }));
+    const toolCalls = collectToolCalls(res);
+    const processActivities = collectActivities(res);
+    console.log(
+      JSON.stringify({
+        sessionId: res.sessionId,
+        content,
+        ...(toolCalls.length > 0 ? { toolCalls } : {}),
+        ...(processActivities.length > 0 ? { processActivities } : {}),
+        ...(res.interrupted === true ? { interrupted: true, failure: res.failure ?? null } : {}),
+      })
+    );
   } else {
     console.log(formatMarkdownForTerminal(content));
   }
+  if (res.interrupted === true) process.exitCode = 1;
 }
 
 async function rawChatPendingCommand(rawArgs: string[]): Promise<boolean> {

--- a/src/cli/commands/chat.ts
+++ b/src/cli/commands/chat.ts
@@ -10,6 +10,7 @@ import {
   formatTokenUsageLine,
   shortPath,
   subagentsFromResponse,
+  subagentListPath,
   tasksFromResponse,
 } from "../tui/chat-environment";
 import { resolveAgentIdentifier } from "./agent-resolution";
@@ -795,7 +796,7 @@ async function printEnvironment(sessionId: string): Promise<void> {
   const [snapshot, taskResponse, subagentResponse] = await Promise.all([
     fetchSessionEnvironment(sessionId),
     chatContext().fetchAPI<unknown>("/api/tasks"),
-    chatContext().fetchAPI<unknown>("/api/subagents"),
+    chatContext().fetchAPI<unknown>(subagentListPath(sessionId)),
   ]);
   const tasks = tasksFromResponse(taskResponse);
   const subagents = subagentsFromResponse(subagentResponse);
@@ -1213,7 +1214,7 @@ async function rawChat(options: CliChatOptions): Promise<void> {
     if (command === "subagent" || command === "subagents") {
       const [subcommand, ...subRest] = rest;
       if (subcommand !== "spawn") {
-        const response = await chatContext().fetchAPI<unknown>("/api/subagents");
+        const response = await chatContext().fetchAPI<unknown>(subagentListPath(sessionId));
         const subagents = subagentsFromResponse(response);
         if (subagents.length === 0) {
           console.log("  No subagents");
@@ -1239,6 +1240,7 @@ async function rawChat(options: CliChatOptions): Promise<void> {
         body: JSON.stringify({
           task,
           agentId,
+          requesterSessionId: sessionId,
           model: useModelRouter ? undefined : modelOverride,
           workspaceDir,
           cleanup: "keep",

--- a/src/cli/tui/chat-environment.ts
+++ b/src/cli/tui/chat-environment.ts
@@ -133,6 +133,11 @@ export function shortPath(path: string, max = 42): string {
   return tail.length <= max - 2 ? `…/${tail}` : `…${tail.slice(-(max - 1))}`;
 }
 
+export function subagentListPath(sessionId?: string): string {
+  const key = sessionId?.trim();
+  return key ? `/api/subagents?sessionId=${encodeURIComponent(key)}` : "/api/subagents";
+}
+
 export function contextUsageFromDetail(detail: unknown): TuiContextUsage | null {
   if (!isRecord(detail) || !isRecord(detail.contextUsage)) return null;
   const usage = detail.contextUsage;
@@ -141,10 +146,12 @@ export function contextUsageFromDetail(detail: unknown): TuiContextUsage | null 
   const contextWindow =
     asNumber(usage.contextWindow) ||
     asNumber(usage.contextWindowTokens) ||
+    asNumber(usage.limitTokens) ||
     asNumber(usage.maxTokens);
   const percentage =
     asNumber(usage.percentage) ||
     asNumber(usage.percent) ||
+    asNumber(usage.usedPercent) ||
     (contextWindow > 0 ? Math.round((tokensUsed / contextWindow) * 100) : 0);
   return {
     tokensUsed,

--- a/src/cli/tui/components/interactive-chat-status.ts
+++ b/src/cli/tui/components/interactive-chat-status.ts
@@ -1,5 +1,8 @@
 import React from "react";
-import { isProviderRecoveryStatusLabel } from "../../../../shared/chat-status";
+import {
+  isDelegatedWaitStatusLabel,
+  isProviderRecoveryStatusLabel,
+} from "../../../../shared/chat-status";
 import {
   maintainTUIStatusStream,
   reconcileTUIStreamingText,
@@ -114,6 +117,7 @@ export function useInteractiveChatStatus({
       setStreamDetail(
         event.detail && !isProviderRecoveryStatusLabel(event.detail) ? event.detail : ""
       );
+      if (isDelegatedWaitStatusLabel(event.detail)) setStreamingText("");
       if (!event.toolPhase && !event.toolName) return;
       const phase = event.toolPhase || (event.status === "error" ? "error" : "result");
       const id = event.toolCallId || `${event.toolName || "activity"}-${event.timestamp}`;

--- a/src/cli/tui/components/interactive-chat.tsx
+++ b/src/cli/tui/components/interactive-chat.tsx
@@ -22,6 +22,7 @@ import {
   formatTokenUsageLine,
   messagesFromDetail,
   subagentsFromResponse,
+  subagentListPath,
   tasksForSession,
   type TuiEnvironmentSnapshot,
   type TuiLspSummary,
@@ -337,9 +338,7 @@ export function InteractiveChatTUI({
       setSubagents([]);
       return [];
     }
-    const response = await fetchAPI<unknown>(
-      "/api/subagents?sessionId=" + encodeURIComponent(targetSessionId),
-    );
+    const response = await fetchAPI<unknown>(subagentListPath(targetSessionId));
     const next = subagentsFromResponse(response);
     setSubagents(next);
     return next;
@@ -1011,7 +1010,7 @@ export function InteractiveChatTUI({
               task,
               agentId: selectedAgentId || undefined,
               model: useModelRouter ? undefined : modelOverride || undefined,
-              sessionId: localSessionId || undefined,
+              requesterSessionId: localSessionId || undefined,
             }),
           });
           const spawnedId =

--- a/src/core/providers.ts
+++ b/src/core/providers.ts
@@ -689,7 +689,7 @@ export function getDefaultModel(providerType: string): string {
     venice: "zai-org-glm-5",
     "z.ai": "glm-5.2",
     zai: "glm-5.2",
-    "z.ai-coding": "glm-5.2",
+    "z.ai-coding": "glm-5.3",
     xiaomi: "mimo-v2.5-pro",
     opencode_zen: "claude-opus-5",
     commandcode: "claude-opus-5",

--- a/src/core/providers/catalog-cloud.ts
+++ b/src/core/providers/catalog-cloud.ts
@@ -8,6 +8,14 @@ const XAI_GROK_PROXY_BASE_URL = "https://cli-chat-proxy.grok.com/v1";
 
 const QWEN_TOKEN_PLAN_MODELS = [
   {
+    id: "qwen3.8-max",
+    name: "Qwen3.8 Max",
+    context: 1000000,
+    maxTokens: 65536,
+    reasoning: true,
+    input: ["text", "image"],
+  },
+  {
     id: "qwen3.7-max",
     name: "Qwen3.7 Max",
     context: 1000000,

--- a/src/core/providers/catalog-coding.ts
+++ b/src/core/providers/catalog-coding.ts
@@ -926,6 +926,15 @@ export const codingProviderCatalog = {
     authType: "api_key",
     models: [
       {
+        id: "glm-5.3",
+        name: "GLM-5.3 (Coding)",
+        context: 1000000,
+        maxTokens: 131072,
+        reasoning: true,
+        input: ["text"],
+        code: true,
+      },
+      {
         id: "glm-5.2",
         name: "GLM-5.2 (Coding)",
         context: 1000000,

--- a/src/core/subagent-registry.ts
+++ b/src/core/subagent-registry.ts
@@ -1,10 +1,11 @@
 import { randomUUID } from "crypto";
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "fs";
 import { join } from "path";
-import { homedir, tmpdir } from "os";
+import { tmpdir } from "os";
 import { EventEmitter } from "events";
 import { redactSecrets, redactSecretText } from "./redaction";
 import { formatRecoverableToolOutputPreview } from "./tool-output-recovery";
+import { cybaraDir } from "./paths";
 
 export interface SubagentActivity {
   id: string;
@@ -78,7 +79,7 @@ interface SubagentConfig {
 const defaultPersistPath =
   process.env.NODE_ENV === "test"
     ? join(tmpdir(), `cybara-subagent-registry-${process.pid}.json`)
-    : join(homedir(), ".cybara", "subagent-registry.json");
+    : join(cybaraDir, "subagent-registry.json");
 
 const DEFAULT_CONFIG: SubagentConfig = {
   archiveAfterMinutes: 60,
@@ -248,6 +249,12 @@ function resolveRunTimeoutMs(runTimeoutSeconds: number | undefined): number | un
   return Math.floor(seconds) * 1000;
 }
 
+function scheduleRunArchive(entry: SubagentRunRecord, endedAt: number): void {
+  const archiveAfterMs = resolveArchiveAfterMs();
+  entry.archiveAtMs = archiveAfterMs ? endedAt + archiveAfterMs : undefined;
+  if (entry.archiveAtMs) startSweeper();
+}
+
 function startSweeper(): void {
   if (sweeper) return;
   sweeper = setInterval(() => {
@@ -327,6 +334,7 @@ function ensureListener(): void {
     if (evt.type === "end" || evt.type === "error") {
       const endedAt = typeof evt.data?.endedAt === "number" ? evt.data.endedAt : Date.now();
       entry.endedAt = endedAt;
+      scheduleRunArchive(entry, endedAt);
 
       if (evt.type === "error") {
         const error = typeof evt.data?.error === "string" ? evt.data.error : undefined;
@@ -341,7 +349,7 @@ function ensureListener(): void {
 
       persistSubagentRuns();
 
-      if (beginSubagentCleanup(evt.runId)) {
+      if (entry.cleanup === "keep" && beginSubagentCleanup(evt.runId)) {
         finalizeSubagentCleanup(evt.runId, entry.cleanup);
       }
     }
@@ -394,16 +402,13 @@ function restoreSubagentRunsOnce(): void {
         entry.cleanupHandled = true;
         entry.cleanupCompletedAt = restoredAt;
       }
-      if (entry.cleanup === "delete") continue;
+      scheduleRunArchive(entry, entry.endedAt);
       if (!subagentRuns.has(runId)) {
         subagentRuns.set(runId, entry);
       }
     }
 
     ensureListener();
-    if ([...subagentRuns.values()].some((e) => e.archiveAtMs)) {
-      startSweeper();
-    }
     persistSubagentRuns();
 
     console.log(`[Subagent] Restored ${restored.size} runs from disk`);
@@ -463,8 +468,6 @@ export function registerSubagentRun(params: {
 }): SubagentRunRecord {
   const runId = params.runId || randomUUID();
   const now = Date.now();
-  const archiveAfterMs = resolveArchiveAfterMs();
-  const archiveAtMs = archiveAfterMs ? now + archiveAfterMs : undefined;
   const timeoutMs = resolveRunTimeoutMs(params.runTimeoutSeconds);
 
   const run: SubagentRunRecord = {
@@ -482,17 +485,12 @@ export function registerSubagentRun(params: {
     silent: params.silent === true,
     createdAt: now,
     startedAt: now,
-    archiveAtMs,
     cleanupHandled: false,
   };
 
   subagentRuns.set(runId, run);
   ensureListener();
   persistSubagentRuns();
-
-  if (archiveAfterMs) {
-    startSweeper();
-  }
 
   if (timeoutMs) {
     void waitForSubagentCompletion(runId, timeoutMs);
@@ -581,6 +579,7 @@ export function markRunKilled(runId: string): boolean {
 
   entry.endedAt = Date.now();
   entry.outcome = { status: "killed" };
+  scheduleRunArchive(entry, entry.endedAt);
   persistSubagentRuns();
 
   const timer = runTimers.get(runId);

--- a/src/core/tools/handlers/channel.ts
+++ b/src/core/tools/handlers/channel.ts
@@ -415,12 +415,18 @@ export async function handleSessionsWait(
     .filter((run): run is SubagentRunRecord => Boolean(run));
   const pendingRunIds = completedRuns.filter((run) => !run.endedAt).map((run) => run.runId);
   const finishedCount = completedRuns.length - pendingRunIds.length;
-  return {
+  const result = {
     status: pendingRunIds.length === 0 ? "completed" : finishedCount > 0 ? "partial" : "timeout",
     runs: completedRuns.map(subagentWaitResult),
     pendingRunIds,
     elapsedMs: Date.now() - startedAt,
-  };
+  } as const;
+  if (pendingRunIds.length === 0) {
+    for (const run of completedRuns) {
+      if (run.cleanup === "delete") subagentRegistry.releaseSubagentRun(run.runId);
+    }
+  }
+  return result;
 }
 
 function buildSubagentSystemPrompt(

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,10 @@ import {
   stopActiveChatTurn,
 } from "./api/chat";
 import { getClientIp } from "./api/client-ip";
-import { setGatewayHostApplyHandler } from "./api/gateway-network";
+import {
+  ensureWindowsGatewayFirewallRule,
+  setGatewayHostApplyHandler,
+} from "./api/gateway-network";
 import { gatewayRequestIdleTimeoutSeconds } from "./api/gateway-request-timeout";
 import { createLivenessPayload, isLivenessProbe } from "./api/health-probe";
 import { classifyRequestBodyReadFailure, readRequestText } from "./api/request-body";
@@ -1059,6 +1062,14 @@ function createInitialGatewayServer(hostname: string): ReturnType<typeof Bun.ser
 }
 
 let gatewayServer = createInitialGatewayServer(runtimeHost);
+const startupGatewayFirewall = ensureWindowsGatewayFirewallRule({ host: runtimeHost, port: PORT });
+if (startupGatewayFirewall.required) {
+  const method = startupGatewayFirewall.configured ? console.log : console.warn;
+  method(`[Gateway] ${startupGatewayFirewall.message}`);
+  if (!startupGatewayFirewall.configured && startupGatewayFirewall.command) {
+    console.warn(`[Gateway] Run as Administrator: ${startupGatewayFirewall.command}`);
+  }
+}
 if (process.env.CYBARA_GATEWAY_PORT_SIGNAL === "stdout") {
   console.log(gatewayPortSignal(PORT));
 }

--- a/tests/api/chat-plan-sanitization.test.ts
+++ b/tests/api/chat-plan-sanitization.test.ts
@@ -21,7 +21,7 @@ describe("chat plan API sanitization", () => {
                 { content: "inspect", status: "completed", priority: "high" },
                 { content: "test", status: "pending", priority: "medium" },
               ],
-              summary: { total: 2, pending: 1, inProgress: 0, completed: 1 },
+              summary: { total: 2, pending: 1, inProgress: 0, completed: 1, cancelled: 0 },
               note: "Task list updated",
             },
           },
@@ -36,7 +36,7 @@ describe("chat plan API sanitization", () => {
         { content: "inspect", status: "completed", priority: "high" },
         { content: "test", status: "pending", priority: "medium" },
       ],
-      summary: { total: 2, pending: 1, inProgress: 0, completed: 1 },
+      summary: { total: 2, pending: 1, inProgress: 0, completed: 1, cancelled: 0 },
       note: "Task list updated",
     });
   });

--- a/tests/api/chat-subagent-completion.test.ts
+++ b/tests/api/chat-subagent-completion.test.ts
@@ -12,6 +12,7 @@ import {
   registerSubagentRun,
   releaseSubagentRun,
 } from "../../src/core/subagent-registry";
+import { getActiveSessionRunId } from "../../src/core/session-event-ledger";
 import { onStatusStream } from "../../src/core/status";
 
 const createdAgentIds: string[] = [];
@@ -40,6 +41,14 @@ function spawnToolCall(runId: string): AgentToolCallResult {
       task: "inspect lifecycle",
     },
   };
+}
+
+async function waitForCondition(predicate: () => boolean, timeoutMs = 1_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error("Timed out waiting for condition");
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
 }
 
 describe("chat subagent completion", () => {
@@ -142,10 +151,22 @@ describe("chat subagent completion", () => {
         sessionId,
         tools: true,
       });
-      await new Promise((resolve) => setTimeout(resolve, 25));
+      let responseSettled = false;
+      void responsePromise.then(() => {
+        responseSettled = true;
+      });
+      await waitForCondition(() => statusDetails.at(-1) === "Waiting for 1 delegated task...");
+
+      expect(responseSettled).toBe(false);
+      expect(getActiveSessionRunId(sessionId)).toBeDefined();
+      expect(statusDetails.at(-1)).toBe("Waiting for 1 delegated task...");
+      expect(executionCount).toBe(1);
+
       markRunCompleted(run.runId, "CHILD_RESULT=verified");
       const response = await responsePromise;
 
+      expect(responseSettled).toBe(true);
+      expect(getActiveSessionRunId(sessionId)).toBeUndefined();
       expect(response.message.content).toBe("The delegated check finished: CHILD_RESULT=verified");
       expect(response.message.tool_calls?.map((toolCall) => toolCall.name)).toEqual([
         "sessions_spawn",

--- a/tests/api/chat-subagent-completion.test.ts
+++ b/tests/api/chat-subagent-completion.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { deleteSession, handleChat } from "../../src/api/chat";
+import {
+  awaitSpawnedSubagentResults,
+  unresolvedSpawnRunIds,
+} from "../../src/api/chat-subagent-completion";
+import { agentManager } from "../../src/core/agent";
+import type { AgentToolCallResult } from "../../src/core/agent-internals";
+import { providerManager } from "../../src/core/providers";
+import {
+  markRunCompleted,
+  registerSubagentRun,
+  releaseSubagentRun,
+} from "../../src/core/subagent-registry";
+import { onStatusStream } from "../../src/core/status";
+
+const createdAgentIds: string[] = [];
+const createdProviderIds: string[] = [];
+const createdSessionIds: string[] = [];
+const createdRunIds: string[] = [];
+const originalExecute = agentManager.execute.bind(agentManager);
+
+afterEach(async () => {
+  agentManager.execute = originalExecute;
+  for (const sessionId of createdSessionIds.splice(0)) await deleteSession(sessionId);
+  for (const runId of createdRunIds.splice(0)) releaseSubagentRun(runId);
+  for (const agentId of createdAgentIds.splice(0)) agentManager.delete(agentId);
+  for (const providerId of createdProviderIds.splice(0)) providerManager.delete(providerId);
+});
+
+function spawnToolCall(runId: string): AgentToolCallResult {
+  return {
+    id: `spawn-${runId}`,
+    name: "sessions_spawn",
+    args: { task: "inspect lifecycle" },
+    result: {
+      status: "accepted",
+      childSessionKey: `agent:child:subagent:${runId}`,
+      runId,
+      task: "inspect lifecycle",
+    },
+  };
+}
+
+describe("chat subagent completion", () => {
+  test("identifies accepted runs that do not have a terminal wait result", () => {
+    const pending = spawnToolCall("run-pending");
+    const completedWait: AgentToolCallResult = {
+      id: "wait-completed",
+      name: "sessions_wait",
+      args: { runIds: ["run-completed"] },
+      result: {
+        status: "completed",
+        pendingRunIds: [],
+        runs: [{ runId: "run-completed", status: "completed" }],
+      },
+    };
+
+    expect(unresolvedSpawnRunIds([spawnToolCall("run-completed"), pending, completedWait])).toEqual(
+      ["run-pending"]
+    );
+  });
+
+  test("waits for a delegated run and returns a synthesis-ready tool result", async () => {
+    const sessionId = `subagent-await-${crypto.randomUUID()}`;
+    const run = registerSubagentRun({
+      childSessionKey: `agent:child:subagent:${crypto.randomUUID()}`,
+      requesterSessionKey: sessionId,
+      task: "inspect lifecycle",
+    });
+    createdRunIds.push(run.runId);
+    const waitingCounts: number[] = [];
+    const waiting = awaitSpawnedSubagentResults({
+      abortSignal: new AbortController().signal,
+      agentId: "parent-agent",
+      sessionId,
+      toolResults: [spawnToolCall(run.runId)],
+      onWaiting: (count) => waitingCounts.push(count),
+    });
+
+    setTimeout(() => markRunCompleted(run.runId, "CHILD_RESULT=ready"), 20);
+    const result = await waiting;
+
+    expect(waitingCounts).toEqual([1]);
+    expect(result?.name).toBe("sessions_wait");
+    expect(result?.result).toEqual(
+      expect.objectContaining({
+        status: "completed",
+        pendingRunIds: [],
+        runs: [expect.objectContaining({ result: "CHILD_RESULT=ready", status: "completed" })],
+      })
+    );
+  });
+
+  test("keeps the chat active until its child finishes and synthesizes the child result", async () => {
+    const provider = providerManager.create({
+      provider: "openai",
+      name: "Automatic Subagent Wait Provider",
+      api_key: "automatic-subagent-wait-key",
+    });
+    createdProviderIds.push(provider.id);
+    const agent = agentManager.create({
+      name: "Automatic Subagent Wait Agent",
+      type: "main",
+      provider_id: provider.id,
+      model: "glm-5.3",
+      memory_enabled: false,
+    });
+    createdAgentIds.push(agent.id);
+    const sessionId = `automatic-subagent-wait-${crypto.randomUUID()}`;
+    createdSessionIds.push(sessionId);
+    const run = registerSubagentRun({
+      childSessionKey: `agent:child:subagent:${crypto.randomUUID()}`,
+      requesterSessionKey: sessionId,
+      task: "inspect lifecycle",
+    });
+    createdRunIds.push(run.runId);
+    const statusDetails: string[] = [];
+    const unsubscribe = onStatusStream((event) => {
+      if (event.type === "status" && event.sessionId === sessionId && event.detail) {
+        statusDetails.push(event.detail);
+      }
+    });
+    let executionCount = 0;
+    agentManager.execute = (async (_agentId, messages, options) => {
+      executionCount += 1;
+      if (executionCount === 1) {
+        return {
+          content: "I started the delegated task.",
+          tool_calls: [spawnToolCall(run.runId)],
+        };
+      }
+      expect(options?.useTools).toBe(false);
+      expect(messages.at(-1)?.content).toContain("CHILD_RESULT=verified");
+      return { content: "The delegated check finished: CHILD_RESULT=verified" };
+    }) as typeof agentManager.execute;
+
+    try {
+      const responsePromise = handleChat({
+        message: "Delegate this check and wait for the result",
+        agentId: agent.id,
+        sessionId,
+        tools: true,
+      });
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      markRunCompleted(run.runId, "CHILD_RESULT=verified");
+      const response = await responsePromise;
+
+      expect(response.message.content).toBe("The delegated check finished: CHILD_RESULT=verified");
+      expect(response.message.tool_calls?.map((toolCall) => toolCall.name)).toEqual([
+        "sessions_spawn",
+        "sessions_wait",
+      ]);
+      expect(statusDetails).toContain("Waiting for 1 delegated task...");
+      expect(statusDetails.at(-1)).toBe("Idle");
+      expect(executionCount).toBe(2);
+    } finally {
+      unsubscribe();
+    }
+  });
+});

--- a/tests/api/chat-subagent-completion.test.ts
+++ b/tests/api/chat-subagent-completion.test.ts
@@ -8,6 +8,7 @@ import { agentManager } from "../../src/core/agent";
 import type { AgentToolCallResult } from "../../src/core/agent-internals";
 import { providerManager } from "../../src/core/providers";
 import {
+  getRun,
   markRunCompleted,
   registerSubagentRun,
   releaseSubagentRun,
@@ -39,6 +40,26 @@ function spawnToolCall(runId: string): AgentToolCallResult {
       childSessionKey: `agent:child:subagent:${runId}`,
       runId,
       task: "inspect lifecycle",
+    },
+  };
+}
+
+function todoToolCall(status: "in_progress" | "completed"): AgentToolCallResult {
+  return {
+    id: `todo-${status}`,
+    name: "todo",
+    args: {
+      items: [{ content: "Inspect delegated lifecycle", status, priority: "high" }],
+    },
+    result: {
+      items: [{ content: "Inspect delegated lifecycle", status, priority: "high" }],
+      summary: {
+        total: 1,
+        pending: 0,
+        inProgress: status === "in_progress" ? 1 : 0,
+        completed: status === "completed" ? 1 : 0,
+        cancelled: 0,
+      },
     },
   };
 }
@@ -76,6 +97,7 @@ describe("chat subagent completion", () => {
       childSessionKey: `agent:child:subagent:${crypto.randomUUID()}`,
       requesterSessionKey: sessionId,
       task: "inspect lifecycle",
+      cleanup: "delete",
     });
     createdRunIds.push(run.runId);
     const waitingCounts: number[] = [];
@@ -99,6 +121,7 @@ describe("chat subagent completion", () => {
         runs: [expect.objectContaining({ result: "CHILD_RESULT=ready", status: "completed" })],
       })
     );
+    expect(getRun(run.runId)).toBeUndefined();
   });
 
   test("keeps the chat active until its child finishes and synthesizes the child result", async () => {
@@ -178,5 +201,73 @@ describe("chat subagent completion", () => {
     } finally {
       unsubscribe();
     }
+  });
+
+  test("reconciles an unfinished plan after automatically waiting for delegated work", async () => {
+    const provider = providerManager.create({
+      provider: "openai",
+      name: "Automatic Plan Reconciliation Provider",
+      api_key: "automatic-plan-reconciliation-key",
+    });
+    createdProviderIds.push(provider.id);
+    const agent = agentManager.create({
+      name: "Automatic Plan Reconciliation Agent",
+      type: "main",
+      provider_id: provider.id,
+      model: "glm-5.3",
+      memory_enabled: false,
+    });
+    createdAgentIds.push(agent.id);
+    const sessionId = `automatic-plan-reconciliation-${crypto.randomUUID()}`;
+    createdSessionIds.push(sessionId);
+    const run = registerSubagentRun({
+      childSessionKey: `agent:child:subagent:${crypto.randomUUID()}`,
+      requesterSessionKey: sessionId,
+      task: "inspect lifecycle",
+      cleanup: "delete",
+    });
+    createdRunIds.push(run.runId);
+    let executionCount = 0;
+    agentManager.execute = (async (_agentId, _messages, options) => {
+      executionCount += 1;
+      if (executionCount === 1) {
+        return {
+          content: "The delegated lifecycle check is accepted.",
+          tool_calls: [todoToolCall("in_progress"), spawnToolCall(run.runId)],
+        };
+      }
+      expect(options?.useTools).toBe(true);
+      expect(options?.allowedToolNames).toEqual(["todo"]);
+      expect(options?.requireToolUse).toBe(true);
+      expect(options?.requiredToolName).toBe("todo");
+      return {
+        content: "The delegated lifecycle check finished successfully.",
+        tool_calls: [todoToolCall("completed")],
+      };
+    }) as typeof agentManager.execute;
+
+    setTimeout(() => markRunCompleted(run.runId, "CHILD_RESULT=verified"), 20);
+    const response = await handleChat({
+      message: "Plan, delegate, and complete this lifecycle check",
+      agentId: agent.id,
+      sessionId,
+      tools: true,
+    });
+
+    expect(response.message.content).toBe("The delegated lifecycle check finished successfully.");
+    expect(response.message.tool_calls?.map((toolCall) => toolCall.name)).toEqual([
+      "todo",
+      "sessions_spawn",
+      "sessions_wait",
+      "todo",
+    ]);
+    expect(response.plan?.summary).toEqual({
+      total: 1,
+      pending: 0,
+      inProgress: 0,
+      completed: 1,
+      cancelled: 0,
+    });
+    expect(getRun(run.runId)).toBeUndefined();
   });
 });

--- a/tests/api/gateway-network.test.ts
+++ b/tests/api/gateway-network.test.ts
@@ -3,6 +3,7 @@ import {
   buildWindowsGatewayFirewallCommand,
   ensureWindowsGatewayFirewallRule,
   normalizeGatewayBindHost,
+  readRuntimeGatewayPort,
   requestGatewayHostApply,
   setGatewayHostApplyHandler,
   updateGatewayHostSetting,
@@ -10,6 +11,8 @@ import {
 import { config } from "../../src/core/config";
 
 const originalCybaraHost = process.env.CYBARA_HOST;
+const originalRuntimePort = process.env.CYBARA_RUNTIME_PORT;
+const originalPort = process.env.PORT;
 
 describe("gateway network settings", () => {
   afterEach(() => {
@@ -17,6 +20,10 @@ describe("gateway network settings", () => {
     config.set("host", "127.0.0.1");
     if (originalCybaraHost === undefined) delete process.env.CYBARA_HOST;
     else process.env.CYBARA_HOST = originalCybaraHost;
+    if (originalRuntimePort === undefined) delete process.env.CYBARA_RUNTIME_PORT;
+    else process.env.CYBARA_RUNTIME_PORT = originalRuntimePort;
+    if (originalPort === undefined) delete process.env.PORT;
+    else process.env.PORT = originalPort;
   });
 
   test("normalizes safe bind hosts and rejects URLs", () => {
@@ -58,6 +65,28 @@ describe("gateway network settings", () => {
 
   test("builds a Windows firewall command that works across firewall profiles", () => {
     expect(buildWindowsGatewayFirewallCommand(4269)).toContain("-Profile Any");
+  });
+
+  test("uses the live fallback port for gateway settings and firewall rules", () => {
+    process.env.CYBARA_RUNTIME_PORT = "4271";
+    process.env.PORT = "4269";
+
+    expect(readRuntimeGatewayPort()).toBe(4271);
+
+    const calls: string[][] = [];
+    const result = ensureWindowsGatewayFirewallRule({
+      host: "0.0.0.0",
+      port: readRuntimeGatewayPort(),
+      platform: "win32",
+      runner: (cmd) => {
+        calls.push(cmd);
+        return { exitCode: 0, stdout: "", stderr: "" };
+      },
+    });
+
+    expect(result.ruleName).toBe("Cybara Gateway 4271");
+    expect(result.command).toContain("-LocalPort 4271");
+    expect(calls).toHaveLength(1);
   });
 
   test("does not touch Windows firewall when the host is local-only", () => {

--- a/tests/cli/chat-agent-resolution.test.ts
+++ b/tests/cli/chat-agent-resolution.test.ts
@@ -21,7 +21,11 @@ test("one-shot chat resolves an agent display name before sending the turn", asy
           : {};
         return {
           sessionId: "session-id",
-          message: { content: "done" },
+          message: {
+            content: "done",
+            tool_calls: [{ id: "tool-1", name: "write", status: "completed" }],
+            process_activities: [{ id: "activity-1", phase: "tool_result", text: "wrote file" }],
+          },
         } as T;
       }
       return null;
@@ -30,7 +34,8 @@ test("one-shot chat resolves an agent display name before sending the turn", asy
   });
 
   const originalLog = console.log;
-  console.log = () => undefined;
+  const output: string[] = [];
+  console.log = (...values: unknown[]) => output.push(values.join(" "));
   try {
     await rawAgent(["Inspect the project", "--json", "--agent", "Kimi"]);
   } finally {
@@ -40,6 +45,10 @@ test("one-shot chat resolves an agent display name before sending the turn", asy
   expect(requestBody.agentId).toBe("kimi-agent-id");
   expect(requestBody.message).toBe("Inspect the project");
   expect(requestBody.sessionId).toBeString();
+  expect(JSON.parse(output.at(-1) || "{}")).toMatchObject({
+    toolCalls: [{ id: "tool-1", name: "write", status: "completed" }],
+    processActivities: [{ id: "activity-1", phase: "tool_result", text: "wrote file" }],
+  });
 });
 
 test("one-shot chat recovers the gateway-owned result after its request disconnects", async () => {
@@ -81,4 +90,44 @@ test("one-shot chat recovers the gateway-owned result after its request disconne
     sessionId,
     content: "Built and verified.",
   });
+});
+
+test("one-shot JSON chat reports interrupted provider failures with a failing exit code", async () => {
+  configureChatCli({
+    apiBase: "http://127.0.0.1:4269",
+    fetchAPI: async <T>(endpoint: string): Promise<T | null> => {
+      if (endpoint === "/api/chat") {
+        return {
+          sessionId: "session-rate-limited",
+          interrupted: true,
+          failure: { category: "rate_limit", retryable: true },
+          message: {
+            content: "Response interrupted before completion. Send the message again to retry.",
+          },
+        } as T;
+      }
+      return null;
+    },
+    withAuthHeaders: (headers?: HeadersInit): Headers => new Headers(headers),
+  });
+
+  const output: string[] = [];
+  const originalLog = console.log;
+  const originalExitCode = process.exitCode;
+  console.log = (...values: unknown[]) => output.push(values.join(" "));
+  try {
+    process.exitCode = 0;
+    await rawAgent(["Run the task", "--json"]);
+
+    expect(process.exitCode).toBe(1);
+    expect(JSON.parse(output.at(-1) || "{}")).toEqual({
+      sessionId: "session-rate-limited",
+      content: "Response interrupted before completion. Send the message again to retry.",
+      interrupted: true,
+      failure: { category: "rate_limit", retryable: true },
+    });
+  } finally {
+    process.exitCode = originalExitCode ?? 0;
+    console.log = originalLog;
+  }
 });

--- a/tests/cli/tui-chat-chrome.test.tsx
+++ b/tests/cli/tui-chat-chrome.test.tsx
@@ -169,6 +169,23 @@ describe("CLI TUI chat chrome", () => {
     expect(output).toContain("Inspection thought 7");
   });
 
+  test("renders an automatic delegated wait as active terminal work", () => {
+    const output = renderToString(
+      <LiveRunView
+        activities={[]}
+        content=""
+        detail="Waiting for 1 delegated task..."
+        maxColumns={72}
+        colorScheme="dark"
+        palette={tuiChatPalette("dark")}
+      />,
+      { columns: 80 },
+    );
+
+    expect(output).toContain("Cybara");
+    expect(output).toContain("Waiting for 1 delegated task...");
+  });
+
   test("sweeps a bounded highlight across live terminal status text", () => {
     expect(tuiShineSegments("Running tests", 0)).toEqual({
       before: "",

--- a/tests/cli/tui-environment.test.ts
+++ b/tests/cli/tui-environment.test.ts
@@ -9,6 +9,7 @@ import {
   formatTokenUsageLine,
   lspServersFromResponse,
   subagentsFromResponse,
+  subagentListPath,
   tasksForSession,
   tasksFromResponse,
 } from "../../src/cli/tui/chat-environment";
@@ -68,6 +69,38 @@ describe("CLI TUI environment helpers", () => {
     expect(formatTokenUsageLine(snapshot.tokenUsage)).toContain("18.25 tok/s");
     expect(formatPlanLine(snapshot.plan)).toContain("1/3 complete");
     expect(formatFileChangeLine(snapshot.fileChanges)).toContain("2 files");
+  });
+
+  test("normalizes the gateway context usage field names", () => {
+    const snapshot = environmentSnapshotFromDetail({
+      contextUsage: {
+        usedTokens: 40_143,
+        limitTokens: 128_000,
+        usedPercent: 31.4,
+        compacted: true,
+        compactionCount: 1,
+        compactedTokens: 81_082,
+      },
+    });
+
+    expect(snapshot.contextUsage).toEqual({
+      tokensUsed: 40_143,
+      contextWindow: 128_000,
+      percentage: 31,
+      compacted: true,
+      compactionCount: 1,
+      compactedTokens: 81_082,
+    });
+    expect(formatContextUsageLine(snapshot.contextUsage)).toBe(
+      "Context: 31% · 40k / 128k tokens · compacted 1x (81k summarized)"
+    );
+  });
+
+  test("scopes subagent lists to the active session", () => {
+    expect(subagentListPath(" session/with spaces ")).toBe(
+      "/api/subagents?sessionId=session%2Fwith%20spaces"
+    );
+    expect(subagentListPath(undefined)).toBe("/api/subagents");
   });
 
   test("extracts file changes from structured tool results", () => {

--- a/tests/cli/tui-source.test.ts
+++ b/tests/cli/tui-source.test.ts
@@ -383,7 +383,7 @@ describe("CLI TUI source wiring", () => {
     expect(cliTuiInteractiveChatSource).toContain("resolveTerminalChatInspector");
     expect(cliTuiInteractiveChatSource).toContain('variant="sidebar"');
     expect(cliTuiInteractiveChatSource).toContain("environmentSidebarVisible");
-    expect(cliTuiInteractiveChatSource).toContain("?sessionId=");
+    expect(cliTuiInteractiveChatSource).toContain("subagentListPath(targetSessionId)");
     expect(cliTuiInteractiveChatSource).toContain("environmentSnapshotFromDetail");
     expect(cliTuiInteractiveChatSource).toContain("formatContextUsageLine");
     expect(cliTuiInteractiveChatSource).toContain("formatTokenUsageLine");
@@ -523,6 +523,10 @@ describe("CLI TUI source wiring", () => {
     expect(cliChatSource).toContain("formatAgentLine");
     expect(cliChatSource).toContain("printEnvironment");
     expect(cliChatSource).toContain("fetchSessionEnvironment");
+    expect(cliChatSource).toContain("requesterSessionId: sessionId");
+    expect(cliTuiInteractiveChatSource).toContain(
+      "requesterSessionId: localSessionId || undefined"
+    );
     expect(cliChatSource).toContain("environmentSnapshotFromDetail");
     expect(cliChatSource).toContain("/api/chat/sessions/${encodeURIComponent(sessionId)}/stop");
   });

--- a/tests/core/providers-defaults.test.ts
+++ b/tests/core/providers-defaults.test.ts
@@ -29,7 +29,7 @@ describe("Provider model defaults and API-family parity", () => {
     expect(getDefaultModel("litellm")).toBe("gpt-4o");
     expect(getDefaultModel("z.ai")).toBe("glm-5.2");
     expect(getDefaultModel("zai")).toBe("glm-5.2");
-    expect(getDefaultModel("z.ai-coding")).toBe("glm-5.2");
+    expect(getDefaultModel("z.ai-coding")).toBe("glm-5.3");
     expect(getDefaultModel("antigravity")).toBe("gemini-3.1-pro-preview");
     expect(getDefaultModel("google-antigravity")).toBe("gemini-3.1-pro-preview");
     expect(getDefaultModel("google-gemini-cli")).toBe("gemini-3.1-pro-preview");
@@ -453,7 +453,13 @@ describe("Provider model defaults and API-family parity", () => {
   });
 
   test("keeps Qwen Token Plan regions and supported models distinct", () => {
-    const expectedIds = ["qwen3.7-max", "qwen3.7-plus", "qwen3.6-plus", "qwen3.6-flash"];
+    const expectedIds = [
+      "qwen3.8-max",
+      "qwen3.7-max",
+      "qwen3.7-plus",
+      "qwen3.6-plus",
+      "qwen3.6-flash",
+    ];
 
     expect(providers["qwen-token-plan"].baseUrl).toBe(
       "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1"
@@ -464,6 +470,26 @@ describe("Provider model defaults and API-family parity", () => {
     expect(providers["qwen-token-plan"].models.map((model) => model.id)).toEqual(expectedIds);
     expect(providers["qwen-token-plan-cn"].models.map((model) => model.id)).toEqual(expectedIds);
     expect(providers["qwen-token-plan"].authType).toBe("api_key");
+    expect(providers["qwen-token-plan"].models[0]).toMatchObject({
+      id: "qwen3.8-max",
+      context: 1000000,
+      reasoning: true,
+      input: ["text", "image"],
+    });
+  });
+
+  test("advertises GLM-5.3 only on the Z.AI Coding Plan endpoint", () => {
+    const apiIds = providers["z.ai"].models.map((model) => model.id);
+    const codingIds = providers["z.ai-coding"].models.map((model) => model.id);
+
+    expect(codingIds[0]).toBe("glm-5.3");
+    expect(apiIds).not.toContain("glm-5.3");
+    expect(providers["z.ai-coding"].models[0]).toMatchObject({
+      context: 1000000,
+      maxTokens: 131072,
+      reasoning: true,
+      code: true,
+    });
   });
 
   test("does not advertise non-interactive portal credentials as OAuth", () => {

--- a/tests/core/subagent-execution.test.ts
+++ b/tests/core/subagent-execution.test.ts
@@ -86,6 +86,21 @@ describe("Subagent execution wiring", () => {
     });
 
     expect(run.runTimeoutSeconds).toBe(0);
+    expect(run.archiveAtMs).toBeUndefined();
+  });
+
+  test("starts the archive window only after a subagent becomes terminal", () => {
+    const run = registerSubagentRun({
+      childSessionKey: `child-archive-window-${process.pid}`,
+      requesterSessionKey: `parent-archive-window-${process.pid}`,
+      task: "Keep working beyond the retention window",
+    });
+
+    expect(run.archiveAtMs).toBeUndefined();
+    markRunCompleted(run.runId, "finished");
+
+    const completed = getRun(run.runId);
+    expect(completed?.archiveAtMs).toBeGreaterThan(completed?.endedAt ?? Number.MAX_SAFE_INTEGER);
   });
 
   test("closes restored active runs as interrupted while retaining partial details", () => {
@@ -536,6 +551,25 @@ describe("Subagent execution wiring", () => {
     expect(result.status).toBe("timeout");
     expect(result.pendingRunIds).toEqual([run.runId]);
     expect(result.runs[0]?.status).toBe("running");
+  });
+
+  test("cleanup delete keeps a completed result until the requester consumes it", async () => {
+    const run = registerSubagentRun({
+      childSessionKey: "agent:cleanup:subagent:result",
+      requesterSessionKey: "parent-cleanup",
+      task: "return a disposable result",
+      cleanup: "delete",
+    });
+
+    markRunCompleted(run.runId, "DISPOSABLE_RESULT=verified");
+
+    expect(getRun(run.runId)?.outcome?.result).toBe("DISPOSABLE_RESULT=verified");
+    const waited = await handleSessionsWait(
+      { runIds: [run.runId], timeoutSeconds: 0 },
+      { agentId: "parent-agent", sessionId: "parent-cleanup" }
+    );
+    expect(waited.runs[0]?.result).toBe("DISPOSABLE_RESULT=verified");
+    expect(getRun(run.runId)).toBeUndefined();
   });
 
   test("keeps the completed child result in the registry without announcing it", async () => {

--- a/tests/core/subagent-registry-home.test.ts
+++ b/tests/core/subagent-registry-home.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+describe("subagent registry storage", () => {
+  test("stores production registry state inside CYBARA_HOME", async () => {
+    const cybaraHome = mkdtempSync(join(tmpdir(), "cybara-subagent-home-"));
+    const script = [
+      'const registry = await import("./src/core/subagent-registry.ts")',
+      'registry.registerSubagentRun({ childSessionKey: "child", requesterSessionKey: "parent", task: "persist" })',
+    ].join(";");
+    try {
+      const child = Bun.spawn([process.execPath, "-e", script], {
+        cwd: process.cwd(),
+        env: {
+          ...process.env,
+          NODE_ENV: "production",
+          CYBARA_HOME: cybaraHome,
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const exitCode = await child.exited;
+      const stderr = await new Response(child.stderr).text();
+
+      expect(exitCode).toBe(0);
+      expect(stderr).toBe("");
+      expect(existsSync(join(cybaraHome, "subagent-registry.json"))).toBe(true);
+    } finally {
+      rmSync(cybaraHome, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/runtime/chat-tool-pass-boundary.test.ts
+++ b/tests/runtime/chat-tool-pass-boundary.test.ts
@@ -2,13 +2,16 @@ import { describe, expect, test } from "bun:test";
 import { readChatRuntimeSource } from "../source-fixtures";
 
 describe("chat tool pass boundary", () => {
-  test("does not start another tool-capable model loop after a completed response", () => {
+  test("limits post-wait synthesis tools to forced plan reconciliation", () => {
     const source = readChatRuntimeSource();
 
     expect(source).not.toContain("If more actions are needed to fully complete");
     expect(source).not.toContain("summaryToolPolicy");
-    expect(source).toContain("if (options.responseContent.trim()) return options.responseContent");
+    expect(source).toContain(
+      "return { responseContent: options.responseContent, toolResults: [] }"
+    );
     expect(source).toContain("Write the final user-facing response for the latest request");
-    expect(source).toContain("useTools: false");
+    expect(source).toContain('allowedToolNames: shouldReconcileTodo ? ["todo"] : undefined');
+    expect(source).toContain('requiredToolName: shouldReconcileTodo ? "todo" : undefined');
   });
 });

--- a/tests/shared/chat-status.test.ts
+++ b/tests/shared/chat-status.test.ts
@@ -1,11 +1,19 @@
 import { describe, expect, test } from "bun:test";
 import {
+  isDelegatedWaitStatusLabel,
   isGenericChatStatusLabel,
   isProviderRecoveryStatusLabel,
   isVisibleActivityText,
 } from "../../shared/chat-status";
 
 describe("chat status labels", () => {
+  test("recognizes delegated wait lifecycle labels", () => {
+    expect(isDelegatedWaitStatusLabel("Waiting for 1 delegated task...")).toBe(true);
+    expect(isDelegatedWaitStatusLabel("Waiting for 3 delegated tasks...")).toBe(true);
+    expect(isDelegatedWaitStatusLabel("Waiting for task...")).toBe(false);
+    expect(isDelegatedWaitStatusLabel("Generating response...")).toBe(false);
+  });
+
   test("classifies transient provider recovery as internal status", () => {
     for (const value of [
       "Provider connection interrupted; retrying (1/5)...",

--- a/tests/ui/multi-chat-live-status.test.ts
+++ b/tests/ui/multi-chat-live-status.test.ts
@@ -8,6 +8,22 @@ import {
 } from "../../ui/src/pages/chat/multiChatLiveStatus";
 
 describe("multi-chat live status", () => {
+  test("keeps delegated waits visibly active in web and Tauri chat state", () => {
+    const state = projectMultiChatStatusEvent(undefined, {
+      type: "status",
+      sessionId: "session-waiting",
+      runId: "run-waiting",
+      sequence: 4,
+      status: "thinking",
+      timestamp: 1_000,
+      detail: "Waiting for 2 delegated tasks...",
+    });
+
+    expect(state?.liveStatus).toBe("thinking");
+    expect(state?.currentStep).toBe("Waiting for 2 delegated tasks...");
+    expect(state?.activities.at(-1)?.text).toBe("Waiting for 2 delegated tasks...");
+  });
+
   test("hydrates in-progress tool calls and thoughts from a session snapshot", () => {
     const state = projectMultiChatSnapshot(
       {

--- a/ui/src/pages/chat/useChatLiveSessionRuntime.ts
+++ b/ui/src/pages/chat/useChatLiveSessionRuntime.ts
@@ -14,6 +14,7 @@ import {
   type StatusStreamStatusEvent,
   type StatusStreamTokenEvent,
 } from "@/lib/status-stream";
+import { isDelegatedWaitStatusLabel } from "../../../../shared/chat-status";
 import type { SessionContextUsage, SessionTokenUsage } from "@/types";
 import {
   type Dispatch,
@@ -1051,6 +1052,7 @@ export function useChatLiveSessionRuntime({
           if (!payload.toolName) {
             const activeToolStep = getLatestInFlightStep(runActivityBufferRef.current);
             const detail = typeof payload.detail === "string" ? payload.detail.trim() : "";
+            if (isDelegatedWaitStatusLabel(detail)) setStreamingContent(null);
             const eventTimestamp =
               typeof payload.timestamp === "number" && Number.isFinite(payload.timestamp)
                 ? payload.timestamp


### PR DESCRIPTION
## Summary

- reconcile the Windows Firewall rule on LAN gateway startup using the actual runtime port
- report and reuse fallback runtime ports consistently in gateway settings
- add Qwen 3.8 Max to supported Qwen Token Plan catalogs
- add GLM-5.3 to Z.AI Coding Plan and make it the coding-plan default

## Verification

- `bun run check:ci`
- `bun test tests/e2e/mobile-device-lifecycle.test.ts tests/mobile/connection.test.ts tests/mobile/api-client.test.ts`
- push CI run 31914341005 passed all jobs

<!-- GITZILLA_SUMMARY -->
> [!NOTE]
> **Medium Risk**
>
> **Overview**
> This PR addresses Windows LAN pairing by reconciling the Windows Firewall rule on LAN gateway startup with the actual runtime port, and standardizes reporting and reuse of fallback runtime ports in gateway settings so that the port surfaced matches the one the firewall is configured to allow. It also refreshes provider model catalogs by adding Qwen 3.8 Max to the supported Qwen Token Plan offerings and adding GLM-5.3 to the Z.AI Coding Plan while promoting it to the coding-plan default. The rest of the changes consist of supporting refactors and tests across the chat runtime, subagent registry/completion plumbing, TUI chat status/environment surfaces, channel tool handler, and related test suites.
>
> <sup>Written by [Gitzilla](https://gitzilla.ai) for commit df1d2c9. This will update automatically on new runs. Configure in the [Gitzilla dashboard](https://gitzilla.ai/dashboard).</sup>
<!-- /GITZILLA_SUMMARY -->