### PR TITLE
Add profile pictures for bot avatars

### DIFF
--- a/shared/bot-profile-image.ts
+++ b/shared/bot-profile-image.ts
@@ -1,0 +1,35 @@
+export const BOT_PROFILE_IMAGE_MAX_BYTES = 2 * 1024 * 1024;
+export const BOT_PROFILE_IMAGE_ACCEPT = "image/png,image/jpeg,image/webp";
+
+const BOT_PROFILE_IMAGE_DATA_URL = /^data:(image\/(?:png|jpeg|webp));base64,([A-Za-z0-9+/]+={0,2})$/;
+const BOT_PROFILE_IMAGE_MAX_BASE64_LENGTH = Math.ceil((BOT_PROFILE_IMAGE_MAX_BYTES * 4) / 3) + 4;
+
+function hasBytes(bytes: Uint8Array, offset: number, expected: readonly number[]): boolean {
+  return expected.every((value, index) => bytes[offset + index] === value);
+}
+
+function matchesImageSignature(mimeType: string, bytes: Uint8Array): boolean {
+  if (mimeType === "image/png") {
+    return hasBytes(bytes, 0, [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+  }
+  if (mimeType === "image/jpeg") return hasBytes(bytes, 0, [0xff, 0xd8, 0xff]);
+  return hasBytes(bytes, 0, [0x52, 0x49, 0x46, 0x46]) && hasBytes(bytes, 8, [0x57, 0x45, 0x42, 0x50]);
+}
+
+export function normalizeBotProfileImage(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim();
+  if (!normalized) return "";
+  const match = BOT_PROFILE_IMAGE_DATA_URL.exec(normalized);
+  const mimeType = match?.[1];
+  const base64 = match?.[2];
+  if (!mimeType || !base64 || base64.length > BOT_PROFILE_IMAGE_MAX_BASE64_LENGTH) return null;
+  try {
+    const binary = atob(base64);
+    if (binary.length === 0 || binary.length > BOT_PROFILE_IMAGE_MAX_BYTES) return null;
+    const bytes = Uint8Array.from(binary, (character) => character.charCodeAt(0));
+    return matchesImageSignature(mimeType, bytes) ? normalized : null;
+  } catch {
+    return null;
+  }
+}

--- a/src/api/bot-routes.ts
+++ b/src/api/bot-routes.ts
@@ -13,6 +13,7 @@ import { normalizeCapabilityAlias } from "../core/chat/capability-alias";
 import { uniqueCapabilityHandles } from "../core/chat/capability-handles";
 import { botSessionId } from "../../shared/bot-mode";
 import { BOT_ROLE_LIST, botRolePreset, isBotRoleId } from "../../shared/bot-roles";
+import { normalizeBotProfileImage } from "../../shared/bot-profile-image";
 import type { RouteHandler } from "./routes/_shared";
 
 interface BotInput {
@@ -25,6 +26,7 @@ interface BotInput {
   pinned?: unknown;
   model?: unknown;
   provider_id?: unknown;
+  profile_image?: unknown;
 }
 
 const BOT_AGENT_TYPES = new Set(["main", "research", "coder", "planner", "ops"]);
@@ -53,6 +55,14 @@ function validatedProviderId(value: unknown): string {
     throw new Error("Validation error: Provider not found");
   }
   return providerId;
+}
+
+function validatedProfileImage(value: unknown): string {
+  const image = normalizeBotProfileImage(value);
+  if (image === null) {
+    throw new Error("Validation error: Profile picture must be a PNG, JPEG, or WebP up to 2 MB");
+  }
+  return image;
 }
 
 function isBotAgent(agent: ReturnType<typeof agentManager.list>[number]): boolean {
@@ -159,6 +169,7 @@ function serializeBot(
     name: agent.name,
     title: metadata.title || agent.type || "Assistant",
     description: metadata.description,
+    profile_image: metadata.profileImage,
     role: metadata.role,
     hidden: metadata.hidden,
     pinned: metadata.pinned,
@@ -273,6 +284,8 @@ export const botRoutes: Record<string, RouteHandler> = {
     if (baseId && !base) throw new Error("Validation error: Base agent not found");
     const role = isBotRoleId(input.role) ? input.role : null;
     const preset = botRolePreset(role);
+    const profileImage =
+      input.profile_image === undefined ? "" : validatedProfileImage(input.profile_image);
     const title = boundedText(input.title, 80) || preset?.title || "";
     const description = boundedText(input.description, 2_000) || preset?.description || "";
     const model = boundedText(input.model, 200) || base?.model;
@@ -294,6 +307,7 @@ export const botRoutes: Record<string, RouteHandler> = {
         pinned: false,
         baseSystemPrompt,
         role,
+        profileImage,
       }),
     });
     refreshBotSystemPrompts();
@@ -314,6 +328,10 @@ export const botRoutes: Record<string, RouteHandler> = {
         : boundedText(input.description, 2_000);
     const role =
       input.role === undefined ? metadata.role : isBotRoleId(input.role) ? input.role : null;
+    const profileImage =
+      input.profile_image === undefined
+        ? metadata.profileImage
+        : validatedProfileImage(input.profile_image);
     const updated = agentManager.update(id, {
       name,
       model: input.model === undefined ? agent.model : boundedText(input.model, 200),
@@ -336,6 +354,7 @@ export const botRoutes: Record<string, RouteHandler> = {
         pinned: input.pinned === undefined ? metadata.pinned : input.pinned === true,
         baseSystemPrompt: metadata.baseSystemPrompt,
         role,
+        profileImage,
       }),
     });
     if (!updated) throw new Error("Bot not found");

--- a/src/core/bot-profile.ts
+++ b/src/core/bot-profile.ts
@@ -1,5 +1,6 @@
 import { parseAgentConfig } from "./agent-internals";
 import { type BotRoleId, botRolePreset, isBotRoleId } from "../../shared/bot-roles";
+import { normalizeBotProfileImage } from "../../shared/bot-profile-image";
 
 export interface BotProfileMetadata {
   title: string;
@@ -8,6 +9,7 @@ export interface BotProfileMetadata {
   pinned: boolean;
   baseSystemPrompt: string;
   role: BotRoleId | null;
+  profileImage: string;
 }
 
 function boundedText(value: unknown, maximum: number): string {
@@ -30,7 +32,8 @@ export function isBotProfileConfig(config: unknown): boolean {
     typeof record.hidden === "boolean" ||
     typeof record.pinned === "boolean" ||
     typeof record.base_system_prompt === "string" ||
-    typeof record.role === "string"
+    typeof record.role === "string" ||
+    typeof record.profile_image === "string"
   );
 }
 
@@ -43,6 +46,7 @@ export function readBotProfileMetadata(config: unknown): BotProfileMetadata {
     pinned: record.pinned === true,
     baseSystemPrompt: boundedText(record.base_system_prompt, 20_000),
     role: isBotRoleId(record.role) ? record.role : null,
+    profileImage: normalizeBotProfileImage(record.profile_image) ?? "",
   };
 }
 
@@ -62,6 +66,7 @@ export function withBotProfileMetadata(
       pinned: next.pinned,
       base_system_prompt: next.baseSystemPrompt,
       role: next.role,
+      profile_image: next.profileImage,
     },
   };
 }

