### PR TITLE
Fix long-goal reliability and agent response rendering

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -98,8 +98,8 @@ Key-value settings are stored in the `config` table and exposed via `GET/PUT /ap
 - `reasoning_effort`: default model reasoning effort
 - `self_improving_skills_enabled`: boolean toggle for `skill_save`
 - `provider_plan_monitoring`: coding-plan usage limits and router enforcement
-- `goal_loop_max_iterations`: continuation turns per active goal run (default `25`, range `1..50`)
-- `goal_loop_max_duration_seconds`: active wall-clock time per goal run (default `3600`, range `30..3600`)
+- `goal_loop_max_iterations`: optional continuation-turn safety limit per active goal run (unlimited by default, range `1..10000` when set)
+- `goal_loop_max_duration_seconds`: optional active wall-clock safety limit per goal run (unlimited by default, range `30..604800` when set)
 
 `computer_use.driverCommand` is the persisted Web/Tauri settings override for the Cua Driver
 executable. `CYBARA_CUA_DRIVER_CMD` still takes precedence for scripts and operator-managed

--- a/src/api/chat-formatting.ts
+++ b/src/api/chat-formatting.ts
@@ -26,6 +26,21 @@ const REASONING_OPEN_LINE_PATTERN = new RegExp(`^<(?:${REASONING_TAG_NAME_PATTER
 const REASONING_CLOSE_LINE_PATTERN = new RegExp(`^<\\/(?:${REASONING_TAG_NAME_PATTERN})>`, "i");
 
 const FINAL_BLOCK_PATTERN = /<final\b[^>]*>([\s\S]*?)<\/final>/gi;
+const STRICT_JSON_REQUEST_PATTERN =
+  /\b(?:strict\s+JSON|(?:output|reply|respond|return|emit)\s+(?:only\s+)?(?:a\s+)?JSON|JSON[\s\S]{0,120}no\s+markdown)\b/i;
+const JSON_FENCE_PATTERN = /^\s*```(?:json)?\s*\n?([\s\S]*?)\n?```\s*$/i;
+
+export function normalizeRequestedAssistantResponse(userMessage: string, content: string): string {
+  if (!STRICT_JSON_REQUEST_PATTERN.test(userMessage)) return content;
+  const fenced = content.match(JSON_FENCE_PATTERN)?.[1]?.trim();
+  if (!fenced) return content;
+  try {
+    JSON.parse(fenced);
+    return fenced;
+  } catch {
+    return content;
+  }
+}
 
 export function stripThinkingTags(content: string): StripThinkingTagsResult {
   const thinkingMatches: string[] = [];

--- a/src/api/chat-runtime.ts
+++ b/src/api/chat-runtime.ts
@@ -65,7 +65,11 @@ import {
 } from "./chat-agent-prompt";
 import { buildChatExecutionMessagesForAgent } from "./chat-execution-messages";
 import { executionMetadataFromResult } from "./chat-execution-metadata";
-import { sanitizeProcessThoughtText, stripThinkingTags } from "./chat-formatting";
+import {
+  normalizeRequestedAssistantResponse,
+  sanitizeProcessThoughtText,
+  stripThinkingTags,
+} from "./chat-formatting";
 import { kickOffGoalLoop, maybeScheduleGoalIteration } from "./chat-goal-runtime";
 import { settlePendingChatFailure } from "./chat-pending-failure";
 import {
@@ -1606,6 +1610,7 @@ async function handleChatTurn(
         responseContent = recoveredResponse.responseContent;
         toolResults = recoveredResponse.toolResults;
       }
+      responseContent = normalizeRequestedAssistantResponse(message, responseContent);
       let automaticWaitCompleted = false;
       if (!executionFailure) {
         const automaticWait = await awaitSpawnedSubagentResults({

--- a/src/api/chat-tool-summary.ts
+++ b/src/api/chat-tool-summary.ts
@@ -290,6 +290,8 @@ const EVIDENCE_REQUEST_PATTERN = new RegExp(
 );
 const EVIDENCE_REQUEST_TARGET_PATTERN =
   /\b(?:app|application|build|chat|cli|code|codebase|file|gateway|implementation|project|provider|repo|repository|session|site|system|test|tool|tui|ui|workspace)\b|https?:\/\//i;
+const SELF_CONTAINED_ARITHMETIC_REQUEST_PATTERN =
+  /\b(?:add|subtract|multiply|divide)\s+-?\d+(?:\.\d+)?\b[\s\S]*\b(?:number|sum|total)\b/i;
 
 function successfulToolCalls(toolCalls: ToolCallResultLike[]): ToolCallResultLike[] {
   return toolCalls.filter(isSuccessfulToolCall);
@@ -302,6 +304,7 @@ export function isEvidenceToolCall(toolCall: ToolCallResultLike): boolean {
 export function requiresToolEvidenceForMessage(message: string): boolean {
   const request = message.trim();
   if (!request || LITERAL_COMPLETION_REQUEST_PATTERN.test(request)) return false;
+  if (SELF_CONTAINED_ARITHMETIC_REQUEST_PATTERN.test(request)) return false;
   if (
     EXPLICIT_PLANNING_REQUEST_PATTERN.test(request) &&
     !PLANNING_FOLLOW_THROUGH_PATTERN.test(request)

--- a/src/core/bun-runtime.ts
+++ b/src/core/bun-runtime.ts
@@ -1,4 +1,3 @@
-import { createHash } from "node:crypto";
 import {
   chmodSync,
   copyFileSync,
@@ -157,7 +156,7 @@ export async function installBunRuntimeAt(
   const response = await fetcher(url, { redirect: "follow" });
   if (!response.ok) throw new Error(`Bun runtime download failed: ${response.status}`);
   const archive = Buffer.from(await response.arrayBuffer());
-  const digest = createHash("sha256").update(archive).digest("hex");
+  const digest = new Bun.CryptoHasher("sha256").update(archive).digest("hex");
   if (digest !== release.sha256) throw new Error("Bun runtime checksum verification failed");
 
   const temporaryDir = mkdtempSync(join(tmpdir(), "cybara-bun-runtime-"));

--- a/src/core/llm/text-tool-calls.ts
+++ b/src/core/llm/text-tool-calls.ts
@@ -200,7 +200,7 @@ function parseXmlFields(body: string): Record<string, unknown> {
   return args;
 }
 
-function parseJsonToolCalls(raw: string): TextToolCall[] {
+function parseJsonToolCalls(raw: string, allowNameOnly = false): TextToolCall[] {
   const trimmed = decodeMarkupEntities(raw).trim();
   if (!trimmed) return [];
 
@@ -221,6 +221,16 @@ function parseJsonToolCalls(raw: string): TextToolCall[] {
       record.function && typeof record.function === "object" && !Array.isArray(record.function)
         ? (record.function as Record<string, unknown>)
         : undefined;
+    const hasArgumentEnvelope = [
+      record.arguments,
+      record.args,
+      record.parameters,
+      record.input,
+      functionRecord?.arguments,
+    ].some((value) => value !== undefined);
+    const hasExplicitToolName =
+      record.tool_name !== undefined || record.tool !== undefined || functionRecord !== undefined;
+    if (!allowNameOnly && !hasArgumentEnvelope && !hasExplicitToolName) continue;
     const rawName = record.tool_name ?? record.name ?? record.tool ?? functionRecord?.name;
     const name = typeof rawName === "string" ? rawName.trim() : "";
     if (!name) continue;
@@ -462,7 +472,7 @@ function parseLegacyBracketToolCalls(raw: string): TextToolCall[] {
 
   for (const match of raw.matchAll(LEGACY_BRACKET_TOOL_CALL_PATTERN)) {
     const payload = match[1] || "";
-    calls.push(...parseJsonToolCalls(payload));
+    calls.push(...parseJsonToolCalls(payload, true));
 
     const toolName =
       /\btool\s*=>\s*["']([A-Za-z_][A-Za-z0-9_.:-]{0,119})["']/i.exec(payload)?.[1] ||
@@ -557,7 +567,7 @@ function parseWrappedToolCallContainers(raw: string, depth = 0): TextToolCall[] 
   for (const match of raw.matchAll(containerPattern)) {
     const body = match[2] || "";
     calls.push(
-      ...parseJsonToolCalls(body),
+      ...parseJsonToolCalls(body, true),
       ...parseXmlInvokeToolCalls(body),
       ...parseFunctionXmlToolCalls(body),
       ...parseFunctionEqualsToolCalls(body),

--- a/src/core/session-goal-loop.ts
+++ b/src/core/session-goal-loop.ts
@@ -2,12 +2,12 @@ import type { SessionGoal } from "./session-goals";
 import { config } from "./config";
 
 export interface GoalLoopLimits {
-  maxIterations: number;
-  maxDurationSeconds: number;
+  maxIterations: number | null;
+  maxDurationSeconds: number | null;
 }
 
-const GOAL_LOOP_MAX_ITERATIONS_DEFAULT = 25;
-const GOAL_LOOP_MAX_DURATION_SECONDS_DEFAULT = 3600;
+const GOAL_LOOP_MAX_ITERATIONS_LIMIT = 10_000;
+const GOAL_LOOP_MAX_DURATION_SECONDS_LIMIT = 7 * 24 * 60 * 60;
 const GOAL_LOOP_MAX_CONSECUTIVE_FAILURES = 3;
 const LOOP_STATE_PERSIST_KEY = "session_goal_loop_state";
 const MAX_PERSISTED_LOOP_STATES = 200;
@@ -116,13 +116,15 @@ export function readGoalLoopLimits(): GoalLoopLimits {
   const maxDurationRaw = config.get<unknown>("goal_loop_max_duration_seconds");
 
   const maxIterations =
-    typeof maxIterationsRaw === "number" && Number.isFinite(maxIterationsRaw)
-      ? Math.max(1, Math.min(50, Math.floor(maxIterationsRaw)))
-      : GOAL_LOOP_MAX_ITERATIONS_DEFAULT;
+    typeof maxIterationsRaw === "number" &&
+    Number.isFinite(maxIterationsRaw) &&
+    maxIterationsRaw > 0
+      ? Math.max(1, Math.min(GOAL_LOOP_MAX_ITERATIONS_LIMIT, Math.floor(maxIterationsRaw)))
+      : null;
   const maxDurationSeconds =
-    typeof maxDurationRaw === "number" && Number.isFinite(maxDurationRaw)
-      ? Math.max(30, Math.min(3600, Math.floor(maxDurationRaw)))
-      : GOAL_LOOP_MAX_DURATION_SECONDS_DEFAULT;
+    typeof maxDurationRaw === "number" && Number.isFinite(maxDurationRaw) && maxDurationRaw > 0
+      ? Math.max(30, Math.min(GOAL_LOOP_MAX_DURATION_SECONDS_LIMIT, Math.floor(maxDurationRaw)))
+      : null;
 
   return { maxIterations, maxDurationSeconds };
 }
@@ -225,11 +227,11 @@ export function decideNextGoalIteration(input: {
   if (state.consecutiveFailures >= GOAL_LOOP_MAX_CONSECUTIVE_FAILURES) {
     return { schedule: false, reason: "error", checkpoint: true };
   }
-  if (state.iterations >= limits.maxIterations) {
+  if (limits.maxIterations !== null && state.iterations >= limits.maxIterations) {
     return { schedule: false, reason: "max_iterations", checkpoint: true };
   }
   const elapsedSeconds = (now - state.startedAtMs) / 1000;
-  if (elapsedSeconds > limits.maxDurationSeconds) {
+  if (limits.maxDurationSeconds !== null && elapsedSeconds > limits.maxDurationSeconds) {
     return { schedule: false, reason: "max_duration", checkpoint: true };
   }
   return {
@@ -245,9 +247,12 @@ export function goalIterationPrompt(
   iteration: number,
   limits?: GoalLoopLimits
 ): string {
-  const budgetLine = limits
-    ? `This run may continue for up to ${limits.maxIterations} iterations before the loop pauses for a checkpoint.`
-    : "The loop continues automatically after each turn.";
+  const budgetLine =
+    limits?.maxIterations !== null && limits?.maxIterations !== undefined
+      ? `This run may continue for up to ${limits.maxIterations} iterations before the loop pauses for a checkpoint.`
+      : limits?.maxDurationSeconds !== null && limits?.maxDurationSeconds !== undefined
+        ? `This run may continue for up to ${limits.maxDurationSeconds} seconds before the loop pauses for a checkpoint.`
+        : "The loop continues automatically after each turn until the goal is complete, blocked, or paused by the user.";
   return [
     `[autonomous goal iteration ${iteration}]`,
     `Continue working toward the active goal: ${goal.objective}`,

--- a/tests/api/chat-formatting.test.ts
+++ b/tests/api/chat-formatting.test.ts
@@ -1,9 +1,28 @@
 import { describe, expect, test } from "bun:test";
 
-import { sanitizeProcessThoughtText, stripThinkingTags } from "../../src/api/chat-formatting";
+import {
+  normalizeRequestedAssistantResponse,
+  sanitizeProcessThoughtText,
+  stripThinkingTags,
+} from "../../src/api/chat-formatting";
 import { sanitizeSessionMessages } from "../../src/api/routes/_shared";
 
 describe("chat response formatting", () => {
+  test("removes a valid JSON fence when the user requires strict JSON", () => {
+    expect(
+      normalizeRequestedAssistantResponse(
+        "Fetch the fixture and reply as strict JSON with keys quote and source only.",
+        '```json\n{"quote":"Aurora","source":"fixture://article"}\n```'
+      )
+    ).toBe('{"quote":"Aurora","source":"fixture://article"}');
+    expect(normalizeRequestedAssistantResponse("Explain this JSON.", "```json\n{}\n```")).toBe(
+      "```json\n{}\n```"
+    );
+    expect(
+      normalizeRequestedAssistantResponse("Reply as strict JSON.", "```json\n{bad}\n```")
+    ).toBe("```json\n{bad}\n```");
+  });
+
   test("extracts thinking and shows only final content", () => {
     const result = stripThinkingTags(
       "<think>Check the files first.</think>\n<final>Done with the fix.</final>"

--- a/tests/api/chat-response-recovery.test.ts
+++ b/tests/api/chat-response-recovery.test.ts
@@ -311,6 +311,29 @@ describe("chat response recovery", () => {
     expect(result.message.content).toBe("Completed.");
   });
 
+  test("preserves a direct arithmetic response without forcing a tool retry", async () => {
+    const agentId = createTestAgent("Arithmetic Response Agent");
+    const sessionId = `arithmetic-response-${crypto.randomUUID()}`;
+    createdSessionIds.push(sessionId);
+    let callCount = 0;
+
+    agentManager.execute = (async () => {
+      callCount += 1;
+      return { content: "10" };
+    }) as typeof agentManager.execute;
+
+    const result = await handleChat({
+      message: "Add 10 to your running total. What is the total now? Reply with only the number.",
+      agentId,
+      sessionId,
+      tools: true,
+    });
+
+    expect(callCount).toBe(1);
+    expect(result.message.content).toBe("10");
+    expect(result.message.tool_calls).toBeUndefined();
+  });
+
   test("reports an honest failure after bounded empty-response recovery", async () => {
     const agentId = createTestAgent("Empty Completion Agent");
     const sessionId = `empty-completion-${crypto.randomUUID()}`;

--- a/tests/api/chat-tool-summary.test.ts
+++ b/tests/api/chat-tool-summary.test.ts
@@ -236,6 +236,11 @@ describe("chat tool summary utilities", () => {
     );
     expect(requiresToolEvidenceForMessage("What is dependency injection?")).toBe(false);
     expect(requiresToolEvidenceForMessage("Respond with exactly Completed.")).toBe(false);
+    expect(
+      requiresToolEvidenceForMessage(
+        "Add 10 to your running total. What is the total now? Reply with only the number."
+      )
+    ).toBe(false);
   });
 
   test("detects actionable answers backed only by non-evidence tools", () => {

--- a/tests/core/session-goal-loop.test.ts
+++ b/tests/core/session-goal-loop.test.ts
@@ -24,6 +24,8 @@ import {
 
 afterEach(() => {
   resetGoalLoopsForTests();
+  config.set("goal_loop_max_iterations", null);
+  config.set("goal_loop_max_duration_seconds", null);
 });
 
 function activeGoal(overrides: Partial<SessionGoal> = {}): SessionGoal {
@@ -249,14 +251,31 @@ describe("goal loop helpers", () => {
 
   test("reads configurable limits with sane defaults", () => {
     const defaults = readGoalLoopLimits();
-    expect(defaults.maxIterations).toBeGreaterThan(0);
-    expect(defaults.maxDurationSeconds).toBeGreaterThan(0);
+    expect(defaults).toEqual({ maxIterations: null, maxDurationSeconds: null });
   });
 
-  test("defaults to a continuation budget above the old eight-turn limit", () => {
+  test("defaults to an uncapped continuation loop", () => {
     config.set("goal_loop_max_iterations", null);
     config.set("goal_loop_max_duration_seconds", null);
-    expect(readGoalLoopLimits()).toEqual({ maxIterations: 25, maxDurationSeconds: 3600 });
+    expect(readGoalLoopLimits()).toEqual({ maxIterations: null, maxDurationSeconds: null });
+    const decision = decideNextGoalIteration({
+      goal: activeGoal(),
+      state: loopState({
+        iterations: 50_000,
+        startedAtMs: Date.parse("2020-01-01T00:00:00.000Z"),
+      }),
+      limits: readGoalLoopLimits(),
+      nowMs: Date.parse("2026-08-18T00:00:00.000Z"),
+    });
+    expect(decision.schedule).toBe(true);
+    if (!decision.schedule) throw new Error("Expected an uncapped goal iteration");
+    expect(decision.prompt).toContain("until the goal is complete, blocked, or paused by the user");
+  });
+
+  test("keeps explicit operator safety limits", () => {
+    config.set("goal_loop_max_iterations", 40);
+    config.set("goal_loop_max_duration_seconds", 7200);
+    expect(readGoalLoopLimits()).toEqual({ maxIterations: 40, maxDurationSeconds: 7200 });
   });
 
   test("persists loop progress across an in-memory reload", () => {

--- a/tests/core/text-tool-calls.test.ts
+++ b/tests/core/text-tool-calls.test.ts
@@ -169,6 +169,15 @@ describe("text-form tool call parsing", () => {
     expect(stripTextToolCallMarkup(raw)).toBe("I'll open the repository.");
   });
 
+  test("preserves final JSON data objects that contain a name field", () => {
+    const raw = '{"name":"Ada","score":97,"passed":true}';
+
+    expect(extractTextToolCalls(raw, new Set(["Ada"]))).toEqual([]);
+    expect(stripTextToolCallMarkup(raw)).toBe(raw);
+    expect(sanitizeAssistantContent(raw)).toBe(raw);
+    expect(hasTextToolCallMarkup(raw)).toBe(false);
+  });
+
   test("extracts standalone bare command JSON as exec", () => {
     const raw = '{"command":"cat package.json","cwd":"/Users/carsen/Documents/GitHub/cybara"}';
 

--- a/tests/runtime/package-scripts.test.ts
+++ b/tests/runtime/package-scripts.test.ts
@@ -11,6 +11,7 @@ const REACT_DOCTOR_SCRIPT = join(ROOT_DIR, "scripts", "react-doctor.ts");
 const SMOKE_TEST_SCRIPT = join(ROOT_DIR, "scripts", "run-smoke-tests.ts");
 const TAURI_SIDECAR_SMOKE_SCRIPT = join(ROOT_DIR, "scripts", "smoke-tauri-sidecar-ui.ts");
 const KNIP_CONFIG = join(ROOT_DIR, "knip.json");
+const UI_PACKAGE = join(ROOT_DIR, "ui", "package.json");
 
 describe("package.json script wiring", () => {
   test("exposes cybara CLI bin and expected build/dev scripts", () => {
@@ -138,5 +139,15 @@ describe("package.json script wiring", () => {
     expect(source).toContain("rm -rf node_modules");
     expect(source).toContain('if [ "$i" -ge "$attempts" ]; then');
     expect(source).toContain("bun pm cache rm || true");
+  });
+
+  test("runs Vite through Bun", () => {
+    const pkg = JSON.parse(readFileSync(UI_PACKAGE, "utf8")) as {
+      scripts?: Record<string, string>;
+    };
+
+    expect(pkg.scripts?.dev).toBe("bunx --bun vite");
+    expect(pkg.scripts?.build).toContain("bunx --bun vite build");
+    expect(pkg.scripts?.preview).toBe("bunx --bun vite preview");
   });
 });

--- a/ui/package.json
+++ b/ui/package.json
@@ -4,11 +4,11 @@
   "version": "1.0.1719",
   "type": "module",
   "scripts": {
-    "dev": "bunx vite",
+    "dev": "bunx --bun vite",
     "lint": "bun eslint --quiet \"src/**/*.{ts,tsx}\"",
     "typecheck": "bun ./node_modules/@typescript/native/bin/tsc -b",
-    "build": "bun ./node_modules/@typescript/native/bin/tsc -b && bunx vite build",
-    "preview": "bunx vite preview"
+    "build": "bun ./node_modules/@typescript/native/bin/tsc -b && bunx --bun vite build",
+    "preview": "bunx --bun vite preview"
   },
   "dependencies": {
     "@tanstack/react-query": "5.101.2",


### PR DESCRIPTION
Summary:
- remove default iteration and duration ceilings from active goals while retaining optional operator limits
- preserve strict JSON and prevent ordinary data objects from being consumed as text tool calls
- avoid forced-tool retries for self-contained arithmetic turns
- run Vite under Bun 1.4 and use native Bun hashing

Verification:
- bun run check:ci
- 91 focused context compaction/windowing tests
- real DS4 Flash Web UI goal: 35 iterations with queued steering, reload, and gateway restart
- ClawEval lightweight matrix: 18/18

<!-- GITZILLA_SUMMARY -->
> [!NOTE]
> **Medium Risk**
>
> **Overview**
> This PR improves long-goal reliability and agent response rendering by removing default iteration and duration ceilings from active goal loops while preserving optional operator-imposed limits. It hardens response parsing by enforcing strict JSON output and preventing ordinary data objects from being misinterpreted as text tool calls, while also skipping forced-tool retries for self-contained arithmetic turns. The build infrastructure shifts Vite to run under Bun 1.4 with native Bun hashing, accompanied by expanded tests covering context compaction, windowing, chat formatting, response recovery, tool summarization, and goal-loop behavior.
>
> <sup>Written by [Gitzilla](https://gitzilla.ai) for commit 51aa1b4. This will update automatically on new runs. Configure in the [Gitzilla dashboard](https://gitzilla.ai/dashboard).</sup>
<!-- /GITZILLA_SUMMARY -->