### PR TITLE
Show agent and bot names on the Sessions page

### DIFF
--- a/tests/ui/page-api-wiring.test.ts
+++ b/tests/ui/page-api-wiring.test.ts
@@ -336,7 +336,14 @@ describe("UI page API wiring", () => {
     expect(logsSource).toContain("LogsSkeleton");
     expect(logsSource).not.toContain("apiFetch(");
 
-    expect(sessionsSource).toMatch(/import\s*\{\s*sessionsApi\s*\}\s*from\s*["']@\/lib\/api["'];/);
+    expect(sessionsSource).toMatch(
+      /import\s*\{[^}]*agentsApi[^}]*sessionsApi[^}]*\}\s*from\s*["']@\/lib\/api["'];/
+    );
+    expect(sessionsSource).toContain("agentsApi.summaries()");
+    expect(sessionsSource).toContain("buildSessionAgentIdentities(response.data || [])");
+    expect(sessionsSource).toContain('agentIdentity(session.agent_id).isBot ? "Bot" : "Agent"');
+    expect(sessionsSource).toContain("agentIdentity(selectedSession.agent_id).name");
+    expect(sessionsSource).toContain("agentIdentity(session.agent_id).name.toLowerCase()");
     expect(sessionsSource).toContain("sessionsApi.list({ limit: targetLimit, offset: 0 })");
     expect(sessionsSource).toContain("sessionsApi.list({");
     expect(sessionsSource).toContain("sessionsApi.get(session.id)");

--- a/tests/ui/session-agent-identity.test.ts
+++ b/tests/ui/session-agent-identity.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import type { AgentSummary } from "../../ui/src/types";
+import {
+  buildSessionAgentIdentities,
+  resolveSessionAgentIdentity,
+} from "../../ui/src/pages/sessionAgentIdentity";
+
+const agents: AgentSummary[] = [
+  { id: "agent-key", name: "Cybara", is_bot: false },
+  { id: "bot-key", name: "Loretta", is_bot: true },
+];
+
+describe("session agent identities", () => {
+  const identities = buildSessionAgentIdentities(agents);
+
+  test("resolves a regular agent name", () => {
+    expect(resolveSessionAgentIdentity(identities, "agent-key")).toEqual({
+      name: "Cybara",
+      isBot: false,
+    });
+  });
+
+  test("resolves a bot name and identity", () => {
+    expect(resolveSessionAgentIdentity(identities, "bot-key")).toEqual({
+      name: "Loretta",
+      isBot: true,
+    });
+  });
+
+  test("falls back to the key for an unresolved agent", () => {
+    expect(resolveSessionAgentIdentity(identities, "deleted-agent-key")).toEqual({
+      name: "deleted-agent-key",
+      isBot: false,
+    });
+  });
+});

--- a/ui/src/pages/Sessions.tsx
+++ b/ui/src/pages/Sessions.tsx
@@ -24,9 +24,14 @@ import { Input } from "@/components/ui/Input";
 import { Badge } from "@/components/ui/Badge";
 import { Modal } from "@/components/ui/Modal";
 import { PageLayout } from "@/components/layout";
-import { sessionsApi } from "@/lib/api";
+import { agentsApi, sessionsApi } from "@/lib/api";
 import { connectStatusStream } from "@/lib/status-stream";
 import type { ChatMessage, ToolCallInfo } from "@/types";
+import {
+  buildSessionAgentIdentities,
+  resolveSessionAgentIdentity,
+  type SessionAgentIdentity,
+} from "./sessionAgentIdentity";
 
 interface Session {
   id: string;
@@ -63,8 +68,13 @@ export function Sessions() {
   const [isViewModalOpen, setIsViewModalOpen] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [sessionToDelete, setSessionToDelete] = useState<Session | null>(null);
+  const [agentIdentities, setAgentIdentities] = useState<Map<string, SessionAgentIdentity>>(
+    new Map()
+  );
   const sessionsRef = useRef<Session[]>([]);
   const refreshTimerRef = useRef<number | null>(null);
+
+  const agentIdentity = (agentId: string) => resolveSessionAgentIdentity(agentIdentities, agentId);
 
   const fetchSessions = async (limitOverride?: number) => {
     setIsLoading(true);
@@ -143,6 +153,21 @@ export function Sessions() {
     };
   }, []);
 
+  useEffect(() => {
+    const fetchAgentNames = async () => {
+      try {
+        const response = await agentsApi.summaries();
+        if (response.success) {
+          setAgentIdentities(buildSessionAgentIdentities(response.data || []));
+        }
+      } catch (error) {
+        console.error("Failed to fetch agent names:", error);
+      }
+    };
+
+    void fetchAgentNames();
+  }, []);
+
   const handleViewSession = async (session: Session) => {
     try {
       const response = await sessionsApi.get(session.id);
@@ -173,7 +198,8 @@ export function Sessions() {
   const filteredSessions = sessions.filter(
     (session) =>
       session.id.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      session.agent_id.toLowerCase().includes(searchQuery.toLowerCase())
+      session.agent_id.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      agentIdentity(session.agent_id).name.toLowerCase().includes(searchQuery.toLowerCase())
   );
 
   return (
@@ -184,7 +210,7 @@ export function Sessions() {
             <div className="relative">
               <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-500" />
               <Input
-                placeholder="Search sessions by ID or agent..."
+                placeholder="Search sessions by ID, agent, or bot name..."
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
                 className="pl-10"
@@ -228,7 +254,10 @@ export function Sessions() {
                       <div className="flex flex-wrap items-center gap-3 text-sm text-gray-400">
                         <span className="flex items-center gap-1">
                           <Bot className="w-4 h-4 flex-shrink-0" />
-                          <span className="truncate">Agent: {session.agent_id.slice(0, 8)}...</span>
+                          <span className="truncate">
+                            {agentIdentity(session.agent_id).isBot ? "Bot" : "Agent"}:{" "}
+                            {agentIdentity(session.agent_id).name}
+                          </span>
                         </span>
                         <span className="flex items-center gap-1">
                           <Clock className="w-4 h-4 flex-shrink-0" />
@@ -303,8 +332,10 @@ export function Sessions() {
         {selectedSession && (
           <div className="space-y-4 max-h-[70vh] overflow-y-auto">
             <div className="flex items-center gap-4 p-3 rounded-lg bg-white/5 text-sm">
-              <span className="text-gray-400">Agent:</span>
-              <code className="text-white">{selectedSession.agent_id}</code>
+              <span className="text-gray-400">
+                {agentIdentity(selectedSession.agent_id).isBot ? "Bot:" : "Agent:"}
+              </span>
+              <span className="text-white">{agentIdentity(selectedSession.agent_id).name}</span>
               <span className="text-gray-400 ml-4">Created:</span>
               <span className="text-white">
                 {new Date(selectedSession.created_at).toLocaleString()}

--- a/ui/src/pages/sessionAgentIdentity.ts
+++ b/ui/src/pages/sessionAgentIdentity.ts
@@ -1,0 +1,21 @@
+import type { AgentSummary } from "@/types";
+
+export interface SessionAgentIdentity {
+  name: string;
+  isBot: boolean;
+}
+
+export function buildSessionAgentIdentities(
+  agents: AgentSummary[]
+): Map<string, SessionAgentIdentity> {
+  return new Map(
+    agents.map((agent) => [agent.id, { name: agent.name, isBot: agent.is_bot === true }])
+  );
+}
+
+export function resolveSessionAgentIdentity(
+  identities: Map<string, SessionAgentIdentity>,
+  agentId: string
+): SessionAgentIdentity {
+  return identities.get(agentId) || { name: agentId, isBot: false };
+}


### PR DESCRIPTION
## Summary
- resolve session agent keys through the existing agent summary endpoint
- show human-readable agent and bot names in session cards and details
- label bot-backed sessions as bots and allow searching by the resolved name
- fall back to the stored key when an agent can no longer be resolved

## Testing
- `bun test tests/ui/session-agent-identity.test.ts tests/ui/page-api-wiring.test.ts`
- `bun run ui:typecheck`
- `bun run ui:lint`
- `bun run format:check`
- `bun run ui:build`
- `bun run check:ci` reaches the smoke suite, but the repository-wide run is blocked by 12 unrelated runtime/network failures in nearby networking, agent tool execution, and LSP cleanup tests (2450 passed, 1 skipped). All checks before `test:smoke` passed.


<!-- GITZILLA_SUMMARY -->
> [!NOTE]
> **Low Risk**
>
> **Overview**
> This PR enhances the Sessions page by resolving agent identities for each session. A new `sessionAgentIdentity.ts` module fetches agent metadata through the existing agent summary endpoint, and `Sessions.tsx` consumes it to display human-readable agent and bot names in session cards and details. Bot-backed sessions are now labeled as such, and users can search sessions by the resolved name while gracefully falling back to the stored key when an agent can no longer be resolved. Test coverage was added via a new `session-agent-identity.test.ts` file and an updated wiring assertion in `page-api-wiring.test.ts`.
>
> <sup>Written by [Gitzilla](https://gitzilla.ai) for commit a96671c. This will update automatically on new runs. Configure in the [Gitzilla dashboard](https://gitzilla.ai/dashboard).</sup>
<!-- /GITZILLA_SUMMARY -->