--- a/tests/api/bot-routes.test.ts
+++ b/tests/api/bot-routes.test.ts
@@ -370,4 +370,41 @@ describe("bot routes", () => {
     expect(await getSession(cloned.session_id)).toBeUndefined();
     expect(taskScheduler.list().some((task) => task.agent_id === cloned.bot.id)).toBe(false);
   });
+
+  test("stores, lists, preserves, clears, and validates profile pictures", async () => {
+    const create = botRoutes["POST /api/bots"];
+    const update = botRoutes["PUT /api/bots/:id"];
+    const list = botRoutes["GET /api/bots"];
+    const png = `data:image/png;base64,${Buffer.from(
+      Uint8Array.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+    ).toString("base64")}`;
+    const created = (await create?.({ name: "Portrait Bot" })) as {
+      bot: { id: string; profile_image: string };
+    };
+    createdAgentIds.push(created.bot.id);
+
+    expect(created.bot.profile_image).toBe("");
+    const pictured = (await update?.({ profile_image: png }, { id: created.bot.id })) as {
+      bot: { profile_image: string };
+    };
+    expect(pictured.bot.profile_image).toBe(png);
+    expect(
+      ((await list?.()) as { bots: Array<{ id: string; profile_image: string }> }).bots.find(
+        (bot) => bot.id === created.bot.id
+      )?.profile_image
+    ).toBe(png);
+
+    const preserved = (await update?.({ title: "Still pictured" }, { id: created.bot.id })) as {
+      bot: { profile_image: string };
+    };
+    expect(preserved.bot.profile_image).toBe(png);
+    await expect(
+      update?.({ profile_image: "https://example.com/untrusted.png" }, { id: created.bot.id })
+    ).rejects.toThrow("Profile picture must be a PNG, JPEG, or WebP up to 2 MB");
+
+    const cleared = (await update?.({ profile_image: "" }, { id: created.bot.id })) as {
+      bot: { profile_image: string };
+    };
+    expect(cleared.bot.profile_image).toBe("");
+  });
 });

