### PR TITLE
Pin xmldom to 0.8.15

### DIFF
--- a/apps/mobile/bun.lock
+++ b/apps/mobile/bun.lock
@@ -39,7 +39,7 @@
     "image-size@1.2.1": "patches/image-size@1.2.1.patch",
   },
   "overrides": {
-    "@xmldom/xmldom": "0.9.12",
+    "@xmldom/xmldom": "0.8.15",
     "brace-expansion": "5.0.9",
     "browserslist": "4.28.7",
     "js-yaml": "4.3.1",
@@ -350,7 +350,7 @@
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.2", "", {}, "sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA=="],
 
-    "@xmldom/xmldom": ["@xmldom/xmldom@0.9.12", "", {}, "sha512-5AXjrcMClTryPe9LgZrygpB1lj7s0S9E0+W+AHaVKAVyHanafK86iPSvG5xHVSp/jC+VH1UXu0TAEmY279xH7A=="],
+    "@xmldom/xmldom": ["@xmldom/xmldom@0.8.15", "", {}, "sha512-/5NV/vDALVFDXgLmfsy9TRCBlKwO2LNBFzpzvb9iIj+jR+eSc6DLYYvVOdivT/jm7MtU6TebYuRmzEOI7w40UA=="],
 
     "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
 

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -45,7 +45,7 @@
     "postcss": "8.5.23",
     "uuid": "11.1.1",
     "js-yaml": "4.3.1",
-    "@xmldom/xmldom": "0.9.12"
+    "@xmldom/xmldom": "0.8.15"
   },
   "patchedDependencies": {
     "@react-native/gradle-plugin@0.85.3": "patches/@react-native%2Fgradle-plugin@0.85.3.patch",


### PR DESCRIPTION
Downgrade @xmldom/xmldom from 0.9.12 to 0.8.15 in the mobile app dependencies and lockfile to restore compatibility with the current patched dependency set.

## What does this PR do?

## How was it tested?
- [x] `bun test` passes
- [x] `bunx tsc --noEmit` passes (and `cd ui && bunx tsc --noEmit` for UI changes)
- [x] Verified against a running gateway (if behavior changed)

## Checklist
- [x] No secrets/keys in the diff
- [x] Follows the import/style rules in CLAUDE.md


<!-- GITZILLA_SUMMARY -->
> [!NOTE]
> **Low Risk**
>
> **Overview**
> Pins `@xmldom/xmldom` to version `0.8.15` in the mobile app's `package.json` and updates `bun.lock` to match. The downgrade from `0.9.12` restores compatibility with the existing patched dependency set, preventing conflicts introduced by the newer release.
>
> <sup>Written by [Gitzilla](https://gitzilla.ai) for commit 4e38c48. This will update automatically on new runs. Configure in the [Gitzilla dashboard](https://gitzilla.ai/dashboard).</sup>
<!-- /GITZILLA_SUMMARY -->