### PR TITLE
Chat: show configurable unread response indicators

### DIFF
--- a/src/api/bot-routes.ts
+++ b/src/api/bot-routes.ts
@@ -188,6 +188,7 @@ function serializeBot(
           title: session.title,
           updated_at: session.updatedAt,
           message_count: session.messageCount,
+          unread: session.unread,
           last_message: session.lastMessage,
         }
       : null,

--- a/src/api/chat-runtime-state.ts
+++ b/src/api/chat-runtime-state.ts
@@ -83,6 +83,7 @@ export interface SessionListEntry {
   updatedAt: string;
   workspaceDir: string | null;
   pinned: boolean;
+  unread: boolean;
   lastMessage: SessionLastMessagePreview | null;
   modelMetadata: SessionModelMetadata | null;
   room?: RoomConfig | null;
@@ -243,10 +244,11 @@ export function buildLastMessagePreview(message?: ChatMessage): SessionLastMessa
 export function normalizePersistedIndexEntry(
   entry: Omit<
     PersistedSessionIndexEntry,
-    "title" | "lastMessage" | "pinned" | "modelMetadata" | "useModelRouter"
+    "title" | "lastMessage" | "pinned" | "unread" | "modelMetadata" | "useModelRouter"
   > & {
     title?: string | null;
     pinned?: boolean;
+    unread?: boolean;
     useModelRouter?: boolean;
     lastMessage?: SessionLastMessagePreview | null;
     modelMetadata?: SessionModelMetadata | null;
@@ -259,6 +261,7 @@ export function normalizePersistedIndexEntry(
       entry.useModelRouter ?? persistedSessionIndex.get(entry.id)?.useModelRouter ?? false,
     title: stripSessionTitleAgentPrefix(entry.title, [modelMetadata?.agent_name, entry.agentId]),
     pinned: entry.pinned ?? persistedSessionIndex.get(entry.id)?.pinned ?? false,
+    unread: entry.unread ?? persistedSessionIndex.get(entry.id)?.unread ?? false,
     lastMessage: entry.lastMessage
       ? {
           role: entry.lastMessage.role,
@@ -272,10 +275,11 @@ export function normalizePersistedIndexEntry(
 export function upsertPersistedSessionIndex(
   entry: Omit<
     PersistedSessionIndexEntry,
-    "title" | "lastMessage" | "pinned" | "modelMetadata" | "useModelRouter"
+    "title" | "lastMessage" | "pinned" | "unread" | "modelMetadata" | "useModelRouter"
   > & {
     title?: string | null;
     pinned?: boolean;
+    unread?: boolean;
     useModelRouter?: boolean;
     lastMessage?: SessionLastMessagePreview | null;
     modelMetadata?: SessionModelMetadata | null;
@@ -341,6 +345,7 @@ export function buildMemorySessionListEntries(): SessionListEntry[] {
       updatedAt: s.updatedAt || s.createdAt,
       workspaceDir: s.workspaceDir ?? null,
       pinned: persistedSessionIndex.get(s.id)?.pinned ?? false,
+      unread: persistedSessionIndex.get(s.id)?.unread ?? false,
       lastMessage: buildLastMessagePreview(s.messages[s.messages.length - 1]),
       modelMetadata,
       room: s.room ?? null,
@@ -361,6 +366,7 @@ export function persistedSessionToIndexEntry(
     updatedAt: persisted.updatedAt,
     workspaceDir: persisted.workspaceDir ?? null,
     pinned: persisted.pinned,
+    unread: persisted.unread,
     room: persisted.roomConfig,
     modelMetadata: persisted.modelMetadata ?? resolveSessionModelMetadata(persisted.agentId),
     lastMessage:

--- a/src/api/chat-session-api.ts
+++ b/src/api/chat-session-api.ts
@@ -1,5 +1,5 @@
 import { agentManager } from "../core/agent";
-import db from "../core/database";
+import db, { tables } from "../core/database";
 import { logSessionMessage } from "../core/logging";
 import {
   clearSessionContextState,
@@ -402,7 +402,11 @@ async function buildSessionListIndex(): Promise<SessionListEntry[]> {
 
   const memoryMap = new Map(memorySessions.map((session) => [session.id, session]));
   for (const persisted of persistedSessionIndex.values()) {
-    if (memoryMap.has(persisted.id)) continue;
+    const memory = memoryMap.get(persisted.id);
+    if (memory) {
+      memory.unread = persisted.unread;
+      continue;
+    }
     memorySessions.push({
       id: persisted.id,
       agentId: persisted.agentId,
@@ -413,6 +417,7 @@ async function buildSessionListIndex(): Promise<SessionListEntry[]> {
       updatedAt: persisted.updatedAt,
       workspaceDir: persisted.workspaceDir,
       pinned: persisted.pinned,
+      unread: persisted.unread,
       lastMessage: persisted.lastMessage,
       modelMetadata: persisted.modelMetadata,
       room: persisted.room ?? null,
@@ -437,7 +442,9 @@ async function buildPersistedSessionPage(options: { limit: number; offset: numbe
   const memoryById = new Map(memorySessions.map((session) => [session.id, session]));
   const persistedEntries = page.sessions.map((persisted) => {
     const memory = memoryById.get(persisted.id);
-    return memory ?? persistedSessionToIndexEntry(persisted);
+    return memory
+      ? { ...memory, unread: persisted.unread }
+      : persistedSessionToIndexEntry(persisted);
   });
 
   if (transientSessions.length === 0) {
@@ -501,6 +508,15 @@ export async function listSessionPage(options?: { limit?: number; offset?: numbe
     offset,
     hasMore: limit ? offset + sessions.length < sortedSessions.length : false,
   };
+}
+
+export function markSessionRead(sessionId: string): { found: boolean; unread: false } {
+  const key = sessionId.trim();
+  if (!key) return { found: false, unread: false };
+  const found = tables.chatSessions.markRead(key);
+  const indexed = persistedSessionIndex.get(key);
+  if (indexed) persistedSessionIndex.set(key, { ...indexed, unread: false });
+  return { found, unread: false };
 }
 
 export async function deleteSession(sessionId: string): Promise<boolean> {

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -11,6 +11,7 @@ import {
   listPendingChatMessages,
   listSessionPage,
   listSessions,
+  markSessionRead,
   reorderPendingChatMessages,
   revertSessionToMessage,
   setSessionPinned,
@@ -1255,6 +1256,7 @@ const routes: Record<string, RouteHandler> = {
             ? session.workspaceDir
             : null,
         pinned: session.pinned === true,
+        unread: session.unread === true,
         room: session.room ? roomConfigToApi(session.room) : null,
         message_count: session.messageCount,
         last_message: lastMessage
@@ -1559,6 +1561,11 @@ const routes: Record<string, RouteHandler> = {
   "DELETE /api/sessions/:sessionId": async (_body, params) => {
     await deleteSession(params!.sessionId);
     return { success: true, message: "Session deleted" };
+  },
+  "PUT /api/sessions/:sessionId/read": async (_body, params) => {
+    const result = markSessionRead(params!.sessionId);
+    if (!result.found) throw new Error("Session not found");
+    return { success: true, session_id: params!.sessionId, unread: false };
   },
 
   "POST /api/subagents/spawn": async (body) => {

--- a/src/core/database.ts
+++ b/src/core/database.ts
@@ -177,6 +177,7 @@ try {
     workspace_dir TEXT,
     pinned INTEGER NOT NULL DEFAULT 0,
     room_config TEXT,
+    last_read_assistant_message_id TEXT,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
   );
@@ -488,6 +489,41 @@ try {
     db.exec("ALTER TABLE chat_sessions ADD COLUMN room_config TEXT");
     console.error("[Database] Migration: Added room_config column to chat_sessions");
   } catch {}
+
+  try {
+    db.exec("ALTER TABLE chat_sessions ADD COLUMN last_read_assistant_message_id TEXT");
+    console.error("[Database] Migration: Added session read cursors");
+  } catch {}
+
+  try {
+    const migrationKey = "migration.session_read_cursors_v1";
+    const migrated = db.query("SELECT value FROM config WHERE key = ?").get(migrationKey);
+    if (!migrated) {
+      db.exec("BEGIN IMMEDIATE");
+      try {
+        db.exec(`
+          UPDATE chat_sessions
+          SET last_read_assistant_message_id = COALESCE(
+            (
+              SELECT sm.id
+              FROM session_messages sm
+              WHERE sm.session_id = chat_sessions.id AND sm.role = 'assistant'
+              ORDER BY sm.rowid DESC
+              LIMIT 1
+            ),
+            '__read__'
+          )
+        `);
+        db.query("INSERT INTO config (key, value) VALUES (?, ?)").run(migrationKey, "1");
+        db.exec("COMMIT");
+      } catch (error) {
+        db.exec("ROLLBACK");
+        throw error;
+      }
+    }
+  } catch (error) {
+    console.warn("[Database] session read cursor backfill failed:", error);
+  }
 
   try {
     db.exec("ALTER TABLE mcp_servers ADD COLUMN url TEXT");
@@ -894,6 +930,15 @@ const stmts = {
       "UPDATE chat_sessions SET room_config = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?"
     ),
     setPinned: prepare("UPDATE chat_sessions SET pinned = ? WHERE id = ?"),
+    markRead: prepare(
+      `UPDATE chat_sessions
+       SET last_read_assistant_message_id = (
+         SELECT id FROM session_messages
+         WHERE session_id = ? AND role = 'assistant'
+         ORDER BY rowid DESC LIMIT 1
+       )
+       WHERE id = ?`
+    ),
     delete: prepare("DELETE FROM chat_sessions WHERE id = ?"),
     list: prepare("SELECT * FROM chat_sessions ORDER BY pinned DESC, updated_at DESC"),
   },
@@ -1495,6 +1540,10 @@ export const tables = {
     },
     setRoomConfig: (id: string, roomConfig: string | null): boolean => {
       const result = stmts.chatSessions?.setRoomConfig.run(roomConfig, id);
+      return (result?.changes ?? 0) > 0;
+    },
+    markRead: (id: string): boolean => {
+      const result = stmts.chatSessions?.markRead.run(id, id);
       return (result?.changes ?? 0) > 0;
     },
     delete: (id: string) => stmts.chatSessions?.delete.run(id),

--- a/src/core/database.ts
+++ b/src/core/database.ts
@@ -937,7 +937,8 @@ const stmts = {
          WHERE session_id = ? AND role = 'assistant'
          ORDER BY rowid DESC LIMIT 1
        )
-       WHERE id = ?`
+       WHERE id = ?
+       RETURNING id`
     ),
     delete: prepare("DELETE FROM chat_sessions WHERE id = ?"),
     list: prepare("SELECT * FROM chat_sessions ORDER BY pinned DESC, updated_at DESC"),
@@ -1542,10 +1543,8 @@ export const tables = {
       const result = stmts.chatSessions?.setRoomConfig.run(roomConfig, id);
       return (result?.changes ?? 0) > 0;
     },
-    markRead: (id: string): boolean => {
-      const result = stmts.chatSessions?.markRead.run(id, id);
-      return (result?.changes ?? 0) > 0;
-    },
+    markRead: (id: string): boolean =>
+      Boolean(stmts.chatSessions?.markRead.get(id, id) as { id?: string } | null),
     delete: (id: string) => stmts.chatSessions?.delete.run(id),
     all: () => stmts.chatSessions?.list.all() || [],
   },

--- a/src/core/session-context.ts
+++ b/src/core/session-context.ts
@@ -1373,6 +1373,7 @@ export interface PersistedSessionListEntry {
   messageCount: number;
   workspaceDir: string | null;
   pinned: boolean;
+  unread: boolean;
   lastMessageRole: string | null;
   lastMessageContent: string | null;
   modelMetadata: SessionModelMetadata | null;
@@ -1389,6 +1390,7 @@ interface PersistedSessionListRow {
   messageCount: number;
   workspaceDir: string | null;
   pinned: number;
+  unread: number;
   lastMessageRole: string | null;
   lastMessageContent: string | null;
   lastModelMetadata: string | null;
@@ -1420,6 +1422,7 @@ function normalizePersistedSessionListRow(
         ? sanitizeAssistantContent(session.lastMessageContent)
         : session.lastMessageContent,
     pinned: !!session.pinned,
+    unread: !!session.unread,
     modelMetadata: mergeSessionModelMetadata(
       resolveSessionModelMetadata(session.agentId),
       parseSessionModelMetadata(session.lastModelMetadata)
@@ -1444,6 +1447,17 @@ function persistedSessionListSql(
         cs.updated_at as updatedAt,
         cs.workspace_dir as workspaceDir,
         COALESCE(cs.pinned, 0) as pinned,
+        CASE WHEN EXISTS (
+          SELECT 1
+          FROM session_messages unread_message
+          WHERE unread_message.session_id = cs.id
+            AND unread_message.role = 'assistant'
+            AND unread_message.rowid > COALESCE((
+              SELECT read_message.rowid
+              FROM session_messages read_message
+              WHERE read_message.id = cs.last_read_assistant_message_id
+            ), 0)
+        ) THEN 1 ELSE 0 END as unread,
         cs.room_config as roomConfig,
         COALESCE(NULLIF((
           SELECT COUNT(*)

--- a/tests/api/routes-sessions.test.ts
+++ b/tests/api/routes-sessions.test.ts
@@ -546,6 +546,50 @@ describe("Session API", () => {
     expect(Array.isArray(data)).toBe(true);
   });
 
+  test("marks the latest assistant response read without hiding later responses", async () => {
+    const suffix = Date.now();
+    const sessionId = `session-unread-${suffix}`;
+    const agentId = `session-unread-agent-${suffix}`;
+    try {
+      fixture.insertRawAgent(agentId, "Unread Agent", "{}");
+      fixture.insertRawSession(sessionId, agentId, [
+        { role: "user", content: "Work on this" },
+        { role: "assistant", content: "Finished" },
+      ]);
+
+      const before = await fixture.api("GET", "/api/sessions");
+      expect(
+        (before.data as Array<{ id: string; unread: boolean }>).find(
+          (session) => session.id === sessionId
+        )?.unread
+      ).toBe(true);
+
+      const marked = await fixture.api("PUT", `/api/sessions/${sessionId}/read`);
+      expect(marked.status).toBe(200);
+      expect(marked.data).toMatchObject({ success: true, session_id: sessionId, unread: false });
+
+      const after = await fixture.api("GET", "/api/sessions");
+      expect(
+        (after.data as Array<{ id: string; unread: boolean }>).find(
+          (session) => session.id === sessionId
+        )?.unread
+      ).toBe(false);
+
+      fixture.insertRawSession(sessionId, agentId, [
+        { role: "assistant", content: "Another response" },
+      ]);
+      const later = await fixture.api("GET", "/api/sessions");
+      expect(
+        (later.data as Array<{ id: string; unread: boolean }>).find(
+          (session) => session.id === sessionId
+        )?.unread
+      ).toBe(true);
+    } finally {
+      fixture.deleteRawSession(sessionId);
+      fixture.deleteRawAgent(agentId);
+    }
+  });
+
   test("session list and detail include provider/model metadata for the chat agent", async () => {
     const suffix = Date.now();
     const providerId = `session-provider-${suffix}`;

--- a/tests/api/routes-sessions.test.ts
+++ b/tests/api/routes-sessions.test.ts
@@ -568,6 +568,10 @@ describe("Session API", () => {
       expect(marked.status).toBe(200);
       expect(marked.data).toMatchObject({ success: true, session_id: sessionId, unread: false });
 
+      const repeated = await fixture.api("PUT", `/api/sessions/${sessionId}/read`);
+      expect(repeated.status).toBe(200);
+      expect(repeated.data).toMatchObject({ success: true, session_id: sessionId, unread: false });
+
       const after = await fixture.api("GET", "/api/sessions");
       expect(
         (after.data as Array<{ id: string; unread: boolean }>).find(

--- a/tests/core/session-unread-state.test.ts
+++ b/tests/core/session-unread-state.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { deleteSession, listSessions, markSessionRead } from "../../src/api/chat";
+import { persistSession, upsertPersistedSessionMessage } from "../../src/core/session-context";
+
+const createdSessionIds: string[] = [];
+
+function sessionId(): string {
+  return `test-unread-${Date.now()}-${crypto.randomUUID()}`;
+}
+
+async function unreadState(id: string): Promise<boolean | undefined> {
+  return (await listSessions()).find((session) => session.id === id)?.unread;
+}
+
+afterEach(async () => {
+  for (const id of createdSessionIds.splice(0)) await deleteSession(id);
+});
+
+describe("session unread state", () => {
+  test("tracks assistant responses after the durable read cursor", async () => {
+    const id = sessionId();
+    createdSessionIds.push(id);
+    await persistSession(id, "test-agent", []);
+
+    expect(await unreadState(id)).toBe(false);
+
+    await upsertPersistedSessionMessage(id, "test-agent", {
+      role: "assistant",
+      content: "First response",
+      timestamp: "2099-01-01T00:00:01.000Z",
+    });
+    expect(await unreadState(id)).toBe(true);
+
+    expect(markSessionRead(id)).toEqual({ found: true, unread: false });
+    expect(await unreadState(id)).toBe(false);
+
+    await upsertPersistedSessionMessage(id, "test-agent", {
+      role: "user",
+      content: "Follow-up",
+      timestamp: "2099-01-01T00:00:02.000Z",
+    });
+    expect(await unreadState(id)).toBe(false);
+
+    await upsertPersistedSessionMessage(id, "test-agent", {
+      role: "assistant",
+      content: "Second response",
+      timestamp: "2099-01-01T00:00:03.000Z",
+    });
+    expect(await unreadState(id)).toBe(true);
+  });
+
+  test("does not acknowledge unknown sessions", () => {
+    expect(markSessionRead("missing-session")).toEqual({ found: false, unread: false });
+    expect(markSessionRead(" ")).toEqual({ found: false, unread: false });
+  });
+});

--- a/tests/core/session-unread-state.test.ts
+++ b/tests/core/session-unread-state.test.ts
@@ -33,6 +33,7 @@ describe("session unread state", () => {
 
     expect(markSessionRead(id)).toEqual({ found: true, unread: false });
     expect(await unreadState(id)).toBe(false);
+    expect(markSessionRead(id)).toEqual({ found: true, unread: false });
 
     await upsertPersistedSessionMessage(id, "test-agent", {
       role: "user",
@@ -47,6 +48,16 @@ describe("session unread state", () => {
       timestamp: "2099-01-01T00:00:03.000Z",
     });
     expect(await unreadState(id)).toBe(true);
+  });
+
+  test("acknowledges an existing empty session idempotently", async () => {
+    const id = sessionId();
+    createdSessionIds.push(id);
+    await persistSession(id, "test-agent", []);
+
+    expect(markSessionRead(id)).toEqual({ found: true, unread: false });
+    expect(markSessionRead(id)).toEqual({ found: true, unread: false });
+    expect(await unreadState(id)).toBe(false);
   });
 
   test("does not acknowledge unknown sessions", () => {

--- a/tests/ui/unread-response-indicators.test.ts
+++ b/tests/ui/unread-response-indicators.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  DEFAULT_UNREAD_DOT_COLOR,
+  normalizeUnreadDotColor,
+  readUnreadDotColor,
+} from "../../ui/src/lib/unreadPreferences";
+
+const root = resolve(import.meta.dir, "../..");
+const source = (path: string): string => readFileSync(resolve(root, path), "utf8");
+
+describe("unread response indicators", () => {
+  test("normalizes the configurable dot color and has a safe default", () => {
+    expect(normalizeUnreadDotColor("#ABCDEF")).toBe("#abcdef");
+    expect(normalizeUnreadDotColor("red")).toBe(DEFAULT_UNREAD_DOT_COLOR);
+    expect(normalizeUnreadDotColor("#fff")).toBe(DEFAULT_UNREAD_DOT_COLOR);
+    expect(readUnreadDotColor()).toBe(DEFAULT_UNREAD_DOT_COLOR);
+  });
+
+  test("shows the configured dot to the right of unread bot and session names", () => {
+    const botSidebar = source("ui/src/pages/chat/BotSidebar.tsx");
+    const sessionSidebar = source("ui/src/pages/chat/SessionSidebar.tsx");
+
+    for (const sidebar of [botSidebar, sessionSidebar]) {
+      expect(sidebar).toContain('aria-label="Unread response"');
+      expect(sidebar).toContain("backgroundColor: unreadDotColor");
+    }
+    expect(botSidebar.indexOf("{bot.name}")).toBeLessThan(
+      botSidebar.indexOf("bot.session?.unread")
+    );
+    expect(sessionSidebar.indexOf("{displayTitle}")).toBeLessThan(
+      sessionSidebar.indexOf("session.unread && !isSessionSelected")
+    );
+  });
+
+  test("clears unread state immediately when a bot or session opens", () => {
+    const botSidebar = source("ui/src/pages/chat/BotSidebar.tsx");
+    const sessionSidebar = source("ui/src/pages/chat/SessionSidebar.tsx");
+    const chat = source("ui/src/pages/Chat.tsx");
+
+    expect(botSidebar).toContain("markBotReadImmediately(bot.session_id)");
+    expect(botSidebar).toContain("unread: false");
+    expect(sessionSidebar).toContain("markReadImmediately(sessionId)");
+    expect(sessionSidebar).toContain("sessionQueryClient.setQueriesData");
+    expect(chat).toContain("chatApi.markSessionRead(sessionId)");
+    expect(chat).toContain("typedMessages.length");
+  });
+
+  test("exposes the color picker in Appearance settings", () => {
+    const settings = source("ui/src/pages/settings/ThemeSettings.tsx");
+    expect(settings).toContain("Unread response color");
+    expect(settings).toContain('type="color"');
+    expect(settings).toContain("persistUnreadDotColor");
+  });
+});

--- a/tests/ui/unread-response-indicators.test.ts
+++ b/tests/ui/unread-response-indicators.test.ts
@@ -38,13 +38,15 @@ describe("unread response indicators", () => {
     const botSidebar = source("ui/src/pages/chat/BotSidebar.tsx");
     const sessionSidebar = source("ui/src/pages/chat/SessionSidebar.tsx");
     const chat = source("ui/src/pages/Chat.tsx");
+    const acknowledgement = source("ui/src/pages/chat/useSessionReadAcknowledgement.ts");
 
     expect(botSidebar).toContain("markBotReadImmediately(bot.session_id)");
     expect(botSidebar).toContain("unread: false");
     expect(sessionSidebar).toContain("markReadImmediately(sessionId)");
     expect(sessionSidebar).toContain("sessionQueryClient.setQueriesData");
-    expect(chat).toContain("chatApi.markSessionRead(sessionId)");
-    expect(chat).toContain("typedMessages.length");
+    expect(chat).toContain("useSessionReadAcknowledgement(sessionId, typedMessages.length)");
+    expect(acknowledgement).toContain("chatApi.markSessionRead(sessionId)");
+    expect(acknowledgement).toContain("[messageCount, queryClient, sessionId]");
   });
 
   test("exposes the color picker in Appearance settings", () => {

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1411,6 +1411,7 @@ export const chatApi = {
         pinned?: boolean;
         room?: SessionRoomConfig | null;
         message_count?: number;
+        unread?: boolean;
         last_message?: { role: string; content: string };
       }[]
     >("/sessions" + (suffix ? `?${suffix}` : ""));
@@ -1630,6 +1631,11 @@ export const chatApi = {
     }>(`/sessions/${encodeURIComponent(sessionId)}/artifacts/${encodeURIComponent(artifactName)}`, {
       method: "DELETE",
     }),
+  markSessionRead: (id: string) =>
+    fetchApi<{ success: boolean; session_id: string; unread: false }>(
+      `/sessions/${encodeURIComponent(id)}/read`,
+      { method: "PUT" }
+    ),
   deleteSession: (id: string) => fetchApi<void>("/sessions/" + id, { method: "DELETE" }),
 };
 
@@ -1920,6 +1926,7 @@ export const sessionsApi = {
         pinned?: boolean;
         room?: SessionRoomConfig | null;
         message_count?: number;
+        unread?: boolean;
         last_message?: { role: string; content: string };
       }[]
     >("/sessions" + (suffix ? `?${suffix}` : ""));

--- a/ui/src/lib/unreadPreferences.ts
+++ b/ui/src/lib/unreadPreferences.ts
@@ -1,0 +1,49 @@
+import { useSyncExternalStore } from "react";
+
+export const DEFAULT_UNREAD_DOT_COLOR = "#38bdf8";
+const UNREAD_DOT_COLOR_KEY = "cybara-unread-dot-color";
+const UNREAD_DOT_COLOR_EVENT = "cybara:unread-dot-color-changed";
+const HEX_COLOR = /^#[0-9a-f]{6}$/i;
+
+export function normalizeUnreadDotColor(value: unknown): string {
+  return typeof value === "string" && HEX_COLOR.test(value.trim())
+    ? value.trim().toLowerCase()
+    : DEFAULT_UNREAD_DOT_COLOR;
+}
+
+export function readUnreadDotColor(): string {
+  if (typeof window === "undefined") return DEFAULT_UNREAD_DOT_COLOR;
+  try {
+    return normalizeUnreadDotColor(window.localStorage.getItem(UNREAD_DOT_COLOR_KEY));
+  } catch {
+    return DEFAULT_UNREAD_DOT_COLOR;
+  }
+}
+
+export function persistUnreadDotColor(color: string): void {
+  const normalized = normalizeUnreadDotColor(color);
+  try {
+    window.localStorage.setItem(UNREAD_DOT_COLOR_KEY, normalized);
+    window.dispatchEvent(new CustomEvent(UNREAD_DOT_COLOR_EVENT));
+  } catch {
+    return;
+  }
+}
+
+function subscribeUnreadDotColor(onChange: () => void): () => void {
+  const listener = (): void => onChange();
+  window.addEventListener(UNREAD_DOT_COLOR_EVENT, listener);
+  window.addEventListener("storage", listener);
+  return () => {
+    window.removeEventListener(UNREAD_DOT_COLOR_EVENT, listener);
+    window.removeEventListener("storage", listener);
+  };
+}
+
+export function useUnreadDotColor(): string {
+  return useSyncExternalStore(
+    subscribeUnreadDotColor,
+    readUnreadDotColor,
+    () => DEFAULT_UNREAD_DOT_COLOR
+  );
+}

--- a/ui/src/pages/Chat.tsx
+++ b/ui/src/pages/Chat.tsx
@@ -631,11 +631,15 @@ export function Chat() {
   useEffect(() => {
     if (sessionId) {
       persistSessionId(sessionId);
-      void chatApi.markSessionRead(sessionId).then(() => {
-        void queryClient.invalidateQueries({ queryKey: ["sessions"] });
-        void queryClient.invalidateQueries({ queryKey: ["bots"] });
-      });
     }
+  }, [sessionId]);
+
+  useEffect(() => {
+    if (!sessionId) return;
+    void chatApi.markSessionRead(sessionId).then(() => {
+      void queryClient.invalidateQueries({ queryKey: ["sessions"] });
+      void queryClient.invalidateQueries({ queryKey: ["bots"] });
+    });
   }, [queryClient, sessionId, typedMessages.length]);
 
   useEffect(() => {

--- a/ui/src/pages/Chat.tsx
+++ b/ui/src/pages/Chat.tsx
@@ -52,6 +52,7 @@ import { ChatEmptyState } from "./chat/ChatEmptyState";
 import { GoalPanel } from "./chat/GoalPanel";
 import { isVisibleChatTranscriptMessage } from "./chat/goalLoopPresentation";
 import { useSessionGoal } from "./chat/useSessionGoal";
+import { useSessionReadAcknowledgement } from "./chat/useSessionReadAcknowledgement";
 import { normalizeToolApprovalMode, type ToolApprovalMode } from "./chat/ChatFollowUpControls";
 import { onOpenChatImageLightbox } from "@/lib/chatImageLightbox";
 import { ChatImageLightbox } from "./chat/ChatImageLightbox";
@@ -161,6 +162,7 @@ export function Chat() {
   const goalController = useSessionGoal(sessionId || undefined);
   const { data: environmentSubagents = [] } = useSubagents(sessionId);
   const typedMessages = messages as ChatMessage[];
+  useSessionReadAcknowledgement(sessionId, typedMessages.length);
   const currentBot = useCurrentBot(botRoster, sessionId);
   const currentRoom = useCurrentRoom(sessionId);
   const composerAgents = useComposerAgents(agents, currentBot);
@@ -633,14 +635,6 @@ export function Chat() {
       persistSessionId(sessionId);
     }
   }, [sessionId]);
-
-  useEffect(() => {
-    if (!sessionId) return;
-    void chatApi.markSessionRead(sessionId).then(() => {
-      void queryClient.invalidateQueries({ queryKey: ["sessions"] });
-      void queryClient.invalidateQueries({ queryKey: ["bots"] });
-    });
-  }, [queryClient, sessionId, typedMessages.length]);
 
   useEffect(() => {
     let active = true;

--- a/ui/src/pages/Chat.tsx
+++ b/ui/src/pages/Chat.tsx
@@ -631,8 +631,12 @@ export function Chat() {
   useEffect(() => {
     if (sessionId) {
       persistSessionId(sessionId);
+      void chatApi.markSessionRead(sessionId).then(() => {
+        void queryClient.invalidateQueries({ queryKey: ["sessions"] });
+        void queryClient.invalidateQueries({ queryKey: ["bots"] });
+      });
     }
-  }, [sessionId]);
+  }, [queryClient, sessionId, typedMessages.length]);
 
   useEffect(() => {
     let active = true;

--- a/ui/src/pages/Chat.tsx
+++ b/ui/src/pages/Chat.tsx
@@ -10,7 +10,7 @@ import {
 import { ChatRoomBanner, roomComposerLabel, useCurrentRoom } from "./chat/RoomBanner";
 import { useComposerAgents, useCurrentBot } from "./chat/useChatBotContext";
 import { canShareNearbySession, useNearbyStatus } from "@/hooks/useNearbyStatus";
-import { botsApi, chatApi, extractApiError, providerPlansApi, settingsApi } from "@/lib/api";
+import { chatApi, providerPlansApi, settingsApi } from "@/lib/api";
 import {
   APP_HOTKEY_EVENT,
   type AppHotkeyActionId,
@@ -28,14 +28,9 @@ import { useI18n } from "@/lib/i18n";
 import { type PendingChatMessage, type StatusSessionSnapshot } from "@/lib/status-stream";
 import { cn } from "@/lib/utils";
 import { useUIStore } from "@/stores/uiStore";
-import type {
-  BotRosterItem,
-  ProviderPlanStatusResponse,
-  SessionContextUsage,
-  SessionTokenUsage,
-} from "@/types";
+import type { ProviderPlanStatusResponse, SessionContextUsage, SessionTokenUsage } from "@/types";
 import { openExternal } from "@/utils/openExternal";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQueryClient } from "@tanstack/react-query";
 import { ArrowDown, Loader2, RotateCcw } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router";
@@ -99,6 +94,7 @@ import {
   type StoppedRunSuppressions,
 } from "./chat/stopSuppression";
 import { useArtifactViewer } from "./chat/useArtifactViewer";
+import { useBotRoster } from "./chat/useBotRoster";
 import { useChatAttachments } from "./chat/useChatAttachments";
 import { useChatCapabilityPicker } from "./chat/useChatCapabilityPicker";
 import { useChatDictation } from "./chat/useChatDictation";
@@ -123,18 +119,7 @@ export function Chat() {
   const { data: agents = [] } = useAgentSummaries();
   const updateAgentReasoning = useUpdateAgentReasoning();
   const { data: info } = useInfo();
-  const { data: botRoster = [] } = useQuery<BotRosterItem[]>({
-    queryKey: ["bots"],
-    queryFn: async () => {
-      const response = await botsApi.list();
-      if (!response.success || !response.data) {
-        throw new Error(extractApiError(response, "Could not load bots"));
-      }
-      return response.data.bots;
-    },
-    staleTime: 5_000,
-    refetchInterval: 10_000,
-  });
+  const botRoster = useBotRoster();
   const [initialChatRoute] = useState(() => parseInitialChatRoute(window.location.search));
   const [selectedAgentId, setSelectedAgentId] = useState<string | undefined>(
     initialChatRoute.agentId ?? undefined

--- a/ui/src/pages/chat/BotSidebar.tsx
+++ b/ui/src/pages/chat/BotSidebar.tsx
@@ -22,13 +22,15 @@ import {
   Wrench,
   X,
 } from "lucide-react";
-import { useDeferredValue, useMemo, useState, type ChangeEvent } from "react";
+import { useDeferredValue, useEffect, useMemo, useRef, useState, type ChangeEvent } from "react";
 import { useNavigate } from "react-router";
 import { Button, ConfirmDialog, Input, Modal, Select, Textarea } from "@/components/ui";
 import { useAgentSummaries, useDeleteSession, useProviders } from "@/hooks/useApi";
-import { botsApi, extractApiError } from "@/lib/api";
+import { botsApi, chatApi, extractApiError } from "@/lib/api";
 import { useI18n } from "@/lib/i18n";
 import { cn, formatRelativeTime } from "@/lib/utils";
+import { useUnreadDotColor } from "@/lib/unreadPreferences";
+import { connectStatusStream } from "@/lib/status-stream";
 import type { BotRosterItem } from "@/types";
 import { BotAvatar } from "./BotAvatar";
 import { resolveBotBaseAgentId, selectableBotBaseAgents } from "./botAgentSelection";
@@ -88,6 +90,7 @@ export function BotSidebar({
 }: BotSidebarProps) {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const unreadDotColor = useUnreadDotColor();
   const { t } = useI18n();
   const { data: providers = [] } = useProviders();
   const agentsQuery = useAgentSummaries();
@@ -109,6 +112,7 @@ export function BotSidebar({
   const [role, setRole] = useState<BotRoleId | "">("");
   const [teamBotIds, setTeamBotIds] = useState<string[]>([]);
   const deferredQuery = useDeferredValue(query);
+  const botsRefreshTimerRef = useRef<number | null>(null);
   const activeIds = useMemo(() => new Set(activeSessionIds), [activeSessionIds]);
   const botsQuery = useQuery({
     queryKey: ["bots"],
@@ -123,6 +127,30 @@ export function BotSidebar({
     refetchInterval: 10_000,
   });
   const allBots = botsQuery.data ?? [];
+  const refetchBots = botsQuery.refetch;
+  useEffect(() => {
+    const disconnect = connectStatusStream({
+      onEvent: (event) => {
+        if (!event || typeof event !== "object") return;
+        if (
+          event.type !== "status" &&
+          event.type !== "snapshot" &&
+          event.type !== "task_completed"
+        ) {
+          return;
+        }
+        if (botsRefreshTimerRef.current !== null) window.clearTimeout(botsRefreshTimerRef.current);
+        botsRefreshTimerRef.current = window.setTimeout(() => {
+          void refetchBots();
+          botsRefreshTimerRef.current = null;
+        }, 600);
+      },
+    });
+    return () => {
+      disconnect();
+      if (botsRefreshTimerRef.current !== null) window.clearTimeout(botsRefreshTimerRef.current);
+    };
+  }, [refetchBots]);
   const { data: allSessions = [] } = useSessions();
   const roomSessionList = useMemo(
     () => allSessions.filter((session) => isRoomSessionId(session.id)),
@@ -158,6 +186,17 @@ export function BotSidebar({
     void queryClient.invalidateQueries({ queryKey: ["agents"] });
   };
 
+  const markBotReadImmediately = (sessionId: string): void => {
+    queryClient.setQueryData<BotRosterItem[]>(["bots"], (bots) =>
+      bots?.map((bot) =>
+        bot.session_id === sessionId && bot.session
+          ? { ...bot, session: { ...bot.session, unread: false } }
+          : bot
+      )
+    );
+    void chatApi.markSessionRead(sessionId).then(refreshBots).catch(refreshBots);
+  };
+
   const openBot = useMutation({
     mutationFn: async (id: string) => {
       const response = await botsApi.ensureSession(id);
@@ -170,6 +209,7 @@ export function BotSidebar({
       refreshBots();
       navigate(buildSessionChatPath(sessionId));
     },
+    onError: refreshBots,
   });
   const createBot = useMutation({
     mutationFn: async () => {
@@ -468,7 +508,10 @@ export function BotSidebar({
                   >
                     <button
                       type="button"
-                      onClick={() => openBot.mutate(bot.id)}
+                      onClick={() => {
+                        markBotReadImmediately(bot.session_id);
+                        openBot.mutate(bot.id);
+                      }}
                       className="flex min-w-0 flex-1 items-center gap-2.5 rounded-xl px-2 py-2 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(var(--accent-primary),0.45)]"
                     >
                       <BotAvatar bot={bot} active={active} />
@@ -480,6 +523,14 @@ export function BotSidebar({
                           <span className="min-w-0 flex-1 truncate text-[13px] font-semibold text-[var(--text-primary)]">
                             {bot.name}
                           </span>
+                          {bot.session?.unread && !selected ? (
+                            <span
+                              className="h-2.5 w-2.5 shrink-0 rounded-full shadow-[0_0_0_2px_rgba(255,255,255,0.12)]"
+                              style={{ backgroundColor: unreadDotColor }}
+                              aria-label="Unread response"
+                              title="Unread response"
+                            />
+                          ) : null}
                           {bot.session?.updated_at ? (
                             <span className="shrink-0 text-[10px] text-[var(--text-subtle)]">
                               {formatRelativeTime(bot.session.updated_at).replace(" ago", "")}

--- a/ui/src/pages/chat/SessionSidebar.tsx
+++ b/ui/src/pages/chat/SessionSidebar.tsx
@@ -28,6 +28,7 @@ import {
 } from "react";
 import { createPortal } from "react-dom";
 import { useNavigate } from "react-router";
+import { useQueryClient } from "@tanstack/react-query";
 import { Button, Modal } from "@/components/ui";
 import { useTasks } from "@/hooks/useApi";
 import {
@@ -39,8 +40,10 @@ import {
   useSessions,
 } from "@/hooks/useChat";
 import { apiFetch } from "@/lib/auth";
+import { chatApi } from "@/lib/api";
 import { useI18n } from "@/lib/i18n";
 import { connectStatusStream } from "@/lib/status-stream";
+import { useUnreadDotColor } from "@/lib/unreadPreferences";
 import { cn } from "@/lib/utils";
 import type { SessionContextUsage, SessionTokenUsage, Task } from "@/types";
 import type { ChatMessage } from "./chatModel";
@@ -284,7 +287,9 @@ export function SessionsPanel({
 }: SessionsPanelProps) {
   const navigate = useNavigate();
   const { t } = useI18n();
+  const unreadDotColor = useUnreadDotColor();
   const { data: allSessions, isLoading, refetch } = useSessions();
+  const sessionQueryClient = useQueryClient();
   const sessions = useMemo(
     () => allSessions?.filter((session) => !isRoomSessionId(session.id)),
     [allSessions]
@@ -460,7 +465,22 @@ export function SessionsPanel({
     [onLoadSession]
   );
 
+  const markReadImmediately = (sessionId: string): void => {
+    sessionQueryClient.setQueriesData<Array<ChatSidebarSession>>(
+      { queryKey: ["sessions"] },
+      (sessions) =>
+        sessions?.map((session) =>
+          session.id === sessionId ? { ...session, unread: false } : session
+        )
+    );
+    void chatApi
+      .markSessionRead(sessionId)
+      .then(() => refetch())
+      .catch(() => refetch());
+  };
+
   const handleLoadSession = async (sessionId: string) => {
+    markReadImmediately(sessionId);
     if (placement === "main") {
       navigate(`/chat?session=${encodeURIComponent(sessionId)}`);
       return;
@@ -850,6 +870,14 @@ export function SessionsPanel({
                                 <span className="min-w-0 flex-1 truncate leading-none">
                                   {displayTitle}
                                 </span>
+                                {session.unread && !isSessionSelected ? (
+                                  <span
+                                    className="h-2.5 w-2.5 shrink-0 rounded-full shadow-[0_0_0_2px_rgba(255,255,255,0.12)]"
+                                    style={{ backgroundColor: unreadDotColor }}
+                                    aria-label="Unread response"
+                                    title="Unread response"
+                                  />
+                                ) : null}
                                 <span className="ml-1 flex h-full w-8 shrink-0 items-center justify-end text-[12px] font-medium leading-none text-gray-500">
                                   {isSessionActive ? (
                                     <Loader2 className="h-3 w-3 animate-spin text-gray-400" />

--- a/ui/src/pages/chat/sessionGrouping.ts
+++ b/ui/src/pages/chat/sessionGrouping.ts
@@ -13,6 +13,7 @@ export interface ChatSidebarSession {
   updated_at?: string;
   workspace_dir?: string | null;
   pinned?: boolean;
+  unread?: boolean;
   message_count?: number;
   last_message?: { role: string; content: string } | null;
 }

--- a/ui/src/pages/chat/useBotRoster.ts
+++ b/ui/src/pages/chat/useBotRoster.ts
@@ -1,0 +1,20 @@
+import { botsApi, extractApiError } from "@/lib/api";
+import type { BotRosterItem } from "@/types";
+import { useQuery } from "@tanstack/react-query";
+
+export function useBotRoster(): BotRosterItem[] {
+  return (
+    useQuery<BotRosterItem[]>({
+      queryKey: ["bots"],
+      queryFn: async () => {
+        const response = await botsApi.list();
+        if (!response.success || !response.data) {
+          throw new Error(extractApiError(response, "Could not load bots"));
+        }
+        return response.data.bots;
+      },
+      staleTime: 5_000,
+      refetchInterval: 10_000,
+    }).data ?? []
+  );
+}

--- a/ui/src/pages/chat/useSessionReadAcknowledgement.ts
+++ b/ui/src/pages/chat/useSessionReadAcknowledgement.ts
@@ -1,0 +1,18 @@
+import { chatApi } from "@/lib/api";
+import { useQueryClient } from "@tanstack/react-query";
+import { useEffect } from "react";
+
+export function useSessionReadAcknowledgement(
+  sessionId: string | null,
+  messageCount: number
+): void {
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (!sessionId) return;
+    void chatApi.markSessionRead(sessionId).then(() => {
+      void queryClient.invalidateQueries({ queryKey: ["sessions"] });
+      void queryClient.invalidateQueries({ queryKey: ["bots"] });
+    });
+  }, [messageCount, queryClient, sessionId]);
+}

--- a/ui/src/pages/settings/ThemeSettings.tsx
+++ b/ui/src/pages/settings/ThemeSettings.tsx
@@ -4,6 +4,7 @@ import { useIdentity, useUpdateIdentity, type IdentityConfig } from "@/hooks/use
 import { settingsApi } from "@/lib/api";
 import { useI18n, languageOptions } from "@/lib/i18n";
 import { persistPetEnabled, readPetEnabled } from "@/lib/petPreferences";
+import { persistUnreadDotColor, readUnreadDotColor } from "@/lib/unreadPreferences";
 import { cn } from "@/lib/settingsFormat";
 import {
   customThemeConfigPayload,
@@ -67,6 +68,7 @@ export function ThemeSettings() {
   const [savingAccent, setSavingAccent] = useState<ThemeAccent | null>(null);
   const [draftTheme, setDraftTheme] = useState<CustomThemeBundle | null>(null);
   const [petEnabled, setPetEnabled] = useState(() => readPetEnabled());
+  const [unreadDotColor, setUnreadDotColor] = useState(() => readUnreadDotColor());
   const fileInputRef = useRef<HTMLInputElement>(null);
   const identityThemeRef = useRef<{ initialized: boolean; value: unknown }>({
     initialized: false,
@@ -513,6 +515,32 @@ export function ThemeSettings() {
               }))}
             />
           </div>
+        </section>
+
+        <section className="flex items-center justify-between gap-4 border-t border-[var(--surface-border)] pt-5">
+          <div>
+            <span className="text-sm text-[var(--text-secondary)]">Unread response color</span>
+            <p className="mt-1 text-xs text-[var(--text-muted)]">
+              Used for the dot shown to the right of agents with unread responses.
+            </p>
+          </div>
+          <label className="flex items-center gap-2">
+            <input
+              type="color"
+              value={unreadDotColor}
+              onChange={(event) => {
+                setUnreadDotColor(event.target.value);
+                persistUnreadDotColor(event.target.value);
+              }}
+              className="h-8 w-10 cursor-pointer rounded-md border border-[var(--surface-border)] bg-transparent p-0.5"
+              aria-label="Unread response color"
+            />
+            <span
+              className="h-2.5 w-2.5 rounded-full"
+              style={{ backgroundColor: unreadDotColor }}
+              aria-hidden="true"
+            />
+          </label>
         </section>
 
         <section className="flex items-center justify-between gap-4 border-t border-[var(--surface-border)] pt-5">

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -72,6 +72,7 @@ export interface BotRosterItem {
     title?: string | null;
     updated_at?: string;
     message_count?: number;
+    unread?: boolean;
     last_message?: { role: string; content: string } | null;
   } | null;
 }


### PR DESCRIPTION
## Summary

- persist a per-session read cursor and expose unread assistant-response state in session and bot rosters
- show a configurable colored unread dot to the right of bot and session names
- clear the dot optimistically as soon as the conversation is opened, then acknowledge it on the gateway
- keep an already-open conversation read as new assistant responses arrive
- initialize existing conversations as read during a one-time migration so upgrades do not mark historical replies unread
- refresh bot and session rosters from existing status-stream events rather than adding a polling loop

## User experience

The unread dot appears only after a newer assistant response exists beyond the session's durable read cursor. It is distinct from the bot presence indicator. Opening the bot/session removes the dot immediately; a failed acknowledgement restores canonical state on refresh.

The color is configurable under **Settings → General → Appearance → Unread response color** and defaults to `#38bdf8`.

## Persistence and API

- adds `chat_sessions.last_read_assistant_message_id`
- derives `unread` from assistant-message row order versus the read cursor
- adds `PUT /api/sessions/:sessionId/read`
- includes `unread` in `/api/sessions` and bot roster session summaries

## Testing

Passed:

- focused unread backend/UI tests: 6 tests
- related bot/settings tests: 24 tests
- route regression for mark-read and later responses
- root TypeScript typecheck
- UI TypeScript typecheck
- root lint
- UI lint
- format check
- production UI build
- browser acceptance: verified color picker, right-side unread dot, immediate removal on opening, and persisted `unread: false` from the session API

`bun run check:ci` passed static phases, LOC, dependency checks, React Doctor scanning, and several smoke shards. The smoke runner reported 2,450 passing, 1 skipped, 20 failing, and 136 loader/environment errors on this host. The failures were outside this change: child-process `execute_code`, nearby UDP networking, agent tool timing/budgets, LSP cleanup, and dataset concurrency/timeout suites. Focused tests covering this change are green.

## Security review

The complete diff and staged commit were scanned before push for tokens, private keys, credential literals, personal hostnames/IPs, and contributor-specific paths; no matches were found. This change stores only opaque local session-message IDs and a display color. It does not add secrets or log message content.


<!-- GITZILLA_SUMMARY -->
> [!NOTE]
> **Low Risk**
>
> **Overview**
> This PR introduces configurable unread-response indicators for chat sessions and bots. On the backend, it adds a per-session read cursor persisted in the database (with a one-time migration that marks existing conversations as read), exposes unread counts on session and bot roster payloads via new API endpoints, and adds a route to acknowledge reads on the gateway. On the frontend, a new `unreadPreferences` module controls dot visibility and color, which is exposed in the theme settings; new hooks (`useBotRoster`, `useSessionReadAcknowledgement`) drive the UI, and the bot/session sidebars render a colored unread dot to the right of each name. The dot clears optimistically when a conversation is opened and is kept cleared as new assistant responses stream in while the chat is open, with new tests covering the session state, routes, and indicator rendering.
>
> <sup>Written by [Gitzilla](https://gitzilla.ai) for commit fb38b21. This will update automatically on new runs. Configure in the [Gitzilla dashboard](https://gitzilla.ai/dashboard).</sup>
<!-- /GITZILLA_SUMMARY -->