--- a/tests/core/bot-profile-image.test.ts
+++ b/tests/core/bot-profile-image.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import {
+  BOT_PROFILE_IMAGE_MAX_BYTES,
+  normalizeBotProfileImage,
+} from "../../shared/bot-profile-image";
+
+const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a] as const;
+
+function dataUrl(mimeType: string, bytes: Uint8Array): string {
+  return `data:${mimeType};base64,${Buffer.from(bytes).toString("base64")}`;
+}
+
+function pngBytes(size: number): Uint8Array {
+  const bytes = new Uint8Array(size);
+  bytes.set(PNG_SIGNATURE);
+  return bytes;
+}
+
+describe("bot profile images", () => {
+  test("accepts supported image data URLs and clearing the image", () => {
+    const png = dataUrl("image/png", pngBytes(PNG_SIGNATURE.length));
+    const jpeg = dataUrl("image/jpeg", Uint8Array.from([0xff, 0xd8, 0xff, 0xdb]));
+    const webp = dataUrl(
+      "image/webp",
+      Uint8Array.from([0x52, 0x49, 0x46, 0x46, 0, 0, 0, 0, 0x57, 0x45, 0x42, 0x50])
+    );
+
+    expect(normalizeBotProfileImage(png)).toBe(png);
+    expect(normalizeBotProfileImage(jpeg)).toBe(jpeg);
+    expect(normalizeBotProfileImage(webp)).toBe(webp);
+    expect(normalizeBotProfileImage("")).toBe("");
+  });
+
+  test("rejects unsupported, mislabeled, malformed, and remote image values", () => {
+    expect(normalizeBotProfileImage("https://example.com/bot.png")).toBeNull();
+    expect(normalizeBotProfileImage("data:image/svg+xml;base64,PHN2Zz4=")).toBeNull();
+    expect(normalizeBotProfileImage("data:image/png;base64,A===")).toBeNull();
+    expect(
+      normalizeBotProfileImage(dataUrl("image/png", Uint8Array.from([0xff, 0xd8, 0xff, 0xdb])))
+    ).toBeNull();
+  });
+
+  test("accepts the byte limit and rejects the smallest value above it", () => {
+    expect(
+      normalizeBotProfileImage(dataUrl("image/png", pngBytes(BOT_PROFILE_IMAGE_MAX_BYTES)))
+    ).toBeString();
+    expect(
+      normalizeBotProfileImage(dataUrl("image/png", pngBytes(BOT_PROFILE_IMAGE_MAX_BYTES + 1)))
+    ).toBeNull();
+  });
+});

