### PR TITLE
feat: add Atlas Cloud provider

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -95,6 +95,7 @@ sent.
 
 | Provider ID | Name | Auth |
 |-------------|------|------|
+| `atlascloud` | Atlas Cloud | API key |
 | `openai` | OpenAI | API key |
 | `meta` | Meta AI | API key |
 | `elevenlabs` | ElevenLabs | API key |

--- a/src/core/model-discovery.ts
+++ b/src/core/model-discovery.ts
@@ -44,33 +44,54 @@ function endpointModel(value: unknown): ModelsDevModel | undefined {
   const displayName =
     typeof model.display_name === "string" && model.display_name.trim()
       ? model.display_name.trim()
-      : undefined;
+      : typeof model.name === "string" && model.name.trim()
+        ? model.name.trim()
+        : undefined;
   const contextWindow =
     positiveInteger(model.context_length) ??
     positiveInteger(model.max_model_len) ??
     positiveInteger(model.context_window) ??
     positiveInteger(model.max_context_length);
-  const maxTokens = positiveInteger(model.max_output_tokens) ?? positiveInteger(model.max_tokens);
+  const maxTokens =
+    positiveInteger(model.max_output_tokens) ??
+    positiveInteger(model.max_output_length) ??
+    positiveInteger(model.max_tokens);
+  const endpointInput = Array.isArray(model.input_modalities)
+    ? model.input_modalities.filter((entry): entry is string => typeof entry === "string")
+    : [];
   const hasInputCapabilities =
-    Object.hasOwn(model, "supports_image_in") || Object.hasOwn(model, "supports_video_in");
-  const input = hasInputCapabilities
-    ? [
-        "text",
-        ...(model.supports_image_in === true ? ["image"] : []),
-        ...(model.supports_video_in === true ? ["video"] : []),
-      ]
-    : undefined;
+    endpointInput.length > 0 ||
+    Object.hasOwn(model, "supports_image_in") ||
+    Object.hasOwn(model, "supports_video_in");
+  const input = endpointInput.length
+    ? endpointInput
+    : hasInputCapabilities
+      ? [
+          "text",
+          ...(model.supports_image_in === true ? ["image"] : []),
+          ...(model.supports_video_in === true ? ["video"] : []),
+        ]
+      : undefined;
+  const supportedFeatures = Array.isArray(model.supported_features)
+    ? model.supported_features.filter((entry): entry is string => typeof entry === "string")
+    : [];
+  const reasoning = Object.hasOwn(model, "supports_reasoning")
+    ? model.supports_reasoning === true
+    : supportedFeatures.length > 0
+      ? supportedFeatures.includes("reasoning")
+      : undefined;
+  const toolCall = Object.hasOwn(model, "supports_tool_use")
+    ? model.supports_tool_use !== false
+    : supportedFeatures.length > 0
+      ? supportedFeatures.includes("tools")
+      : undefined;
   return {
     id,
     ...(displayName ? { name: displayName } : {}),
     ...(contextWindow ? { contextWindow } : {}),
     ...(maxTokens ? { maxTokens } : {}),
-    ...(Object.hasOwn(model, "supports_reasoning")
-      ? { reasoning: model.supports_reasoning === true }
-      : {}),
-    ...(Object.hasOwn(model, "supports_tool_use")
-      ? { toolCall: model.supports_tool_use !== false }
-      : {}),
+    ...(reasoning !== undefined ? { reasoning } : {}),
+    ...(toolCall !== undefined ? { toolCall } : {}),
     ...(input ? { input } : {}),
   };
 }