--- a/tests/ui/bot-sidebar-wiring.test.ts
+++ b/tests/ui/bot-sidebar-wiring.test.ts
@@ -60,6 +60,10 @@ describe("bot sidebar wiring", () => {
     expect(sidebar).toContain("hidden: !bot.hidden");
     expect(sidebar).toContain("Model and provider");
     expect(sidebar).toContain("provider_id: editDraft.providerId");
+    expect(sidebar).toContain("profile_image: editDraft.profileImage");
+    expect(sidebar).toContain("BOT_PROFILE_IMAGE_ACCEPT");
+    expect(sidebar).toContain("Add picture");
+    expect(sidebar).toContain("Remove picture");
     expect(sidebar).toContain("useAgentSummaries");
     expect(sidebar).toContain('label="Agent"');
     expect(sidebar).toContain("selectableBotBaseAgents");

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -248,6 +248,7 @@ export const botsApi = {
       pinned?: boolean;
       model?: string;
       provider_id?: string;
+      profile_image?: string;
     }
   ) =>
     fetchApi<{ bot: BotRosterItem }>(`/bots/${id}`, {

--- a/ui/src/pages/chat/BotAvatar.tsx
+++ b/ui/src/pages/chat/BotAvatar.tsx
@@ -44,6 +44,16 @@ export function BotAvatar({ bot, active = false, className, showPresence = true 
       aria-hidden="true"
     >
       {agentAvatarInitials(bot.name) || <Bot className="h-4 w-4" />}
+      {bot.profile_image ? (
+        <img
+          src={bot.profile_image}
+          alt=""
+          className="absolute inset-0 h-full w-full rounded-[inherit] object-cover"
+          onError={(event) => {
+            event.currentTarget.hidden = true;
+          }}
+        />
+      ) : null}
       {showPresence ? (
         <span
           className={cn(

--- a/ui/src/pages/chat/BotSidebar.tsx
+++ b/ui/src/pages/chat/BotSidebar.tsx
@@ -6,6 +6,7 @@ import {
   Copy,
   Eye,
   EyeOff,
+  ImagePlus,
   Loader2,
   MessagesSquare,
   MoreHorizontal,
@@ -21,7 +22,7 @@ import {
   Wrench,
   X,
 } from "lucide-react";
-import { useDeferredValue, useMemo, useState } from "react";
+import { useDeferredValue, useMemo, useState, type ChangeEvent } from "react";
 import { useNavigate } from "react-router";
 import { Button, ConfirmDialog, Input, Modal, Select, Textarea } from "@/components/ui";
 import { useAgentSummaries, useDeleteSession, useProviders } from "@/hooks/useApi";
@@ -37,6 +38,11 @@ import { useSessions } from "@/hooks/useChat";
 import { BOT_ROLE_LIST, type BotRoleId, botRolePreset } from "../../../../shared/bot-roles";
 import { isRoomSessionId, ROOM_MODE_LABELS } from "../../../../shared/room-mode";
 import { buildMultiChatPath, MULTI_CHAT_MAX_PANES } from "./multiChatLayout";
+import {
+  BOT_PROFILE_IMAGE_ACCEPT,
+  BOT_PROFILE_IMAGE_MAX_BYTES,
+  normalizeBotProfileImage,
+} from "../../../../shared/bot-profile-image";
 
 interface BotSidebarProps {
   activeSessionIds: string[];
@@ -53,6 +59,7 @@ interface BotProfileDraft {
   description: string;
   model: string;
   providerId: string;
+  profileImage: string;
 }
 
 function previewForBot(bot: BotRosterItem): string {
@@ -67,6 +74,7 @@ function profileDraft(bot: BotRosterItem): BotProfileDraft {
     description: bot.description,
     model: bot.model ?? "",
     providerId: bot.provider_id ?? "",
+    profileImage: bot.profile_image ?? "",
   };
 }
 
@@ -266,6 +274,38 @@ export function BotSidebar({
     setEditingBot(bot);
     setEditDraft(profileDraft(bot));
     setActionBotId(null);
+  };
+
+  const changeProfileImage = (event: ChangeEvent<HTMLInputElement>): void => {
+    const input = event.currentTarget;
+    const file = input.files?.[0];
+    if (!file) return;
+    if (!BOT_PROFILE_IMAGE_ACCEPT.split(",").includes(file.type)) {
+      setError("Profile picture must be a PNG, JPEG, or WebP image");
+      input.value = "";
+      return;
+    }
+    if (file.size > BOT_PROFILE_IMAGE_MAX_BYTES) {
+      setError("Profile picture must be 2 MB or smaller");
+      input.value = "";
+      return;
+    }
+    const reader = new FileReader();
+    reader.onload = () => {
+      const image = normalizeBotProfileImage(reader.result);
+      if (image === null) {
+        setError("Could not read that profile picture");
+      } else {
+        setEditDraft((current) => (current ? { ...current, profileImage: image } : current));
+        setError(null);
+      }
+      input.value = "";
+    };
+    reader.onerror = () => {
+      setError("Could not read that profile picture");
+      input.value = "";
+    };
+    reader.readAsDataURL(file);
   };
 
   const providerModels = (selectedProviderId: string): string[] =>
@@ -831,13 +871,18 @@ export function BotSidebar({
                   description: editDraft.description,
                   model: editDraft.model,
                   provider_id: editDraft.providerId,
+                  profile_image: editDraft.profileImage,
                 },
               });
             }}
           >
             <div className="flex items-center gap-3 rounded-xl border border-[var(--surface-border)] bg-[var(--surface-raised)] p-3">
               <BotAvatar
-                bot={{ ...editingBot, name: editDraft.name || editingBot.name }}
+                bot={{
+                  ...editingBot,
+                  name: editDraft.name || editingBot.name,
+                  profile_image: editDraft.profileImage,
+                }}
                 showPresence={false}
               />
               <div className="min-w-0">
@@ -848,6 +893,35 @@ export function BotSidebar({
                   {editingBot.model || "Inherited model"}
                 </p>
               </div>
+            </div>
+            <div className="space-y-2">
+              <div className="flex flex-wrap items-center gap-2">
+                <label className="inline-flex cursor-pointer items-center gap-2 rounded-xl border border-[var(--surface-border)] bg-[var(--surface-raised)] px-3 py-2 text-sm font-medium text-[var(--text-secondary)] transition-colors hover:bg-[var(--surface-hover)] hover:text-[var(--text-primary)]">
+                  <ImagePlus className="h-4 w-4" />
+                  {editDraft.profileImage ? "Change picture" : "Add picture"}
+                  <input
+                    type="file"
+                    accept={BOT_PROFILE_IMAGE_ACCEPT}
+                    className="sr-only"
+                    onChange={changeProfileImage}
+                  />
+                </label>
+                {editDraft.profileImage ? (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={() =>
+                      setEditDraft((current) =>
+                        current ? { ...current, profileImage: "" } : current
+                      )
+                    }
+                  >
+                    Remove picture
+                  </Button>
+                ) : null}
+              </div>
+              <p className="text-xs text-[var(--text-subtle)]">PNG, JPEG, or WebP. Maximum 2 MB.</p>
             </div>
             <Input
               data-autofocus

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -52,6 +52,7 @@ export interface BotRosterItem {
   name: string;
   title: string;
   description: string;
+  profile_image?: string;
   role?: string | null;
   hidden: boolean;
   pinned: boolean;


### PR DESCRIPTION
## Summary

- add profile picture upload, preview, replacement, and removal to the bot profile editor
- render saved profile pictures anywhere the shared bot avatar appears, including the left bot bar
- persist images in bot profile metadata and keep the generated initials/gradient as a fallback
- validate PNG, JPEG, and WebP data URLs by declared type, file signature, and a 2 MB limit

## Testing

- `bun test tests/core/bot-profile-image.test.ts tests/api/bot-routes.test.ts tests/ui/bot-sidebar-wiring.test.ts` — 16 pass
- `bun run typecheck` — pass
- `bun run ui:typecheck` — pass
- `bun run lint` — pass
- `bun run ui:lint` — pass
- `bun run ui:build` — pass
- browser acceptance pass: uploaded a PNG in Edit bot profile, confirmed the preview and removal control, saved it, and confirmed the image replaced initials in the left bot bar while retaining the presence indicator

## Full gate

`bun run check:ci` passes typecheck, lint, formatting, LOC, Expo dependency check, mobile typecheck, and React Doctor. Its smoke phase currently reports 2,482 passing, 1 skipped, and 12 failing tests. The failures are outside this change, including existing mocked-route `require()`/async-module incompatibilities and environment-dependent nearby-network, iOS simulator, agent-tool timing, and LSP cleanup cases.


<!-- GITZILLA_SUMMARY -->
> [!NOTE]
> **Low Risk**
>
> **Overview**
> This PR introduces support for profile pictures on bot avatars. It adds a new `shared/bot-profile-image.ts` utility that validates PNG, JPEG, and WebP data URLs via declared type, file signature, and a 2 MB size cap, and stores the validated image in bot profile metadata. The backend API (`src/api/bot-routes.ts`, `src/core/bot-profile.ts`, `ui/src/lib/api.ts`, `ui/src/types/index.ts`) now accepts, persists, and returns the profile picture alongside the existing gradient/initials fallback. On the UI side, `BotSidebar.tsx` gains upload, preview, replace, and remove controls, while `BotAvatar.tsx` renders the saved picture (with the gradient/initials retained as a fallback) wherever the shared bot avatar is used. New tests cover image validation and route handling, and existing bot sidebar wiring tests are extended to verify the new behavior.
>
> <sup>Written by [Gitzilla](https://gitzilla.ai) for commit 29e7886. This will update automatically on new runs. Configure in the [Gitzilla dashboard](https://gitzilla.ai/dashboard).</sup>
<!-- /GITZILLA_SUMMARY -->