--- a/src/core/providers.ts
+++ b/src/core/providers.ts
@@ -659,6 +659,7 @@ export function getProviderBaseUrl(providerType: string): string {
 
 export function getDefaultModel(providerType: string): string {
   const defaults: Record<string, string> = {
+    atlascloud: "qwen/qwen3.5-397b-a17b",
     openai: "gpt-5.6-sol",
     meta: "muse-spark-1.1",
     elevenlabs: "eleven_multilingual_v2",

--- a/src/core/providers/api-console-links.ts
+++ b/src/core/providers/api-console-links.ts
@@ -1,4 +1,5 @@
 const providerApiConsoleUrls: Readonly<Record<string, string>> = {
+  atlascloud: "https://www.atlascloud.ai/console",
   openai: "https://platform.openai.com/api-keys",
   elevenlabs: "https://elevenlabs.io/app/settings/api-keys",
   meta: "https://llama.developer.meta.com/",

--- a/src/core/providers/catalog-cloud.ts
+++ b/src/core/providers/catalog-cloud.ts
@@ -197,6 +197,38 @@ const XAI_GROK_OAUTH_MODELS = [
 ] as const;
 
 export const cloudProviderCatalog = {
+  atlascloud: {
+    name: "Atlas Cloud",
+    baseUrl: "https://api.atlascloud.ai/v1",
+    api: "openai-completions",
+    authType: "api_key",
+    models: [
+      {
+        id: "qwen/qwen3.5-397b-a17b",
+        name: "Qwen3.5 397B A17B",
+        context: 262144,
+        maxTokens: 65536,
+        reasoning: true,
+        input: ["text", "image", "video"],
+      },
+      {
+        id: "deepseek-ai/deepseek-v4-flash",
+        name: "DeepSeek V4 Flash",
+        context: 1048576,
+        maxTokens: 393216,
+        reasoning: false,
+        input: ["text"],
+      },
+      {
+        id: "moonshotai/kimi-k2.6",
+        name: "Kimi K2.6",
+        context: 262144,
+        maxTokens: 262144,
+        reasoning: true,
+        input: ["text", "image", "video"],
+      },
+    ],
+  },
   ds4: {
     name: "ds4",
     baseUrl: "http://127.0.0.1:18000/v1",

--- a/tests/core/model-discovery.test.ts
+++ b/tests/core/model-discovery.test.ts
@@ -12,6 +12,40 @@ afterEach(() => {
 });
 
 describe("provider model discovery", () => {
+  test("persists OpenAI-compatible endpoint metadata", async () => {
+    const provider = providerManager.create({
+      provider: "atlascloud",
+      name: "Atlas Cloud Discovery Test",
+      api_key: "atlas-test-key",
+    });
+    createdProviderIds.push(provider.id);
+
+    const result = await discoverProviderModels(provider.id, {
+      request: async () =>
+        Response.json({
+          data: [
+            {
+              id: "qwen/qwen3.5-397b-a17b",
+              name: "Qwen3.5 397BA17B",
+              context_length: 262144,
+              max_output_length: 65536,
+              input_modalities: ["text", "image", "video"],
+              supported_features: ["json_mode", "structured_outputs", "tools", "reasoning"],
+            },
+          ],
+        }),
+      discoverCatalog: async () => [],
+    });
+
+    expect(result.source).toBe("endpoint");
+    const discovered = providerManager.getModels(provider.id)[0];
+    expect(discovered?.model_name).toBe("Qwen3.5 397BA17B");
+    expect(discovered?.context_window).toBe(262144);
+    expect(discovered?.max_tokens).toBe(65536);
+    expect(Boolean(discovered?.reasoning)).toBe(true);
+    expect(discovered?.input_types).toBe('["text","image","video"]');
+  });
+
   test("reads the context window a vLLM endpoint reports as max_model_len", async () => {
     const provider = providerManager.create({
       provider: "custom",

--- a/tests/core/providers-defaults.test.ts
+++ b/tests/core/providers-defaults.test.ts
@@ -11,6 +11,7 @@ import {
 
 describe("Provider model defaults and API-family parity", () => {
   test("uses updated defaults for newly added providers", () => {
+    expect(getDefaultModel("atlascloud")).toBe("qwen/qwen3.5-397b-a17b");
     expect(getDefaultModel("openai")).toBe("gpt-5.6-sol");
     expect(getDefaultModel("meta")).toBe("muse-spark-1.1");
     expect(getDefaultModel("ds4")).toBe("deepseek-v4-flash");
@@ -78,6 +79,7 @@ describe("Provider model defaults and API-family parity", () => {
   });
 
   test("declares expected API-family names for compatibility methods", () => {
+    expect(providers.atlascloud.api).toBe("openai-completions");
     expect(providers.ollama.api).toBe("ollama");
     expect(providers["openai-codex"].api).toBe("openai-codex-responses");
     expect(providers.vllm.api).toBe("openai-completions");


### PR DESCRIPTION
## Summary

- register Atlas Cloud as an optional OpenAI-compatible provider
- add verified Atlas Cloud model metadata and API console routing
- consume standard model discovery metadata for names, output limits, modalities, and supported features
- document the provider and cover defaults/discovery with tests

## Validation

- `bun test tests/core/model-discovery.test.ts tests/core/providers-defaults.test.ts tests/core/provider-api-console-links.test.ts` (34 passed)
- `bun run typecheck`
- changed-file ESLint and Biome checks
- `bun run build`
- one live Atlas Cloud chat-completions smoke request
- `bun run check:ci` completed every pre-test gate; the full suite reported one unrelated cold-start timeout in `vector-store-atomic-index.test.ts` (2,495 passed), and the timed-out test file passed on a focused 15-second rerun


<!-- GITZILLA_SUMMARY -->
> [!NOTE]
> **Low Risk**
>
> **Overview**
> Adds support for the Atlas Cloud provider as an optional OpenAI-compatible endpoint by registering it in the providers catalog, supplying verified model metadata, and wiring up its API console link. Atlas Cloud entries now consume the standard model discovery metadata for display names, output token limits, modalities, and supported features, replacing inline definitions with shared discovery output. Documentation is updated to describe the new provider, and the existing defaults/discovery test suites are extended with coverage for Atlas Cloud.
>
> <sup>Written by [Gitzilla](https://gitzilla.ai) for commit cafbf73. This will update automatically on new runs. Configure in the [Gitzilla dashboard](https://gitzilla.ai/dashboard).</sup>
<!-- /GITZILLA_SUMMARY -->