### PR TITLE
Release

### DIFF
--- a/apps/mobile/src/lib/chat-format.ts
+++ b/apps/mobile/src/lib/chat-format.ts
@@ -1,5 +1,6 @@
-import type { MobileMessageImage, SessionMessageSummary } from "./api";
 import { isProviderRecoveryStatusLabel } from "cybara-shared/chat-status";
+import { formatStructuredToolActivityDetail } from "cybara-shared/tool-activity-detail";
+import type { MobileMessageImage, SessionMessageSummary } from "./api";
 
 export function formatBytes(bytes: number): string {
   if (!bytes || bytes <= 0 || !Number.isFinite(bytes)) return "";
@@ -233,6 +234,9 @@ function formatToolIntent(
   phase: MobileWorkActivityPhase,
   fallbackDetail?: string
 ): string {
+  const structuredDetail = formatStructuredToolActivityDetail(toolName, args ?? {}, phase);
+  if (structuredDetail) return structuredDetail;
+
   if (fallbackDetail?.trim() && !isGenericStatusLabel(fallbackDetail)) {
     return normalizeVerb(fallbackDetail, phase);
   }

--- a/plugins/blender-workflows/skills/blender-headless/SKILL.md
+++ b/plugins/blender-workflows/skills/blender-headless/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: blender-headless
+description: Build, render, and visually verify 3D models with Blender's Python API in headless mode, using the image tool to inspect renders and iterate.
+metadata: {"cybara":{"os":["darwin","linux","win32"]}}
+---
+
+# Blender Headless Modeling
+
+Use this when the user wants a 3D model, scene, or render produced locally with Blender and no Blender MCP server is configured.
+
+## Locate Blender
+
+1. Try `which blender`, then platform defaults: `/Applications/Blender.app/Contents/MacOS/Blender`, `/usr/bin/blender`, `/snap/bin/blender`, `%ProgramFiles%\Blender Foundation\Blender*\blender.exe`.
+2. Confirm with `<blender> --version` and note the major version; the Python API changes between releases.
+
+## Build with a script
+
+1. Write one `build_<name>.py` that resets the scene (`bpy.ops.wm.read_factory_settings(use_empty=True)`), builds geometry with `bpy.ops.mesh.primitive_*` or `bmesh`, assigns materials, adds a camera and lights, sets `scene.render.filepath` to an absolute path, and renders with `bpy.ops.render.render(write_still=True)`.
+2. Keep every file write comfortably under the model output limit: build large scripts in parts (a base file, then `edit` calls that append helpers) instead of one huge `write`. A tool call cut off by the output limit loses its arguments.
+3. Run `<blender> --background --python build_<name>.py` with a timeout of at least 300 seconds and capture stdout and stderr; Blender prints Python tracebacks there.
+4. Prefer `BLENDER_EEVEE` (Blender 4.2+ removed the `_NEXT` suffix) or `CYCLES` with a low sample count for verification renders; render around 1400x900 PNG.
+5. Save the `.blend` with `bpy.ops.wm.save_as_mainfile(filepath=...)` so the user can open the result.
+
+## Verify visually, then iterate
+
+1. Render at least two views (side and three-quarter) to separate PNG files.
+2. Inspect each render with the `image` tool and compare it with the requested object: proportions, missing parts, floating geometry, exposure, framing.
+3. Fix the script for each discrepancy, re-render, and inspect again. Do not report success from script output alone.
+4. Do not delete or overwrite renders you already reported to the user; write new versions to new file names.
+
+## Report
+
+List the script, the `.blend`, and every render path, and describe what the final renders show.

--- a/plugins/game-development/skills/unreal-engine/SKILL.md
+++ b/plugins/game-development/skills/unreal-engine/SKILL.md
@@ -33,6 +33,14 @@ Use the project's existing scripts when present. Otherwise select the narrowest 
 5. Launch the correct map and exercise the changed player flow.
 6. Inspect logs for ensures, access violations, asset load failures, shader failures, and automation errors.
 
+## Headless automation and visual verification
+
+1. Drive editor automation with Python when no C++ change is needed: `UnrealEditor-Cmd <project.uproject> -run=pythonscript -script=<absolute script.py> -unattended -nop4 -nosplash` after resolving the real editor binary; enable the Python Editor Script Plugin first.
+2. Keep each generated script small and split large scripts across several write or edit calls; a tool call cut off by the output limit loses its arguments.
+3. For visual checks, capture stills with `HighResShot` console commands, `unreal.AutomationLibrary.take_high_res_screenshot`, or a Movie Render Queue job, writing PNG files to absolute paths.
+4. Inspect every capture with the `image` tool, compare it with the requested result, fix, re-run, and inspect again before reporting.
+5. Keep captures you reported to the user; write new versions to new file names.
+
 ## Performance
 
 Capture representative frame timing before changing performance-sensitive code. Distinguish game thread, render thread, GPU, streaming, shader compilation, and memory pressure. Validate packaged behavior because editor timing is not a shipping baseline.

--- a/shared/chat-activity-groups.ts
+++ b/shared/chat-activity-groups.ts
@@ -7,7 +7,14 @@ export interface SharedActivityItem {
   toolName?: string;
 }
 
-export type SharedActivityGroupKind = "read" | "search" | "list" | "edit" | "fetch" | "command";
+export type SharedActivityGroupKind =
+  | "read"
+  | "search"
+  | "list"
+  | "edit"
+  | "fetch"
+  | "command"
+  | "view";
 
 export interface SharedActivityDisplayGroup<T extends SharedActivityItem> {
   type: "group";
@@ -27,6 +34,7 @@ export type SharedActivityDisplayEntry<T extends SharedActivityItem> =
   | SharedActivityDisplaySingle<T>;
 
 const TOOL_KINDS: Record<string, SharedActivityGroupKind> = {
+  image: "view",
   read: "read",
   grep: "search",
   file_search: "search",
@@ -43,7 +51,7 @@ const TOOL_KINDS: Record<string, SharedActivityGroupKind> = {
   http_request: "fetch",
 };
 
-const STANDALONE_TOOLS = new Set(["image", "browser_screenshot", "computer_use", "mobile_simulator"]);
+const STANDALONE_TOOLS = new Set(["browser_screenshot", "computer_use", "mobile_simulator"]);
 
 const COMMAND_KINDS: Record<string, SharedActivityGroupKind> = {
   cat: "read",
@@ -162,6 +170,7 @@ const PHRASES: Record<
   edit: { one: "edited a file", many: (count) => `edited ${count} files` },
   fetch: { one: "fetched a page", many: (count) => `fetched ${count} pages` },
   command: { one: "ran a command", many: (count) => `ran ${count} commands` },
+  view: { one: "viewed an image", many: (count) => `viewed ${count} images` },
 };
 
 function groupLabel(kinds: SharedActivityGroupKind[]): string {
@@ -175,7 +184,7 @@ function groupLabel(kinds: SharedActivityGroupKind[]): string {
 
 function dominantKind(kinds: SharedActivityGroupKind[]): SharedActivityGroupKind {
   return (
-    (["edit", "fetch", "search", "read", "list", "command"] as const).find((kind) =>
+    (["view", "edit", "fetch", "search", "read", "list", "command"] as const).find((kind) =>
       kinds.includes(kind),
     ) ?? "command"
   );
@@ -224,6 +233,7 @@ export function groupSharedActivities<T extends SharedActivityItem>(
       entries.push({ type: "single", activity });
       continue;
     }
+    if (run && (kind === "view") !== (run.kinds[0] === "view")) flush();
     if (run) {
       run.kinds.push(kind);
       run.items.push(activity);

--- a/shared/chat-activity-groups.ts
+++ b/shared/chat-activity-groups.ts
@@ -43,6 +43,8 @@ const TOOL_KINDS: Record<string, SharedActivityGroupKind> = {
   http_request: "fetch",
 };
 
+const STANDALONE_TOOLS = new Set(["image", "browser_screenshot", "computer_use", "mobile_simulator"]);
+
 const COMMAND_KINDS: Record<string, SharedActivityGroupKind> = {
   cat: "read",
   head: "read",
@@ -134,6 +136,7 @@ export function sharedActivityKind(
 ): SharedActivityGroupKind | null {
   if (activity.phase !== "result") return null;
   const toolName = activity.toolName?.toLowerCase() || "";
+  if (STANDALONE_TOOLS.has(toolName)) return null;
   if (toolName in TOOL_KINDS) return TOOL_KINDS[toolName] ?? "command";
   if (toolName === "exec" || toolName === "process" || toolName === "git" || !toolName) {
     const command = activity.text.match(/^Ran\s+(.+)$/s)?.[1];

--- a/shared/tool-activity-detail.ts
+++ b/shared/tool-activity-detail.ts
@@ -104,11 +104,45 @@ export function formatStructuredToolActivityDetail(
     return name ? `Skill load failed for ${name}` : "Skill load failed";
   }
 
+  if (key === "image") {
+    if (phase === "start") return "Viewing an image";
+    if (phase === "result") return "Viewed an image";
+    if (phase === "blocked") return "Image view blocked";
+    return "Image view failed";
+  }
+
   if (key === "todo" || key === "update_plan") {
     return formatPlanSummary(resolvePlanItems(args, result), phase);
   }
 
   return undefined;
+}
+
+function imageSourceName(source: string): string | undefined {
+  if (source.startsWith("data:")) return undefined;
+  const segments = source
+    .replace(/[?#].*$/, "")
+    .replace(/\\/g, "/")
+    .split("/")
+    .filter(Boolean);
+  return segments[segments.length - 1];
+}
+
+function imageActivityDetail(
+  args: Record<string, unknown>,
+  phase: ToolActivityPhase,
+  result?: unknown,
+): string | undefined {
+  const summary = formatStructuredToolActivityDetail("image", args, phase, result);
+  const source = readString(args, ["image", "path", "filePath", "url"]);
+  const name = source ? imageSourceName(source) : undefined;
+  const prompt = readString(args, ["prompt"]);
+  const lines = [
+    summary,
+    name ? `Image: ${name}` : undefined,
+    prompt ? `Prompt: ${prompt}` : undefined,
+  ].filter((line): line is string => Boolean(line));
+  return lines.length > 1 ? lines.join("\n") : undefined;
 }
 
 function commandActivityDetail(
@@ -160,6 +194,9 @@ export function formatExpandedToolActivityDetail(
   }
   if (key === "todo" || key === "update_plan") {
     return planActivityDetail(args, phase, result);
+  }
+  if (key === "image") {
+    return imageActivityDetail(args, phase, result);
   }
   return formatStructuredToolActivityDetail(toolName, args, phase, result);
 }

--- a/src/api/bot-routes.ts
+++ b/src/api/bot-routes.ts
@@ -188,6 +188,7 @@ function serializeBot(
           title: session.title,
           updated_at: session.updatedAt,
           message_count: session.messageCount,
+          unread: session.unread,
           last_message: session.lastMessage,
         }
       : null,

--- a/src/api/chat-process-activities.ts
+++ b/src/api/chat-process-activities.ts
@@ -1,4 +1,5 @@
 import { formatStructuredToolActivityDetail } from "../../shared/tool-activity-detail";
+import { imagePathFromToolCall } from "../core/agent-tool-images";
 
 export interface ProcessActivityInfo {
   id: string;
@@ -8,6 +9,7 @@ export interface ProcessActivityInfo {
   toolName?: string;
   toolCallId?: string;
   sandboxProvider?: string;
+  imagePath?: string;
 }
 
 export interface ToolCallInfo {
@@ -90,6 +92,14 @@ function normalizeProcessActivityTextForPhase(
     .replace(/^Running\b/i, "Command failed")
     .replace(/^Writing\b/i, "Edit failed")
     .replace(/^Editing\b/i, "Edit failed");
+}
+
+function viewedImagePathFromToolCall(toolCall: ToolCallInfo): string | undefined {
+  const result = toolCall.result;
+  if (!result || typeof result !== "object" || Array.isArray(result)) return undefined;
+  const snapshot = (result as Record<string, unknown>).snapshot;
+  if (typeof snapshot === "string" && snapshot.trim()) return snapshot;
+  return imagePathFromToolCall({ name: toolCall.name, result });
 }
 
 export function formatProcessActivityFromToolCall(toolCall: ToolCallInfo): string {
@@ -271,6 +281,7 @@ export function buildFallbackProcessActivities(
       toolName: toolCall.name,
       toolCallId: typeof toolCall.id === "string" && toolCall.id.trim() ? toolCall.id : undefined,
       sandboxProvider: extractSandboxProviderFromToolCall(toolCall),
+      imagePath: viewedImagePathFromToolCall(toolCall),
     });
   }
 

--- a/src/api/chat-run-recovery.ts
+++ b/src/api/chat-run-recovery.ts
@@ -4,11 +4,11 @@ import {
   appendSessionEvent,
   getActiveSessionRunId,
   latestSessionRunId,
-  listAllSessionEvents,
   listAllRunEvents,
+  listAllSessionEvents,
   listIncompleteSessionRuns,
-  sessionEventsFingerprint,
   type SessionLedgerEvent,
+  sessionEventsFingerprint,
 } from "../core/session-event-ledger";
 import {
   type AgentStatus,
@@ -16,8 +16,8 @@ import {
   type SessionStatusSnapshot,
   type StatusPayload,
 } from "../core/status";
-import type { ProcessActivityInfo } from "./chat-process-activities";
 import { INTERRUPTED_RESPONSE } from "./chat-interruption";
+import type { ProcessActivityInfo } from "./chat-process-activities";
 import type { ChatMessage } from "./chat-types";
 
 const LEGACY_RUN_RECOVERY_SETTLE_MS = 30_000;
@@ -113,6 +113,7 @@ function statusPayload(event: SessionLedgerEvent): StatusPayload | null {
     ...(typeof payload.sandboxProvider === "string"
       ? { sandboxProvider: payload.sandboxProvider }
       : {}),
+    ...(typeof payload.imagePath === "string" ? { imagePath: payload.imagePath } : {}),
     ...(payload.toolPhase === "start" ||
     payload.toolPhase === "result" ||
     payload.toolPhase === "error" ||

--- a/src/api/chat-runtime-state.ts
+++ b/src/api/chat-runtime-state.ts
@@ -83,6 +83,7 @@ export interface SessionListEntry {
   updatedAt: string;
   workspaceDir: string | null;
   pinned: boolean;
+  unread: boolean;
   lastMessage: SessionLastMessagePreview | null;
   modelMetadata: SessionModelMetadata | null;
   room?: RoomConfig | null;
@@ -243,10 +244,11 @@ export function buildLastMessagePreview(message?: ChatMessage): SessionLastMessa
 export function normalizePersistedIndexEntry(
   entry: Omit<
     PersistedSessionIndexEntry,
-    "title" | "lastMessage" | "pinned" | "modelMetadata" | "useModelRouter"
+    "title" | "lastMessage" | "pinned" | "unread" | "modelMetadata" | "useModelRouter"
   > & {
     title?: string | null;
     pinned?: boolean;
+    unread?: boolean;
     useModelRouter?: boolean;
     lastMessage?: SessionLastMessagePreview | null;
     modelMetadata?: SessionModelMetadata | null;
@@ -259,6 +261,7 @@ export function normalizePersistedIndexEntry(
       entry.useModelRouter ?? persistedSessionIndex.get(entry.id)?.useModelRouter ?? false,
     title: stripSessionTitleAgentPrefix(entry.title, [modelMetadata?.agent_name, entry.agentId]),
     pinned: entry.pinned ?? persistedSessionIndex.get(entry.id)?.pinned ?? false,
+    unread: entry.unread ?? persistedSessionIndex.get(entry.id)?.unread ?? false,
     lastMessage: entry.lastMessage
       ? {
           role: entry.lastMessage.role,
@@ -272,10 +275,11 @@ export function normalizePersistedIndexEntry(
 export function upsertPersistedSessionIndex(
   entry: Omit<
     PersistedSessionIndexEntry,
-    "title" | "lastMessage" | "pinned" | "modelMetadata" | "useModelRouter"
+    "title" | "lastMessage" | "pinned" | "unread" | "modelMetadata" | "useModelRouter"
   > & {
     title?: string | null;
     pinned?: boolean;
+    unread?: boolean;
     useModelRouter?: boolean;
     lastMessage?: SessionLastMessagePreview | null;
     modelMetadata?: SessionModelMetadata | null;
@@ -341,6 +345,7 @@ export function buildMemorySessionListEntries(): SessionListEntry[] {
       updatedAt: s.updatedAt || s.createdAt,
       workspaceDir: s.workspaceDir ?? null,
       pinned: persistedSessionIndex.get(s.id)?.pinned ?? false,
+      unread: persistedSessionIndex.get(s.id)?.unread ?? false,
       lastMessage: buildLastMessagePreview(s.messages[s.messages.length - 1]),
       modelMetadata,
       room: s.room ?? null,
@@ -361,6 +366,7 @@ export function persistedSessionToIndexEntry(
     updatedAt: persisted.updatedAt,
     workspaceDir: persisted.workspaceDir ?? null,
     pinned: persisted.pinned,
+    unread: persisted.unread,
     room: persisted.roomConfig,
     modelMetadata: persisted.modelMetadata ?? resolveSessionModelMetadata(persisted.agentId),
     lastMessage:

--- a/src/api/chat-session-api.ts
+++ b/src/api/chat-session-api.ts
@@ -1,5 +1,5 @@
 import { agentManager } from "../core/agent";
-import db from "../core/database";
+import db, { tables } from "../core/database";
 import { logSessionMessage } from "../core/logging";
 import {
   clearSessionContextState,
@@ -402,7 +402,11 @@ async function buildSessionListIndex(): Promise<SessionListEntry[]> {
 
   const memoryMap = new Map(memorySessions.map((session) => [session.id, session]));
   for (const persisted of persistedSessionIndex.values()) {
-    if (memoryMap.has(persisted.id)) continue;
+    const memory = memoryMap.get(persisted.id);
+    if (memory) {
+      memory.unread = persisted.unread;
+      continue;
+    }
     memorySessions.push({
       id: persisted.id,
       agentId: persisted.agentId,
@@ -413,6 +417,7 @@ async function buildSessionListIndex(): Promise<SessionListEntry[]> {
       updatedAt: persisted.updatedAt,
       workspaceDir: persisted.workspaceDir,
       pinned: persisted.pinned,
+      unread: persisted.unread,
       lastMessage: persisted.lastMessage,
       modelMetadata: persisted.modelMetadata,
       room: persisted.room ?? null,
@@ -437,7 +442,9 @@ async function buildPersistedSessionPage(options: { limit: number; offset: numbe
   const memoryById = new Map(memorySessions.map((session) => [session.id, session]));
   const persistedEntries = page.sessions.map((persisted) => {
     const memory = memoryById.get(persisted.id);
-    return memory ?? persistedSessionToIndexEntry(persisted);
+    return memory
+      ? { ...memory, unread: persisted.unread }
+      : persistedSessionToIndexEntry(persisted);
   });
 
   if (transientSessions.length === 0) {
@@ -501,6 +508,15 @@ export async function listSessionPage(options?: { limit?: number; offset?: numbe
     offset,
     hasMore: limit ? offset + sessions.length < sortedSessions.length : false,
   };
+}
+
+export function markSessionRead(sessionId: string): { found: boolean; unread: false } {
+  const key = sessionId.trim();
+  if (!key) return { found: false, unread: false };
+  const found = tables.chatSessions.markRead(key);
+  const indexed = persistedSessionIndex.get(key);
+  if (indexed) persistedSessionIndex.set(key, { ...indexed, unread: false });
+  return { found, unread: false };
 }
 
 export async function deleteSession(sessionId: string): Promise<boolean> {

--- a/src/api/chat-steering-activities.ts
+++ b/src/api/chat-steering-activities.ts
@@ -5,8 +5,9 @@ import {
   type ProcessActivityInfo,
   type ToolCallInfo,
 } from "./chat-process-activities";
-import { parseIsoTimestampMs, type InMemoryChatSession } from "./chat-runtime-state";
+import { type InMemoryChatSession, parseIsoTimestampMs } from "./chat-runtime-state";
 import type { ChatMessage } from "./chat-types";
+
 export { stripThinkingTags } from "./chat-formatting";
 export {
   formatProcessActivityFromToolCall,
@@ -45,6 +46,7 @@ export function getSessionProcessActivities(
       toolName: activity.toolName,
       toolCallId: activity.toolCallId,
       sandboxProvider: activity.sandboxProvider,
+      imagePath: activity.imagePath,
     }));
   return sanitizeObservedProcessActivities(activities);
 }
@@ -87,6 +89,10 @@ export function sanitizeObservedProcessActivities(
       typeof record.sandboxProvider === "string" && record.sandboxProvider.trim()
         ? record.sandboxProvider.trim().slice(0, 80)
         : undefined;
+    const imagePath =
+      typeof record.imagePath === "string" && record.imagePath.trim()
+        ? record.imagePath.trim().slice(0, 1024)
+        : undefined;
     sanitized.push({
       id,
       phase,
@@ -95,6 +101,7 @@ export function sanitizeObservedProcessActivities(
       toolName,
       toolCallId,
       sandboxProvider,
+      imagePath,
     });
   }
   const deduped = dedupeProcessActivities(sanitized);

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -11,6 +11,7 @@ import {
   listPendingChatMessages,
   listSessionPage,
   listSessions,
+  markSessionRead,
   reorderPendingChatMessages,
   revertSessionToMessage,
   setSessionPinned,
@@ -1255,6 +1256,7 @@ const routes: Record<string, RouteHandler> = {
             ? session.workspaceDir
             : null,
         pinned: session.pinned === true,
+        unread: session.unread === true,
         room: session.room ? roomConfigToApi(session.room) : null,
         message_count: session.messageCount,
         last_message: lastMessage
@@ -1559,6 +1561,11 @@ const routes: Record<string, RouteHandler> = {
   "DELETE /api/sessions/:sessionId": async (_body, params) => {
     await deleteSession(params!.sessionId);
     return { success: true, message: "Session deleted" };
+  },
+  "PUT /api/sessions/:sessionId/read": async (_body, params) => {
+    const result = markSessionRead(params!.sessionId);
+    if (!result.found) throw new Error("Session not found");
+    return { success: true, session_id: params!.sessionId, unread: false };
   },
 
   "POST /api/subagents/spawn": async (body) => {

--- a/src/api/routes/_shared.ts
+++ b/src/api/routes/_shared.ts
@@ -1,9 +1,9 @@
 import { existsSync, statSync } from "fs";
 import { readdir, stat } from "fs/promises";
 import { join } from "path";
+import { presentProviderProtocolText } from "../../../shared/provider-protocol";
 import { getArtifactsRootDir } from "../../core/artifacts";
 import { sanitizeAssistantContent } from "../../core/llm/text-tool-calls";
-import { presentProviderProtocolText } from "../../../shared/provider-protocol";
 import { cybaraDir, dataDir, logsDir, memoryDir, secureDir, userSkillsDir } from "../../core/paths";
 import {
   type ProviderType,
@@ -980,6 +980,12 @@ export function sanitizeProcessActivities(
       typeof entry.toolCallId === "string" && entry.toolCallId.trim()
         ? entry.toolCallId
         : undefined;
+    const sandboxProvider =
+      typeof entry.sandboxProvider === "string" && entry.sandboxProvider.trim()
+        ? entry.sandboxProvider
+        : undefined;
+    const imagePath =
+      typeof entry.imagePath === "string" && entry.imagePath.trim() ? entry.imagePath : undefined;
 
     sanitized.push({
       id,
@@ -994,6 +1000,8 @@ export function sanitizeProcessActivities(
       timestamp,
       toolName,
       toolCallId,
+      sandboxProvider,
+      imagePath,
     });
   }
 

--- a/src/cli/tui/activity.ts
+++ b/src/cli/tui/activity.ts
@@ -1,9 +1,9 @@
 import {
   groupSharedActivities,
-  sharedActivityKind,
   type SharedActivityGroupKind,
   type SharedActivityItem,
   type SharedActivityPhase,
+  sharedActivityKind,
 } from "../../../shared/chat-activity-groups";
 import { isProviderRecoveryStatusLabel } from "../../../shared/chat-status";
 
@@ -75,6 +75,7 @@ const GROUP_ICONS: Record<SharedActivityGroupKind, string> = {
   edit: "✎",
   fetch: "◎",
   command: "▣",
+  view: "▦",
 };
 
 function classifyActivity(value: string): ActivityKind {

--- a/src/core/agent-provider-anthropic-runtime.ts
+++ b/src/core/agent-provider-anthropic-runtime.ts
@@ -61,8 +61,8 @@ import {
   anthropicRequestBase,
   anthropicRequestHeaders,
 } from "./llm/anthropic-vertex";
-import { normalizeAnthropicModelToolUses } from "./llm/model-dialect";
 import { toAnthropicImageBlock } from "./llm/image-blocks";
+import { normalizeAnthropicModelToolUses } from "./llm/model-dialect";
 import { canRunToolsInParallel } from "./llm/parallel-tools";
 import { toAnthropicHistory } from "./llm/provider-history";
 import { supportsForcedToolChoice } from "./llm/provider-model-transport";
@@ -438,7 +438,8 @@ export abstract class AgentProviderAnthropicRuntime extends AgentProviderCloudRu
                 allowedToolNames,
                 toolContext,
                 hookContext,
-                loopRuntimeTracker
+                loopRuntimeTracker,
+                id
               )
             );
           }
@@ -488,7 +489,8 @@ export abstract class AgentProviderAnthropicRuntime extends AgentProviderCloudRu
             allowedToolNames,
             toolContext,
             hookContext,
-            loopRuntimeTracker
+            loopRuntimeTracker,
+            toolUseId
           ));
         const resultPayload =
           executed.result === undefined

--- a/src/core/agent-provider-cloud-runtime.ts
+++ b/src/core/agent-provider-cloud-runtime.ts
@@ -551,7 +551,8 @@ export abstract class AgentProviderCloudRuntime extends AgentProviderCodexRuntim
           allowedToolNames,
           toolContext,
           hookContext,
-          loopRuntimeTracker
+          loopRuntimeTracker,
+          toolUse.toolUseId
         );
         if (executed.skipped || executed.result === undefined) {
           continue;

--- a/src/core/agent-provider-codex-runtime.ts
+++ b/src/core/agent-provider-codex-runtime.ts
@@ -29,8 +29,8 @@ import {
   sessionIdForVisibleTokenUsage,
   shouldNudgeSkillLearning,
 } from "./agent-provider-common-runtime";
-import { loadToolResultImages } from "./agent-tool-images";
 import { AgentProviderOpenAICompatRuntime } from "./agent-provider-openai-compat-runtime";
+import { loadToolResultImages } from "./agent-tool-images";
 import { hasAgentTransferEnvelope } from "./agent-transfer";
 import { config } from "./config";
 import type { ToolDefinition } from "./database";
@@ -806,7 +806,8 @@ export abstract class AgentProviderCodexRuntime extends AgentProviderOpenAICompa
           allowedToolNames,
           toolContext,
           hookContext,
-          loopRuntimeTracker
+          loopRuntimeTracker,
+          toolCall.id
         );
         const resultPayload =
           executed.result === undefined ? { skipped: true, reason: "no result" } : executed.result;

--- a/src/core/agent-provider-common-runtime.ts
+++ b/src/core/agent-provider-common-runtime.ts
@@ -27,6 +27,7 @@ import {
   callDevinAgentTransport,
   callGitLabDuoTransport,
 } from "./llm/agent-provider-transports";
+import { estimateOpenAIRequestTokens } from "./llm/context-estimate";
 import { prepareAgentMessagesForProvider } from "./llm/provider-image-input";
 import { normalizeProviderMessages } from "./llm/provider-messages";
 import { resolveProviderModelApiFamily } from "./llm/provider-model-transport";
@@ -895,19 +896,7 @@ export abstract class AgentProviderCommonRuntime {
   }
 
   protected estimateOpenAIRequestInputTokens(requestBody: Record<string, unknown>): number {
-    const payload: Record<string, unknown> = {};
-    if (requestBody.model !== undefined) payload.model = requestBody.model;
-    if (requestBody.messages !== undefined) payload.messages = requestBody.messages;
-    if (requestBody.tools !== undefined) payload.tools = requestBody.tools;
-    if (requestBody.tool_choice !== undefined) payload.tool_choice = requestBody.tool_choice;
-
-    try {
-      const serialized = JSON.stringify(payload);
-      if (!serialized) return 0;
-      return Math.max(1, Math.ceil(serialized.length / CONTEXT_CHARS_PER_TOKEN_ESTIMATE));
-    } catch {
-      return DEFAULT_MODEL_CONTEXT_WINDOW_TOKENS;
-    }
+    return estimateOpenAIRequestTokens(requestBody);
   }
 
   protected resolveOpenAIRequestTokenLimit(

--- a/src/core/agent-provider-common-runtime.ts
+++ b/src/core/agent-provider-common-runtime.ts
@@ -413,7 +413,8 @@ export abstract class AgentProviderCommonRuntime {
     allowedToolNames: Set<string>,
     toolContext: ToolContext | undefined,
     hookContext: AgentHookContext,
-    runtimeTracker?: AgenticLoopRuntimeTracker
+    runtimeTracker?: AgenticLoopRuntimeTracker,
+    providerToolCallId?: string
   ): Promise<AgentToolExecutionResult> {
     const { executeAgentTool } = await import("./agent-tool-execution");
     return await executeAgentTool({
@@ -423,6 +424,7 @@ export abstract class AgentProviderCommonRuntime {
       toolContext,
       hookContext,
       runtimeTracker,
+      providerToolCallId,
       broadcastStatus: (status, context, detail, extra) =>
         this.broadcastAgentStatus(status, context, detail, extra),
     });

--- a/src/core/agent-provider-common-runtime.ts
+++ b/src/core/agent-provider-common-runtime.ts
@@ -106,6 +106,9 @@ export function sessionIdForVisibleTokenUsage(toolContext?: ToolContext): string
   return sessionId || undefined;
 }
 
+export const OUTPUT_LIMIT_TRUNCATION_NOTICE =
+  "Your previous reply was cut off by the output token limit, so the last tool call may be incomplete or missing arguments. Re-issue it with smaller content: split large files across several write or edit calls and keep each call well under the output limit.";
+
 export function appendAgentBudgetWarning(content: string, warning?: string): string {
   return warning ? `${content}\n\n${warning}` : content;
 }

--- a/src/core/agent-provider-openai-compat-runtime.ts
+++ b/src/core/agent-provider-openai-compat-runtime.ts
@@ -401,7 +401,8 @@ export abstract class AgentProviderOpenAICompatRuntime extends AgentProviderComm
                 allowedToolNames,
                 toolContext,
                 hookContext,
-                loopRuntimeTracker
+                loopRuntimeTracker,
+                toolCall.id
               )
             );
           }
@@ -508,7 +509,8 @@ export abstract class AgentProviderOpenAICompatRuntime extends AgentProviderComm
             allowedToolNames,
             toolContext,
             hookContext,
-            loopRuntimeTracker
+            loopRuntimeTracker,
+            toolCallId
           ));
         const resultPayload =
           executed.result === undefined

--- a/src/core/agent-provider-openai-compat-runtime.ts
+++ b/src/core/agent-provider-openai-compat-runtime.ts
@@ -1,10 +1,20 @@
 import type { AgentMessage } from "./agent";
 import {
   compactOpenAILoopMessagesForContext,
-  resolveMaterializationContextBudgetChars,
   resolveContextGuardBudgets,
+  resolveMaterializationContextBudgetChars,
   truncateToolResultContentForContext,
 } from "./agent-context-guard";
+import {
+  redactExposedCredentials,
+  requestedDeliverableNeedsExtendedEvidence,
+  requestedDeliverableNeedsInspection,
+  requestedDeliverablePathsFromMessages,
+  toolCallContainsExposedCredential,
+  toolCallContainsPlaceholder,
+  toolCallProducedPath,
+  toolsForInitialDeliverableInspection,
+} from "./agent-deferred-continuation";
 import {
   type AgenticLoopState,
   type AgentToolCallResult,
@@ -22,23 +32,13 @@ import {
   evaluateNoProgressLoop,
   requestedDeliverableMaterializationPrompt,
   requiresRequestedDeliverableMaterialization,
+  resolveAgenticLoopLimit,
   resolveInspectionToolRoundTokenLimit,
   resolveRequestedDeliverableFinalContent,
   resolveRequestedDeliverableToolChoice,
-  resolveAgenticLoopLimit,
   toolsAfterMaterializationCheckpoint,
   updateNoProgressLoopState,
 } from "./agent-loop-runtime";
-import {
-  redactExposedCredentials,
-  requestedDeliverableNeedsInspection,
-  requestedDeliverableNeedsExtendedEvidence,
-  requestedDeliverablePathsFromMessages,
-  toolCallContainsExposedCredential,
-  toolCallContainsPlaceholder,
-  toolCallProducedPath,
-  toolsForInitialDeliverableInspection,
-} from "./agent-deferred-continuation";
 import {
   AgentProviderCommonRuntime,
   appendAgentBudgetWarning,
@@ -54,6 +54,11 @@ import {
 } from "./agent-web-research";
 import type { ToolDefinition } from "./database";
 import { applyProviderApiKey } from "./llm/auth-headers";
+import {
+  DEFAULT_MAX_INLINE_IMAGES,
+  limitInlineImages,
+  parseProviderInlineImageLimit,
+} from "./llm/inline-images";
 import {
   applyMoonshotRequestOptions,
   isKimiCodeProvider,
@@ -73,6 +78,7 @@ import {
   normalizeReasoningEffort,
   openAICompatClosingReasoningParams,
   openAICompatReasoningParams,
+  openAIReasoningContent,
 } from "./llm/reasoning";
 import {
   sanitizeAssistantContent,
@@ -102,16 +108,6 @@ function toOpenAICompatTool(
       parameters: isKimiCodeProvider(providerConfig) ? normalizeKimiToolSchema(schema) : schema,
     },
   };
-}
-
-function openAIReasoningContent(message: OpenAIMessage): string {
-  const candidates = [message.reasoning_content, message.reasoning, message.thinking];
-  return (
-    candidates.find(
-      (candidate): candidate is string =>
-        typeof candidate === "string" && candidate.trim().length > 0
-    ) ?? ""
-  );
 }
 
 export abstract class AgentProviderOpenAICompatRuntime extends AgentProviderCommonRuntime {
@@ -206,6 +202,8 @@ export abstract class AgentProviderOpenAICompatRuntime extends AgentProviderComm
 
     applyMoonshotRequestOptions(requestBody, providerConfig, modelId);
 
+    let maxInlineImages = DEFAULT_MAX_INLINE_IMAGES;
+    limitInlineImages(requestBody.messages as Record<string, unknown>[], maxInlineImages);
     this.compactOpenAIRequestMessagesForContext(requestBody, contextWindowTokens);
     const initialTokenLimit = resolveInspectionToolRoundTokenLimit(
       this.resolveOpenAIRequestTokenLimit(requestBody, maxOutputTokens, contextWindowTokens),
@@ -242,15 +240,16 @@ export abstract class AgentProviderOpenAICompatRuntime extends AgentProviderComm
         { sessionId: sessionIdForVisibleTokenUsage(toolContext) }
       );
     } catch (error) {
-      if (!isContextOverflowError(this.normalizeErrorMessage(error))) {
-        throw error;
-      }
-      const compacted = this.compactOpenAIRequestMessagesForContext(
-        requestBody,
-        contextWindowTokens,
-        true
-      );
-      if (!compacted) {
+      const errorMessage = this.normalizeErrorMessage(error);
+      const providerImageLimit = parseProviderInlineImageLimit(errorMessage);
+      if (providerImageLimit !== undefined) maxInlineImages = providerImageLimit;
+      const recovered =
+        providerImageLimit !== undefined
+          ? limitInlineImages(requestBody.messages as Record<string, unknown>[], maxInlineImages) >
+            0
+          : isContextOverflowError(errorMessage) &&
+            this.compactOpenAIRequestMessagesForContext(requestBody, contextWindowTokens, true);
+      if (!recovered) {
         throw error;
       }
       const retryLimit = this.resolveOpenAIRequestTokenLimit(
@@ -612,6 +611,7 @@ export abstract class AgentProviderOpenAICompatRuntime extends AgentProviderComm
           ? await openAIImageToolFollowup(iterationToolCalls)
           : undefined;
       if (imageFollowup) currentMessages.push(imageFollowup);
+      limitInlineImages(currentMessages, maxInlineImages);
       if (notifyWebResearchBudget) {
         currentMessages.push({
           role: "user",
@@ -716,16 +716,19 @@ export abstract class AgentProviderOpenAICompatRuntime extends AgentProviderComm
         );
       } catch (error) {
         const errorMessage = this.normalizeErrorMessage(error);
-        if (!isContextOverflowError(errorMessage)) {
-          throw error;
-        }
-        const compacted = compactOpenAILoopMessagesForContext(
-          currentMessages,
-          Math.max(4096, Math.floor(contextGuard.contextBudgetChars * 0.65)),
-          true,
-          { model: modelId, toolContext }
-        );
-        if (!compacted) {
+        const providerImageLimit = parseProviderInlineImageLimit(errorMessage);
+        if (providerImageLimit !== undefined) maxInlineImages = providerImageLimit;
+        const recovered =
+          providerImageLimit !== undefined
+            ? limitInlineImages(currentMessages, maxInlineImages) > 0
+            : isContextOverflowError(errorMessage) &&
+              compactOpenAILoopMessagesForContext(
+                currentMessages,
+                Math.max(4096, Math.floor(contextGuard.contextBudgetChars * 0.65)),
+                true,
+                { model: modelId, toolContext }
+              );
+        if (!recovered) {
           throw error;
         }
         const retryLoopRequestBody: Record<string, unknown> = {
@@ -826,8 +829,12 @@ export abstract class AgentProviderOpenAICompatRuntime extends AgentProviderComm
           sessionId: sessionIdForVisibleTokenUsage(toolContext),
           routerRouteId: toolContext?.routerRouteId,
         });
-        const nudgeContent = nudgeData.choices?.[0]?.message?.content;
-        if (typeof nudgeContent === "string" && nudgeContent.trim()) finalContent = nudgeContent;
+        const nudgeMessage = nudgeData.choices?.[0]?.message;
+        const nudgeContent =
+          typeof nudgeMessage?.content === "string" && nudgeMessage.content.trim()
+            ? nudgeMessage.content
+            : openAIReasoningContent(nudgeMessage);
+        if (nudgeContent.trim()) finalContent = nudgeContent;
       } catch (error) {
         console.warn(`[Agent] Closing-response nudge failed: ${this.normalizeErrorMessage(error)}`);
       }

--- a/src/core/agent-provider-openai-compat-runtime.ts
+++ b/src/core/agent-provider-openai-compat-runtime.ts
@@ -42,6 +42,7 @@ import {
 import {
   AgentProviderCommonRuntime,
   appendAgentBudgetWarning,
+  OUTPUT_LIMIT_TRUNCATION_NOTICE,
   sessionIdForVisibleTokenUsage,
 } from "./agent-provider-common-runtime";
 import { openAIImageToolFollowup } from "./agent-tool-images";
@@ -273,6 +274,7 @@ export abstract class AgentProviderOpenAICompatRuntime extends AgentProviderComm
 
     const choice = data.choices?.[0];
     let message = choice?.message;
+    let lastFinishReason = choice?.finish_reason;
 
     trackOpenAIResponseUsage(data, {
       model: modelId,
@@ -594,6 +596,12 @@ export abstract class AgentProviderOpenAICompatRuntime extends AgentProviderComm
       const lastToolResult = toolResults.at(-1);
       if (lastToolResult) {
         lastToolResult.content = appendAgentBudgetWarning(lastToolResult.content, budgetWarning);
+        if (lastFinishReason === "length") {
+          lastToolResult.content = appendAgentBudgetWarning(
+            lastToolResult.content,
+            OUTPUT_LIMIT_TRUNCATION_NOTICE
+          );
+        }
       }
 
       const replayMessage = toOpenAIReplayMessageWithNormalizedToolCalls(
@@ -766,6 +774,7 @@ export abstract class AgentProviderOpenAICompatRuntime extends AgentProviderComm
         routerRouteId: toolContext?.routerRouteId,
       });
       const loopChoice = loopData.choices?.[0];
+      lastFinishReason = loopChoice?.finish_reason;
       message = loopChoice?.message as OpenAIMessage;
 
       if (!message) {

--- a/src/core/agent-provider-runtime.ts
+++ b/src/core/agent-provider-runtime.ts
@@ -26,8 +26,8 @@ import {
   appendAgentBudgetWarning,
   sessionIdForVisibleTokenUsage,
 } from "./agent-provider-common-runtime";
-import { hasAgentTransferEnvelope } from "./agent-transfer";
 import { openAIImageToolFollowup } from "./agent-tool-images";
+import { hasAgentTransferEnvelope } from "./agent-transfer";
 import {
   countWebResearchCalls,
   toolsAfterWebResearchBudget,
@@ -184,7 +184,8 @@ export abstract class AgentProviderRuntime extends AgentProviderAnthropicRuntime
                 allowedToolNames,
                 toolContext,
                 hookContext,
-                loopRuntimeTracker
+                loopRuntimeTracker,
+                toolCall.id
               )
             );
           }
@@ -226,7 +227,8 @@ export abstract class AgentProviderRuntime extends AgentProviderAnthropicRuntime
             allowedToolNames,
             toolContext,
             hookContext,
-            loopRuntimeTracker
+            loopRuntimeTracker,
+            toolCallId
           ));
         const resultPayload =
           executed.result === undefined

--- a/src/core/agent-provider-runtime.ts
+++ b/src/core/agent-provider-runtime.ts
@@ -39,6 +39,7 @@ import { normalizeModelToolCalls } from "./llm/model-dialect";
 import { trackOpenAIResponseUsage } from "./llm/openai-response-usage";
 import { canRunToolsInParallel } from "./llm/parallel-tools";
 import { toOpenAIChatHistory } from "./llm/provider-history";
+import { openAIReasoningContent } from "./llm/reasoning";
 import {
   sanitizeAssistantContent,
   toOpenAIReplayMessageWithNormalizedToolCalls,
@@ -445,8 +446,12 @@ export abstract class AgentProviderRuntime extends AgentProviderAnthropicRuntime
           sessionId: sessionIdForVisibleTokenUsage(toolContext),
           routerRouteId: toolContext?.routerRouteId,
         });
-        const closingContent = closingData.choices?.[0]?.message?.content;
-        if (typeof closingContent === "string" && closingContent.trim()) {
+        const closingMessage = closingData.choices?.[0]?.message;
+        const closingContent =
+          typeof closingMessage?.content === "string" && closingMessage.content.trim()
+            ? closingMessage.content
+            : openAIReasoningContent(closingMessage);
+        if (closingContent.trim()) {
           finalContent = closingContent;
         }
       } catch (error) {

--- a/src/core/agent-tool-execution.ts
+++ b/src/core/agent-tool-execution.ts
@@ -36,6 +36,7 @@ export interface AgentToolExecutionOptions {
   toolContext?: ToolContext;
   hookContext: AgentHookContext;
   runtimeTracker?: AgenticLoopRuntimeTracker;
+  providerToolCallId?: string;
   broadcastStatus: (
     status: AgentStatus,
     toolContext?: ToolContext,
@@ -189,7 +190,7 @@ async function executeAgentToolInternal(
     reservedSubagentSpawn = true;
   }
 
-  const toolCallId = createAgentToolCallStatusId(toolName);
+  const toolCallId = options.providerToolCallId?.trim() || createAgentToolCallStatusId(toolName);
   try {
     const startedAt = Date.now();
     broadcastStatus(

--- a/src/core/agent-tool-execution.ts
+++ b/src/core/agent-tool-execution.ts
@@ -19,7 +19,7 @@ import {
 import { noteSkillCaptureOpportunity } from "./tools/handlers/skill-capture";
 import { noteToolActivityForTodoReminder } from "./tools/handlers/todo";
 import { type ToolContext, toolSchemas } from "./tools/index";
-import { registerViewedMediaPath } from "./viewed-media";
+import { registerViewedMediaPath, snapshotViewedMedia } from "./viewed-media";
 
 export interface AgentToolExecutionResult {
   skipped: boolean;
@@ -219,6 +219,12 @@ async function executeAgentToolInternal(
         ? `${record.system_reminder}\n${skillCaptureReminder}`
         : skillCaptureReminder;
     }
+    const viewedImagePath = imagePathFromToolCall({ name: toolName, result });
+    const viewedImageSnapshot = viewedImagePath ? snapshotViewedMedia(viewedImagePath) : undefined;
+    if (viewedImagePath) registerViewedMediaPath(viewedImagePath);
+    if (viewedImageSnapshot && isPlainResult && viewedImageSnapshot !== viewedImagePath) {
+      (result as Record<string, unknown>).snapshot = viewedImageSnapshot;
+    }
     broadcastStatus(
       "tool_completed",
       toolContext,
@@ -229,7 +235,7 @@ async function executeAgentToolInternal(
         toolPhase: "result",
         durationMs: Date.now() - startedAt,
         sandboxProvider: extractSandboxProviderFromToolResult(result),
-        imagePath: imagePathFromToolCall({ name: toolName, result }),
+        imagePath: viewedImageSnapshot ?? viewedImagePath,
       }
     );
     await emitAgentHook({
@@ -299,11 +305,6 @@ export async function executeAgentTool(
   }
   const completedExecution = { ...execution, durationMs: Math.max(0, Date.now() - startedAt) };
   if (!completedExecution.skipped && completedExecution.result !== undefined) {
-    const viewedImagePath = imagePathFromToolCall({
-      name: options.toolName,
-      result: completedExecution.result,
-    });
-    if (viewedImagePath) registerViewedMediaPath(viewedImagePath);
     executionState?.toolCalls.push({
       order,
       name: options.toolName,

--- a/src/core/agent-tool-execution.ts
+++ b/src/core/agent-tool-execution.ts
@@ -5,6 +5,7 @@ import {
   pauseAgenticLoopRuntime,
   resumeAgenticLoopRuntime,
 } from "./agent-loop-runtime";
+import { imagePathFromToolCall } from "./agent-tool-images";
 import type { AgentStatus, StatusPayload } from "./status";
 import { coerceToolArguments } from "./tool-argument-coercion";
 import { validateToolArguments } from "./tool-argument-validation";
@@ -18,6 +19,7 @@ import {
 import { noteSkillCaptureOpportunity } from "./tools/handlers/skill-capture";
 import { noteToolActivityForTodoReminder } from "./tools/handlers/todo";
 import { type ToolContext, toolSchemas } from "./tools/index";
+import { registerViewedMediaPath } from "./viewed-media";
 
 export interface AgentToolExecutionResult {
   skipped: boolean;
@@ -227,6 +229,7 @@ async function executeAgentToolInternal(
         toolPhase: "result",
         durationMs: Date.now() - startedAt,
         sandboxProvider: extractSandboxProviderFromToolResult(result),
+        imagePath: imagePathFromToolCall({ name: toolName, result }),
       }
     );
     await emitAgentHook({
@@ -296,6 +299,11 @@ export async function executeAgentTool(
   }
   const completedExecution = { ...execution, durationMs: Math.max(0, Date.now() - startedAt) };
   if (!completedExecution.skipped && completedExecution.result !== undefined) {
+    const viewedImagePath = imagePathFromToolCall({
+      name: options.toolName,
+      result: completedExecution.result,
+    });
+    if (viewedImagePath) registerViewedMediaPath(viewedImagePath);
     executionState?.toolCalls.push({
       order,
       name: options.toolName,

--- a/src/core/agent-tool-execution.ts
+++ b/src/core/agent-tool-execution.ts
@@ -19,7 +19,7 @@ import {
 import { noteSkillCaptureOpportunity } from "./tools/handlers/skill-capture";
 import { noteToolActivityForTodoReminder } from "./tools/handlers/todo";
 import { type ToolContext, toolSchemas } from "./tools/index";
-import { registerViewedMediaPath, snapshotViewedMedia } from "./viewed-media";
+import { snapshotViewedMedia } from "./viewed-media";
 
 export interface AgentToolExecutionResult {
   skipped: boolean;
@@ -222,7 +222,6 @@ async function executeAgentToolInternal(
     }
     const viewedImagePath = imagePathFromToolCall({ name: toolName, result });
     const viewedImageSnapshot = viewedImagePath ? snapshotViewedMedia(viewedImagePath) : undefined;
-    if (viewedImagePath) registerViewedMediaPath(viewedImagePath);
     if (viewedImageSnapshot && isPlainResult && viewedImageSnapshot !== viewedImagePath) {
       (result as Record<string, unknown>).snapshot = viewedImageSnapshot;
     }

--- a/src/core/agent-tool-images.ts
+++ b/src/core/agent-tool-images.ts
@@ -1,9 +1,9 @@
 import { extname } from "node:path";
+import type { AgentToolCallResult } from "./agent-internals";
 import {
   COMPUTER_USE_ACTION_TOOL_ALIASES,
   COMPUTER_USE_COMPAT_TOOL_ALIASES,
 } from "./computer-use-actions";
-import type { AgentToolCallResult } from "./agent-internals";
 import { type AgentImage, MAX_INLINE_IMAGE_BYTES, toOpenAIImageBlock } from "./llm/image-blocks";
 import { prepareAgentImageForProvider } from "./llm/provider-image-input";
 
@@ -28,7 +28,9 @@ const visualToolNames = new Set([
   ...Object.keys(COMPUTER_USE_COMPAT_TOOL_ALIASES),
 ]);
 
-function imagePathFromToolCall(toolCall: AgentToolCallResult): string | undefined {
+export function imagePathFromToolCall(
+  toolCall: Pick<AgentToolCallResult, "name" | "result">
+): string | undefined {
   if (!visualToolNames.has(toolCall.name)) return undefined;
   if (!toolCall.result || typeof toolCall.result !== "object") return undefined;
   const result = toolCall.result as Record<string, unknown>;

--- a/src/core/computer-use.ts
+++ b/src/core/computer-use.ts
@@ -1,36 +1,36 @@
-import { spawn, type ChildProcess } from "child_process";
-import { mkdirSync, existsSync, readFileSync, statSync, writeFileSync } from "fs";
+import { type ChildProcess, spawn } from "child_process";
+import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "fs";
 import { join } from "path";
-import { homedir } from "os";
 import { PNG } from "pngjs";
-import { config } from "./config";
-import { setComputerUseTrajectoryStopHandler } from "./computer-use-lifecycle";
-import { CUA_DRIVER_VERSION, ensureManagedCuaDriver, isExecutableFile } from "./cua-driver-runtime";
+import { COMPUTER_FOCUS_UNAVAILABLE_ERROR } from "../../shared/computer-preview";
+import {
+  assertActionAllowed,
+  type ComputerUseAction,
+  type ComputerUseArgs,
+  normalizeComputerUseCompatToolArgs,
+  VALID_ACTIONS,
+} from "./computer-use-actions";
 import {
   CUA_DRIVER_CMD_ENV,
-  getCuaDriverResolution,
-  resolveCuaDriverCommand,
   type CuaDriverCommandSource,
   type CuaDriverResolution,
+  getCuaDriverResolution,
+  resolveCuaDriverCommand,
 } from "./computer-use-driver-resolution";
+import { setComputerUseTrajectoryStopHandler } from "./computer-use-lifecycle";
 import {
   appendComputerUseTrajectoryTurn,
+  type ComputerUseTrajectoryDetail,
+  type ComputerUseTrajectorySurface,
   createComputerUseTrajectory,
   finishComputerUseTrajectory,
   getComputerUseTrajectory,
   getComputerUseTrajectoryDir,
   getPersistedComputerUsePreview,
-  type ComputerUseTrajectoryDetail,
-  type ComputerUseTrajectorySurface,
   touchComputerUseTrajectory,
 } from "./computer-use-trajectories";
-import {
-  VALID_ACTIONS,
-  assertActionAllowed,
-  normalizeComputerUseCompatToolArgs,
-  type ComputerUseAction,
-  type ComputerUseArgs,
-} from "./computer-use-actions";
+import { config } from "./config";
+import { CUA_DRIVER_VERSION, ensureManagedCuaDriver, isExecutableFile } from "./cua-driver-runtime";
 import {
   captureMobileSimulator,
   isMobileSimulatorAction,
@@ -38,13 +38,14 @@ import {
   type MobileSimulatorPlatform,
   runMobileSimulatorAction,
 } from "./mobile-simulator";
-import { COMPUTER_FOCUS_UNAVAILABLE_ERROR } from "../../shared/computer-preview";
+import { screenshotsDir } from "./paths";
 
 export {
+  assertActionAllowed,
   COMPUTER_USE_ACTION_TOOL_ALIASES,
   COMPUTER_USE_COMPAT_TOOL_ALIASES,
-  VALID_ACTIONS,
-  assertActionAllowed,
+  type ComputerUseAction,
+  type ComputerUseArgs,
   isBlockedKeyCombo,
   isBlockedTypeText,
   normalizeComputerUseActionArgs,
@@ -52,16 +53,15 @@ export {
   setComputerUseApprovalCallback,
   setComputerUseAutoApprove,
   summarizeAction,
-  type ComputerUseAction,
-  type ComputerUseArgs,
+  VALID_ACTIONS,
 } from "./computer-use-actions";
 
 const REQUEST_TIMEOUT_MS = 30_000;
 
 export {
-  resolveCuaDriverCommand,
   type CuaDriverCommandSource,
   type CuaDriverResolution,
+  resolveCuaDriverCommand,
 } from "./computer-use-driver-resolution";
 
 let driverProcess: ChildProcess | null = null;
@@ -581,18 +581,12 @@ function isComputerUsePreviewActive(sessionId: string): boolean {
   );
 }
 
-const SCREENSHOTS_DIR = join(
-  process.env.HOME || process.env.USERPROFILE || homedir(),
-  ".cybara",
-  "screenshots"
-);
-
 function persistDriverScreenshot(screenshot: string, mime: string): string | undefined {
   try {
-    mkdirSync(SCREENSHOTS_DIR, { recursive: true });
+    mkdirSync(screenshotsDir, { recursive: true });
     const extension = mime.includes("jpeg") || mime.includes("jpg") ? "jpg" : "png";
     const stamp = new Date().toISOString().replace(/[:.]/g, "-");
-    const filePath = join(SCREENSHOTS_DIR, `computer_${stamp}.${extension}`);
+    const filePath = join(screenshotsDir, `computer_${stamp}.${extension}`);
     writeFileSync(filePath, Buffer.from(screenshot, "base64"));
     return filePath;
   } catch {
@@ -649,11 +643,11 @@ export function isFullDesktopCaptureRequest(
 
 async function nativeScreenCapture(): Promise<ComputerUseResult | null> {
   try {
-    if (!existsSync(SCREENSHOTS_DIR)) {
-      mkdirSync(SCREENSHOTS_DIR, { recursive: true });
+    if (!existsSync(screenshotsDir)) {
+      mkdirSync(screenshotsDir, { recursive: true });
     }
     const stamp = new Date().toISOString().replace(/[:.]/g, "-");
-    const filePath = join(SCREENSHOTS_DIR, `screen_${stamp}.png`);
+    const filePath = join(screenshotsDir, `screen_${stamp}.png`);
 
     const wantsWindowsCapture = process.platform === "win32" || isWsl();
     if (wantsWindowsCapture) {

--- a/src/core/database.ts
+++ b/src/core/database.ts
@@ -177,6 +177,7 @@ try {
     workspace_dir TEXT,
     pinned INTEGER NOT NULL DEFAULT 0,
     room_config TEXT,
+    last_read_assistant_message_id TEXT,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
   );
@@ -488,6 +489,41 @@ try {
     db.exec("ALTER TABLE chat_sessions ADD COLUMN room_config TEXT");
     console.error("[Database] Migration: Added room_config column to chat_sessions");
   } catch {}
+
+  try {
+    db.exec("ALTER TABLE chat_sessions ADD COLUMN last_read_assistant_message_id TEXT");
+    console.error("[Database] Migration: Added session read cursors");
+  } catch {}
+
+  try {
+    const migrationKey = "migration.session_read_cursors_v1";
+    const migrated = db.query("SELECT value FROM config WHERE key = ?").get(migrationKey);
+    if (!migrated) {
+      db.exec("BEGIN IMMEDIATE");
+      try {
+        db.exec(`
+          UPDATE chat_sessions
+          SET last_read_assistant_message_id = COALESCE(
+            (
+              SELECT sm.id
+              FROM session_messages sm
+              WHERE sm.session_id = chat_sessions.id AND sm.role = 'assistant'
+              ORDER BY sm.rowid DESC
+              LIMIT 1
+            ),
+            '__read__'
+          )
+        `);
+        db.query("INSERT INTO config (key, value) VALUES (?, ?)").run(migrationKey, "1");
+        db.exec("COMMIT");
+      } catch (error) {
+        db.exec("ROLLBACK");
+        throw error;
+      }
+    }
+  } catch (error) {
+    console.warn("[Database] session read cursor backfill failed:", error);
+  }
 
   try {
     db.exec("ALTER TABLE mcp_servers ADD COLUMN url TEXT");
@@ -894,6 +930,15 @@ const stmts = {
       "UPDATE chat_sessions SET room_config = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?"
     ),
     setPinned: prepare("UPDATE chat_sessions SET pinned = ? WHERE id = ?"),
+    markRead: prepare(
+      `UPDATE chat_sessions
+       SET last_read_assistant_message_id = (
+         SELECT id FROM session_messages
+         WHERE session_id = ? AND role = 'assistant'
+         ORDER BY rowid DESC LIMIT 1
+       )
+       WHERE id = ?`
+    ),
     delete: prepare("DELETE FROM chat_sessions WHERE id = ?"),
     list: prepare("SELECT * FROM chat_sessions ORDER BY pinned DESC, updated_at DESC"),
   },
@@ -1495,6 +1540,10 @@ export const tables = {
     },
     setRoomConfig: (id: string, roomConfig: string | null): boolean => {
       const result = stmts.chatSessions?.setRoomConfig.run(roomConfig, id);
+      return (result?.changes ?? 0) > 0;
+    },
+    markRead: (id: string): boolean => {
+      const result = stmts.chatSessions?.markRead.run(id, id);
       return (result?.changes ?? 0) > 0;
     },
     delete: (id: string) => stmts.chatSessions?.delete.run(id),

--- a/src/core/database.ts
+++ b/src/core/database.ts
@@ -937,7 +937,8 @@ const stmts = {
          WHERE session_id = ? AND role = 'assistant'
          ORDER BY rowid DESC LIMIT 1
        )
-       WHERE id = ?`
+       WHERE id = ?
+       RETURNING id`
     ),
     delete: prepare("DELETE FROM chat_sessions WHERE id = ?"),
     list: prepare("SELECT * FROM chat_sessions ORDER BY pinned DESC, updated_at DESC"),
@@ -1542,10 +1543,8 @@ export const tables = {
       const result = stmts.chatSessions?.setRoomConfig.run(roomConfig, id);
       return (result?.changes ?? 0) > 0;
     },
-    markRead: (id: string): boolean => {
-      const result = stmts.chatSessions?.markRead.run(id, id);
-      return (result?.changes ?? 0) > 0;
-    },
+    markRead: (id: string): boolean =>
+      Boolean(stmts.chatSessions?.markRead.get(id, id) as { id?: string } | null),
     delete: (id: string) => stmts.chatSessions?.delete.run(id),
     all: () => stmts.chatSessions?.list.all() || [],
   },

--- a/src/core/llm/anthropic-context.ts
+++ b/src/core/llm/anthropic-context.ts
@@ -8,32 +8,15 @@ import {
   DEFAULT_MODEL_MAX_OUTPUT_TOKENS,
 } from "../agent-internals";
 import type { ToolContext } from "../tools";
-
-const IMAGE_TOKEN_ESTIMATE = 4096;
-
-function estimateValueChars(value: unknown): number {
-  if (typeof value === "string") return value.length;
-  if (typeof value === "number" || typeof value === "boolean") return String(value).length;
-  if (Array.isArray(value)) return value.reduce((sum, item) => sum + estimateValueChars(item), 0);
-  if (!value || typeof value !== "object") return 0;
-
-  const record = value as Record<string, unknown>;
-  if (record.type === "image") {
-    return IMAGE_TOKEN_ESTIMATE * CONTEXT_CHARS_PER_TOKEN_ESTIMATE;
-  }
-  return Object.entries(record).reduce(
-    (sum, [key, item]) => sum + key.length + estimateValueChars(item),
-    0
-  );
-}
+import { estimateRequestValueChars } from "./context-estimate";
 
 export function estimateAnthropicRequestInputTokens(requestBody: Record<string, unknown>): number {
   const chars =
-    estimateValueChars(requestBody.system) +
-    estimateValueChars(requestBody.messages) +
-    estimateValueChars(requestBody.tools) +
-    estimateValueChars(requestBody.tool_choice) +
-    estimateValueChars(requestBody.model);
+    estimateRequestValueChars(requestBody.system) +
+    estimateRequestValueChars(requestBody.messages) +
+    estimateRequestValueChars(requestBody.tools) +
+    estimateRequestValueChars(requestBody.tool_choice) +
+    estimateRequestValueChars(requestBody.model);
   return Math.max(1, Math.ceil(chars / CONTEXT_CHARS_PER_TOKEN_ESTIMATE));
 }
 

--- a/src/core/llm/context-estimate.ts
+++ b/src/core/llm/context-estimate.ts
@@ -1,0 +1,36 @@
+import { CONTEXT_CHARS_PER_TOKEN_ESTIMATE } from "../agent-internals";
+
+export const IMAGE_TOKEN_ESTIMATE = 4096;
+
+const IMAGE_CONTENT_BLOCK_TYPES = new Set(["image", "image_url", "input_image"]);
+
+export function isImageContentBlock(value: unknown): boolean {
+  if (!value || typeof value !== "object") return false;
+  const type = (value as Record<string, unknown>).type;
+  return typeof type === "string" && IMAGE_CONTENT_BLOCK_TYPES.has(type);
+}
+
+export function estimateRequestValueChars(value: unknown): number {
+  if (typeof value === "string") return value.length;
+  if (typeof value === "number" || typeof value === "boolean") return String(value).length;
+  if (Array.isArray(value)) {
+    return value.reduce((sum, item) => sum + estimateRequestValueChars(item), 0);
+  }
+  if (!value || typeof value !== "object") return 0;
+  if (isImageContentBlock(value)) {
+    return IMAGE_TOKEN_ESTIMATE * CONTEXT_CHARS_PER_TOKEN_ESTIMATE;
+  }
+  return Object.entries(value as Record<string, unknown>).reduce(
+    (sum, [key, item]) => sum + key.length + estimateRequestValueChars(item),
+    0
+  );
+}
+
+export function estimateOpenAIRequestTokens(requestBody: Record<string, unknown>): number {
+  const chars =
+    estimateRequestValueChars(requestBody.model) +
+    estimateRequestValueChars(requestBody.messages) +
+    estimateRequestValueChars(requestBody.tools) +
+    estimateRequestValueChars(requestBody.tool_choice);
+  return Math.max(1, Math.ceil(chars / CONTEXT_CHARS_PER_TOKEN_ESTIMATE));
+}

--- a/src/core/llm/inline-images.ts
+++ b/src/core/llm/inline-images.ts
@@ -1,0 +1,62 @@
+export const DEFAULT_MAX_INLINE_IMAGES = 8;
+
+const OMITTED_INLINE_IMAGE_TEXT =
+  "[earlier image omitted to stay within the provider's per-request image limit]";
+
+const INLINE_IMAGE_BLOCK_TYPES = new Set(["image_url", "input_image", "image"]);
+
+function isInlineImageBlock(block: unknown): boolean {
+  if (!block || typeof block !== "object") return false;
+  const type = (block as Record<string, unknown>).type;
+  return typeof type === "string" && INLINE_IMAGE_BLOCK_TYPES.has(type);
+}
+
+export function countInlineImages(messages: Array<Record<string, unknown>>): number {
+  let count = 0;
+  for (const message of messages) {
+    if (!Array.isArray(message.content)) continue;
+    for (const block of message.content) if (isInlineImageBlock(block)) count += 1;
+  }
+  return count;
+}
+
+export function limitInlineImages(
+  messages: Array<Record<string, unknown>>,
+  maxImages: number
+): number {
+  const cap = Math.max(0, Math.floor(maxImages));
+  let kept = 0;
+  let elided = 0;
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (!Array.isArray(message.content)) continue;
+    let changed = false;
+    const nextContent: unknown[] = [];
+    for (let blockIndex = message.content.length - 1; blockIndex >= 0; blockIndex -= 1) {
+      const block = message.content[blockIndex];
+      if (!isInlineImageBlock(block)) {
+        nextContent.unshift(block);
+        continue;
+      }
+      if (kept < cap) {
+        kept += 1;
+        nextContent.unshift(block);
+        continue;
+      }
+      elided += 1;
+      changed = true;
+      const textType =
+        (block as Record<string, unknown>).type === "input_image" ? "input_text" : "text";
+      nextContent.unshift({ type: textType, text: OMITTED_INLINE_IMAGE_TEXT });
+    }
+    if (changed) message.content = nextContent;
+  }
+  return elided;
+}
+
+export function parseProviderInlineImageLimit(errorText: string): number | undefined {
+  const match = errorText.match(/at most\s+(\d+)\s+image/i);
+  if (!match) return undefined;
+  const limit = Number.parseInt(match[1] || "", 10);
+  return Number.isFinite(limit) && limit >= 0 ? limit : undefined;
+}

--- a/src/core/llm/reasoning.ts
+++ b/src/core/llm/reasoning.ts
@@ -8,6 +8,7 @@ import {
   usesProviderAdaptiveReasoning,
   type ReasoningEffort,
 } from "../../../shared/reasoning-capabilities";
+import type { OpenAIMessage } from "../agent-internals";
 import { isKimiCodeProvider, kimiThinkingParams } from "./kimi-wire";
 
 export {
@@ -102,4 +103,15 @@ export function googleThinkingConfig(
     return { includeThoughts: true, thinkingLevel: resolved };
   }
   return { includeThoughts: true };
+}
+
+export function openAIReasoningContent(message: OpenAIMessage | undefined): string {
+  if (!message) return "";
+  const candidates = [message.reasoning_content, message.reasoning, message.thinking];
+  return (
+    candidates.find(
+      (candidate): candidate is string =>
+        typeof candidate === "string" && candidate.trim().length > 0
+    ) ?? ""
+  );
 }

--- a/src/core/llm/text-tool-calls.ts
+++ b/src/core/llm/text-tool-calls.ts
@@ -704,6 +704,22 @@ export function hasTextToolCallMarkup(content: string | null | undefined): boole
   );
 }
 
+function isParsableToolArguments(value: unknown): boolean {
+  if (typeof value !== "string") return true;
+  if (!value.trim()) return true;
+  try {
+    JSON.parse(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function sanitizeReplayToolCall(toolCall: OpenAICompatToolCall): OpenAICompatToolCall {
+  if (!toolCall.function || isParsableToolArguments(toolCall.function.arguments)) return toolCall;
+  return { ...toolCall, function: { ...toolCall.function, arguments: "{}" } };
+}
+
 function toOpenAIReplayAssistantMessage(message: OpenAICompatMessage): Record<string, unknown> {
   const replayMessage: Record<string, unknown> = {
     role: typeof message.role === "string" && message.role.trim() ? message.role : "assistant",
@@ -711,7 +727,7 @@ function toOpenAIReplayAssistantMessage(message: OpenAICompatMessage): Record<st
   };
 
   if (Array.isArray(message.tool_calls) && message.tool_calls.length > 0) {
-    replayMessage.tool_calls = message.tool_calls;
+    replayMessage.tool_calls = message.tool_calls.map(sanitizeReplayToolCall);
   }
 
   for (const [key, value] of Object.entries(message)) {

--- a/src/core/llm/tool-transcript.ts
+++ b/src/core/llm/tool-transcript.ts
@@ -1,3 +1,5 @@
+import { estimateRequestValueChars } from "./context-estimate";
+
 export const TOOL_RESULT_COMPACTION_NOTICE =
   "[compacted: earlier tool output elided to free context]";
 export const MESSAGE_CONTENT_COMPACTION_NOTICE =
@@ -80,11 +82,7 @@ function estimateOpenAIChatMessageChars(message: Record<string, unknown>): numbe
   if (typeof content === "string") {
     total += content.length;
   } else if (Array.isArray(content)) {
-    try {
-      total += JSON.stringify(content).length;
-    } catch {
-      total += 256;
-    }
+    total += estimateRequestValueChars(content);
   }
 
   if (Array.isArray(message.tool_calls)) {

--- a/src/core/mobile-simulator.ts
+++ b/src/core/mobile-simulator.ts
@@ -2,8 +2,8 @@ import { createHash, randomUUID } from "node:crypto";
 import {
   existsSync,
   mkdirSync,
-  readFileSync,
   readdirSync,
+  readFileSync,
   rmdirSync,
   unlinkSync,
   writeFileSync,
@@ -15,9 +15,10 @@ import { coalescePendingWork } from "./coalesced-work";
 import {
   ensureIosSimulatorAutomation,
   getIosSimulatorAutomationStatus,
-  iosSimulatorAutomationEnv,
   type IosSimulatorAutomationStatus,
+  iosSimulatorAutomationEnv,
 } from "./mobile-simulator-idb";
+import { screenshotsDir } from "./paths";
 import { readSubprocessStream } from "./subprocess-output";
 
 export type MobileSimulatorPlatform = "ios" | "android";
@@ -152,11 +153,7 @@ const ANDROID_PREVIEW_MAX_WIDTH = 720;
 const ANDROID_PREVIEW_MAX_HEIGHT = 1_600;
 const IOS_PREVIEW_MAX_HEIGHT = 1_600;
 const IOS_PREVIEW_JPEG_QUALITY = "78";
-const screenshotDir = join(
-  process.env.HOME || process.env.USERPROFILE || homedir(),
-  ".cybara",
-  "screenshots"
-);
+
 const frameCache = new Map<string, CachedFrame>();
 const pendingFrameCaptures = new Map<string, Promise<CachedFrame>>();
 const frameGenerations = new Map<string, number>();
@@ -1218,10 +1215,10 @@ export async function saveMobileSimulatorScreenshot(
 ): Promise<{ filePath: string; contentType: string; device: MobileSimulatorDevice }> {
   const frame = await captureMobileSimulator(platform, deviceId);
   if (!frame.bytes) throw new Error("Simulator screenshot was unchanged");
-  mkdirSync(screenshotDir, { recursive: true });
+  mkdirSync(screenshotsDir, { recursive: true });
   const extension = frame.contentType === "image/jpeg" ? "jpg" : "png";
   const stamp = new Date().toISOString().replace(/[:.]/g, "-");
-  const filePath = join(screenshotDir, `${platform}_simulator_${stamp}.${extension}`);
+  const filePath = join(screenshotsDir, `${platform}_simulator_${stamp}.${extension}`);
   writeFileSync(filePath, frame.bytes);
   return { filePath, contentType: frame.contentType, device: frame.device };
 }

--- a/src/core/paths.ts
+++ b/src/core/paths.ts
@@ -1,11 +1,11 @@
+import { chmodSync, type Dirent, existsSync, mkdirSync, readdirSync } from "fs";
 import { dirname, join, resolve } from "path";
 import { fileURLToPath } from "url";
-import { chmodSync, type Dirent, existsSync, mkdirSync, readdirSync } from "fs";
 import {
+  type CybaraHomeSource,
   cybaraHomeOverrideFile,
   resolveCybaraHome,
   runtimeHomeDir,
-  type CybaraHomeSource,
 } from "./cybara-home";
 
 export const homeDir = runtimeHomeDir;
@@ -20,6 +20,7 @@ export const dataDir = join(cybaraDir, "data");
 export const memoryDir = join(cybaraDir, "memory");
 export const logsDir = join(cybaraDir, "logs");
 export const secureDir = join(cybaraDir, "secure");
+export const screenshotsDir = join(cybaraDir, "screenshots");
 export const configDir = process.env.CONFIG_DIR ? resolve(process.env.CONFIG_DIR) : cybaraDir;
 
 const __dirname = dirname(fileURLToPath(import.meta.url));

--- a/src/core/runtime/media-files.ts
+++ b/src/core/runtime/media-files.ts
@@ -1,6 +1,7 @@
-import { existsSync, statSync, readFileSync, realpathSync } from "fs";
-import { resolve, sep, extname, isAbsolute } from "path";
+import { existsSync, readFileSync, realpathSync, statSync } from "fs";
+import { extname, isAbsolute, resolve, sep } from "path";
 import { cybaraDir } from "../paths";
+import { isViewedMediaPath } from "../viewed-media";
 
 const MEDIA_MIME: Record<string, string> = {
   ".png": "image/png",
@@ -40,7 +41,9 @@ export function resolveMediaFile(relPath: string): MediaFileResult {
     ? resolve(relPath)
     : resolve(cybaraDir, relPath.replace(/^\/+/, ""));
   const roots = allowedRoots();
-  const contained = roots.some((root) => target === root || target.startsWith(root + sep));
+  const viewed = isViewedMediaPath(target);
+  const contained =
+    viewed || roots.some((root) => target === root || target.startsWith(root + sep));
   if (!contained) return { status: 403, error: "forbidden" };
 
   const contentType = MEDIA_MIME[extname(target).toLowerCase()];
@@ -54,9 +57,8 @@ export function resolveMediaFile(relPath: string): MediaFileResult {
     const realRoots = roots.map((root) =>
       existsSync(root) ? realpathSync.native(root) : resolve(root)
     );
-    const realContained = realRoots.some(
-      (root) => realTarget === root || realTarget.startsWith(root + sep)
-    );
+    const realContained =
+      viewed || realRoots.some((root) => realTarget === root || realTarget.startsWith(root + sep));
     if (!realContained) return { status: 403, error: "forbidden" };
     return { status: 200, contentType, bytes: readFileSync(realTarget) };
   } catch {

--- a/src/core/runtime/media-files.ts
+++ b/src/core/runtime/media-files.ts
@@ -1,7 +1,6 @@
 import { existsSync, readFileSync, realpathSync, statSync } from "fs";
 import { extname, isAbsolute, resolve, sep } from "path";
 import { cybaraDir } from "../paths";
-import { isViewedMediaPath } from "../viewed-media";
 
 const MEDIA_MIME: Record<string, string> = {
   ".png": "image/png",
@@ -41,9 +40,7 @@ export function resolveMediaFile(relPath: string): MediaFileResult {
     ? resolve(relPath)
     : resolve(cybaraDir, relPath.replace(/^\/+/, ""));
   const roots = allowedRoots();
-  const viewed = isViewedMediaPath(target);
-  const contained =
-    viewed || roots.some((root) => target === root || target.startsWith(root + sep));
+  const contained = roots.some((root) => target === root || target.startsWith(root + sep));
   if (!contained) return { status: 403, error: "forbidden" };
 
   const contentType = MEDIA_MIME[extname(target).toLowerCase()];
@@ -57,8 +54,9 @@ export function resolveMediaFile(relPath: string): MediaFileResult {
     const realRoots = roots.map((root) =>
       existsSync(root) ? realpathSync.native(root) : resolve(root)
     );
-    const realContained =
-      viewed || realRoots.some((root) => realTarget === root || realTarget.startsWith(root + sep));
+    const realContained = realRoots.some(
+      (root) => realTarget === root || realTarget.startsWith(root + sep)
+    );
     if (!realContained) return { status: 403, error: "forbidden" };
     return { status: 200, contentType, bytes: readFileSync(realTarget) };
   } catch {

--- a/src/core/session-context.ts
+++ b/src/core/session-context.ts
@@ -1373,6 +1373,7 @@ export interface PersistedSessionListEntry {
   messageCount: number;
   workspaceDir: string | null;
   pinned: boolean;
+  unread: boolean;
   lastMessageRole: string | null;
   lastMessageContent: string | null;
   modelMetadata: SessionModelMetadata | null;
@@ -1389,6 +1390,7 @@ interface PersistedSessionListRow {
   messageCount: number;
   workspaceDir: string | null;
   pinned: number;
+  unread: number;
   lastMessageRole: string | null;
   lastMessageContent: string | null;
   lastModelMetadata: string | null;
@@ -1420,6 +1422,7 @@ function normalizePersistedSessionListRow(
         ? sanitizeAssistantContent(session.lastMessageContent)
         : session.lastMessageContent,
     pinned: !!session.pinned,
+    unread: !!session.unread,
     modelMetadata: mergeSessionModelMetadata(
       resolveSessionModelMetadata(session.agentId),
       parseSessionModelMetadata(session.lastModelMetadata)
@@ -1444,6 +1447,17 @@ function persistedSessionListSql(
         cs.updated_at as updatedAt,
         cs.workspace_dir as workspaceDir,
         COALESCE(cs.pinned, 0) as pinned,
+        CASE WHEN EXISTS (
+          SELECT 1
+          FROM session_messages unread_message
+          WHERE unread_message.session_id = cs.id
+            AND unread_message.role = 'assistant'
+            AND unread_message.rowid > COALESCE((
+              SELECT read_message.rowid
+              FROM session_messages read_message
+              WHERE read_message.id = cs.last_read_assistant_message_id
+            ), 0)
+        ) THEN 1 ELSE 0 END as unread,
         cs.room_config as roomConfig,
         COALESCE(NULLIF((
           SELECT COUNT(*)

--- a/src/core/status.ts
+++ b/src/core/status.ts
@@ -34,6 +34,7 @@ export interface StatusPayload {
   toolName?: string;
   toolCallId?: string;
   sandboxProvider?: string;
+  imagePath?: string;
   toolPhase?: ToolStatusPhase;
   durationMs?: number;
   pendingChatId?: string;
@@ -108,6 +109,7 @@ export interface SessionActivitySnapshot {
   toolName?: string;
   toolCallId?: string;
   sandboxProvider?: string;
+  imagePath?: string;
 }
 
 export interface SessionStatusSnapshot {
@@ -350,6 +352,7 @@ export function reduceSessionStatusSnapshot(
         toolName,
         toolCallId,
         sandboxProvider: payload.sandboxProvider,
+        imagePath: payload.imagePath,
       });
     } else {
       const matchIndex = findMatchingStartActivityIndex(
@@ -373,6 +376,7 @@ export function reduceSessionStatusSnapshot(
           toolName: toolName || matched.toolName,
           toolCallId: toolCallId || matched.toolCallId,
           sandboxProvider: payload.sandboxProvider || matched.sandboxProvider,
+          imagePath: payload.imagePath || matched.imagePath,
         };
       } else {
         const fallbackText = activityText || defaultToolActivityText(toolName, phase);
@@ -384,6 +388,7 @@ export function reduceSessionStatusSnapshot(
           toolName,
           toolCallId,
           sandboxProvider: payload.sandboxProvider,
+          imagePath: payload.imagePath,
         });
       }
     }

--- a/src/core/tools/handlers/browser.ts
+++ b/src/core/tools/handlers/browser.ts
@@ -1,5 +1,4 @@
 import { existsSync, mkdirSync, writeFileSync } from "fs";
-import { homedir } from "os";
 import { join } from "path";
 import {
   browserViewportPreset,
@@ -21,8 +20,9 @@ import * as profileManager from "../../browser/profiles";
 import * as pwManager from "../../browser/pw-manager";
 import { CONTENT_ROLES, INTERACTIVE_ROLES, STRUCTURAL_ROLES } from "../../browser/pw-role-snapshot";
 import { fetchPublicHttpUrl, type PublicHttpFetcher } from "../../outbound-url-policy";
-import type { ToolContext } from "../index";
+import { screenshotsDir } from "../../paths";
 import { getWebResearchRuntimeEnv } from "../../web-research-settings";
+import type { ToolContext } from "../index";
 import { enforceWebFetchAllowlist } from "./web-policy";
 import {
   extractFirecrawl,
@@ -30,12 +30,6 @@ import {
   firecrawlConfigured,
   parallelConfigured,
 } from "./web-research-providers";
-
-const SCREENSHOTS_DIR = join(
-  process.env.HOME || process.env.USERPROFILE || homedir(),
-  ".cybara",
-  "screenshots"
-);
 
 const sessionPages = new Map<string, string>();
 
@@ -743,11 +737,11 @@ export async function handleBrowser(
         const timestamp = Date.now();
         const filename = `screenshot_${timestamp}.${format}`;
 
-        if (!existsSync(SCREENSHOTS_DIR)) {
-          mkdirSync(SCREENSHOTS_DIR, { recursive: true });
+        if (!existsSync(screenshotsDir)) {
+          mkdirSync(screenshotsDir, { recursive: true });
         }
 
-        const filePath = join(SCREENSHOTS_DIR, filename);
+        const filePath = join(screenshotsDir, filename);
         writeFileSync(filePath, screenshot);
         console.log(`[Browser] Screenshot saved to: ${filePath}`);
 
@@ -794,11 +788,11 @@ export async function handleBrowser(
       const timestamp = Date.now();
       const filename = `screenshot_${timestamp}.${format}`;
 
-      if (!existsSync(SCREENSHOTS_DIR)) {
-        mkdirSync(SCREENSHOTS_DIR, { recursive: true });
+      if (!existsSync(screenshotsDir)) {
+        mkdirSync(screenshotsDir, { recursive: true });
       }
 
-      const filePath = join(SCREENSHOTS_DIR, filename);
+      const filePath = join(screenshotsDir, filename);
       writeFileSync(filePath, screenshot);
       console.log(`[Browser] Screenshot saved to: ${filePath}`);
 

--- a/src/core/viewed-media.ts
+++ b/src/core/viewed-media.ts
@@ -1,80 +1,17 @@
-import {
-  copyFileSync,
-  existsSync,
-  mkdirSync,
-  readdirSync,
-  readFileSync,
-  rmSync,
-  statSync,
-  writeFileSync,
-} from "fs";
+import { copyFileSync, existsSync, mkdirSync, readdirSync, rmSync, statSync } from "fs";
 import { basename, extname, join, resolve, sep } from "path";
-import { cybaraDir, dataDir } from "./paths";
+import { cybaraDir } from "./paths";
 
-const MAX_VIEWED_MEDIA_PATHS = 5000;
 const MAX_SNAPSHOT_BYTES = 25 * 1024 * 1024;
 const MAX_SNAPSHOT_DIRS = 400;
 const SNAPSHOT_EXTENSIONS = new Set([".png", ".jpg", ".jpeg", ".gif", ".webp"]);
-const registryFile = join(dataDir, "viewed-media.json");
 const snapshotRoot = join(cybaraDir, "media", "viewed");
 const snapshotsByFingerprint = new Map<string, string>();
-
-let viewedPaths: Set<string> | undefined;
 
 function normalizeViewedPath(path: string): string | undefined {
   const trimmed = path.trim();
   if (!trimmed || trimmed.startsWith("data:") || /^https?:\/\//i.test(trimmed)) return undefined;
   return resolve(trimmed);
-}
-
-function loadViewedPaths(): Set<string> {
-  if (viewedPaths) return viewedPaths;
-  viewedPaths = new Set();
-  try {
-    if (existsSync(registryFile)) {
-      const parsed = JSON.parse(readFileSync(registryFile, "utf8")) as unknown;
-      if (Array.isArray(parsed)) {
-        for (const entry of parsed) {
-          if (typeof entry === "string" && entry) viewedPaths.add(entry);
-        }
-      }
-    }
-  } catch {
-    viewedPaths = new Set();
-  }
-  return viewedPaths;
-}
-
-function persistViewedPaths(paths: Set<string>): void {
-  try {
-    mkdirSync(dataDir, { recursive: true });
-    writeFileSync(registryFile, JSON.stringify([...paths]));
-  } catch {
-    return;
-  }
-}
-
-export function registerViewedMediaPath(path: string): void {
-  const normalized = normalizeViewedPath(path);
-  if (!normalized) return;
-  const paths = loadViewedPaths();
-  if (paths.has(normalized)) return;
-  paths.add(normalized);
-  while (paths.size > MAX_VIEWED_MEDIA_PATHS) {
-    const oldest = paths.values().next().value;
-    if (oldest === undefined) break;
-    paths.delete(oldest);
-  }
-  persistViewedPaths(paths);
-}
-
-export function isViewedMediaPath(path: string): boolean {
-  const normalized = normalizeViewedPath(path);
-  return normalized ? loadViewedPaths().has(normalized) : false;
-}
-
-export function resetViewedMediaPathsForTests(): void {
-  viewedPaths = undefined;
 }
 
 function pruneSnapshotDirs(): void {

--- a/src/core/viewed-media.ts
+++ b/src/core/viewed-media.ts
@@ -3,10 +3,24 @@ import { basename, extname, join, resolve, sep } from "path";
 import { cybaraDir } from "./paths";
 
 const MAX_SNAPSHOT_BYTES = 25 * 1024 * 1024;
-const MAX_SNAPSHOT_DIRS = 400;
+const DEFAULT_MAX_SNAPSHOT_DIRS = 400;
+const DEFAULT_PRUNE_EVERY = 25;
 const SNAPSHOT_EXTENSIONS = new Set([".png", ".jpg", ".jpeg", ".gif", ".webp"]);
-const snapshotRoot = join(cybaraDir, "media", "viewed");
+const DEFAULT_SNAPSHOT_ROOT = join(cybaraDir, "media", "viewed");
 const snapshotsByFingerprint = new Map<string, string>();
+
+let snapshotRoot = DEFAULT_SNAPSHOT_ROOT;
+let maxSnapshotDirs = DEFAULT_MAX_SNAPSHOT_DIRS;
+let pruneEvery = DEFAULT_PRUNE_EVERY;
+let copiesSincePrune = Number.POSITIVE_INFINITY;
+let snapshotSequence = 0;
+
+function nextSnapshotDirName(): string {
+  snapshotSequence += 1;
+  const stamp = Date.now().toString(36).padStart(9, "0");
+  const order = snapshotSequence.toString(36).padStart(6, "0");
+  return `${stamp}-${order}-${Math.random().toString(36).slice(2, 6)}`;
+}
 
 function normalizeViewedPath(path: string): string | undefined {
   const trimmed = path.trim();
@@ -14,22 +28,44 @@ function normalizeViewedPath(path: string): string | undefined {
   return resolve(trimmed);
 }
 
+function forgetSnapshotsUnder(dir: string): void {
+  const prefix = dir + sep;
+  for (const [fingerprint, target] of snapshotsByFingerprint) {
+    if (target.startsWith(prefix)) snapshotsByFingerprint.delete(fingerprint);
+  }
+}
+
 function pruneSnapshotDirs(): void {
+  copiesSincePrune = 0;
   let entries: string[];
   try {
     entries = readdirSync(snapshotRoot).sort();
   } catch {
     return;
   }
-  while (entries.length > MAX_SNAPSHOT_DIRS) {
+  while (entries.length > maxSnapshotDirs) {
     const oldest = entries.shift();
     if (!oldest) break;
+    const dir = join(snapshotRoot, oldest);
     try {
-      rmSync(join(snapshotRoot, oldest), { recursive: true, force: true });
+      rmSync(dir, { recursive: true, force: true });
     } catch {
       continue;
     }
+    forgetSnapshotsUnder(dir);
   }
+}
+
+function rememberSnapshot(fingerprint: string, target: string): void {
+  snapshotsByFingerprint.delete(fingerprint);
+  snapshotsByFingerprint.set(fingerprint, target);
+  while (snapshotsByFingerprint.size > maxSnapshotDirs) {
+    const oldest = snapshotsByFingerprint.keys().next().value;
+    if (oldest === undefined) break;
+    snapshotsByFingerprint.delete(oldest);
+  }
+  copiesSincePrune += 1;
+  if (copiesSincePrune >= pruneEvery) pruneSnapshotDirs();
 }
 
 export function isViewedMediaSnapshot(path: string): boolean {
@@ -52,10 +88,8 @@ export function snapshotViewedMedia(path: string): string | undefined {
   const fingerprint = `${normalized}:${Math.floor(stats.mtimeMs)}:${stats.size}`;
   const cached = snapshotsByFingerprint.get(fingerprint);
   if (cached && existsSync(cached)) return cached;
-  const dir = join(
-    snapshotRoot,
-    `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
-  );
+  if (cached) snapshotsByFingerprint.delete(fingerprint);
+  const dir = join(snapshotRoot, nextSnapshotDirName());
   const target = join(dir, basename(normalized));
   try {
     mkdirSync(dir, { recursive: true });
@@ -63,7 +97,22 @@ export function snapshotViewedMedia(path: string): string | undefined {
   } catch {
     return undefined;
   }
-  snapshotsByFingerprint.set(fingerprint, target);
-  pruneSnapshotDirs();
+  rememberSnapshot(fingerprint, target);
   return target;
+}
+
+export function configureViewedMediaSnapshotsForTests(options?: {
+  maxDirs?: number;
+  pruneEvery?: number;
+  root?: string;
+}): void {
+  snapshotRoot = options?.root ? resolve(options.root) : DEFAULT_SNAPSHOT_ROOT;
+  maxSnapshotDirs = options?.maxDirs ?? DEFAULT_MAX_SNAPSHOT_DIRS;
+  pruneEvery = options?.pruneEvery ?? DEFAULT_PRUNE_EVERY;
+  snapshotsByFingerprint.clear();
+  copiesSincePrune = Number.POSITIVE_INFINITY;
+}
+
+export function viewedMediaSnapshotCacheSizeForTests(): number {
+  return snapshotsByFingerprint.size;
 }

--- a/src/core/viewed-media.ts
+++ b/src/core/viewed-media.ts
@@ -1,9 +1,23 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
-import { join, resolve } from "path";
-import { dataDir } from "./paths";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "fs";
+import { basename, extname, join, resolve, sep } from "path";
+import { cybaraDir, dataDir } from "./paths";
 
 const MAX_VIEWED_MEDIA_PATHS = 5000;
+const MAX_SNAPSHOT_BYTES = 25 * 1024 * 1024;
+const MAX_SNAPSHOT_DIRS = 400;
+const SNAPSHOT_EXTENSIONS = new Set([".png", ".jpg", ".jpeg", ".gif", ".webp"]);
 const registryFile = join(dataDir, "viewed-media.json");
+const snapshotRoot = join(cybaraDir, "media", "viewed");
+const snapshotsByFingerprint = new Map<string, string>();
 
 let viewedPaths: Set<string> | undefined;
 
@@ -61,4 +75,58 @@ export function isViewedMediaPath(path: string): boolean {
 
 export function resetViewedMediaPathsForTests(): void {
   viewedPaths = undefined;
+}
+
+function pruneSnapshotDirs(): void {
+  let entries: string[];
+  try {
+    entries = readdirSync(snapshotRoot).sort();
+  } catch {
+    return;
+  }
+  while (entries.length > MAX_SNAPSHOT_DIRS) {
+    const oldest = entries.shift();
+    if (!oldest) break;
+    try {
+      rmSync(join(snapshotRoot, oldest), { recursive: true, force: true });
+    } catch {
+      continue;
+    }
+  }
+}
+
+export function isViewedMediaSnapshot(path: string): boolean {
+  const normalized = normalizeViewedPath(path);
+  return !!normalized && normalized.startsWith(snapshotRoot + sep);
+}
+
+export function snapshotViewedMedia(path: string): string | undefined {
+  const normalized = normalizeViewedPath(path);
+  if (!normalized) return undefined;
+  if (isViewedMediaSnapshot(normalized)) return normalized;
+  if (!SNAPSHOT_EXTENSIONS.has(extname(normalized).toLowerCase())) return undefined;
+  let stats: ReturnType<typeof statSync>;
+  try {
+    stats = statSync(normalized);
+  } catch {
+    return undefined;
+  }
+  if (!stats.isFile() || stats.size <= 0 || stats.size > MAX_SNAPSHOT_BYTES) return undefined;
+  const fingerprint = `${normalized}:${Math.floor(stats.mtimeMs)}:${stats.size}`;
+  const cached = snapshotsByFingerprint.get(fingerprint);
+  if (cached && existsSync(cached)) return cached;
+  const dir = join(
+    snapshotRoot,
+    `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
+  );
+  const target = join(dir, basename(normalized));
+  try {
+    mkdirSync(dir, { recursive: true });
+    copyFileSync(normalized, target);
+  } catch {
+    return undefined;
+  }
+  snapshotsByFingerprint.set(fingerprint, target);
+  pruneSnapshotDirs();
+  return target;
 }

--- a/src/core/viewed-media.ts
+++ b/src/core/viewed-media.ts
@@ -1,0 +1,64 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { join, resolve } from "path";
+import { dataDir } from "./paths";
+
+const MAX_VIEWED_MEDIA_PATHS = 5000;
+const registryFile = join(dataDir, "viewed-media.json");
+
+let viewedPaths: Set<string> | undefined;
+
+function normalizeViewedPath(path: string): string | undefined {
+  const trimmed = path.trim();
+  if (!trimmed || trimmed.startsWith("data:") || /^https?:\/\//i.test(trimmed)) return undefined;
+  return resolve(trimmed);
+}
+
+function loadViewedPaths(): Set<string> {
+  if (viewedPaths) return viewedPaths;
+  viewedPaths = new Set();
+  try {
+    if (existsSync(registryFile)) {
+      const parsed = JSON.parse(readFileSync(registryFile, "utf8")) as unknown;
+      if (Array.isArray(parsed)) {
+        for (const entry of parsed) {
+          if (typeof entry === "string" && entry) viewedPaths.add(entry);
+        }
+      }
+    }
+  } catch {
+    viewedPaths = new Set();
+  }
+  return viewedPaths;
+}
+
+function persistViewedPaths(paths: Set<string>): void {
+  try {
+    mkdirSync(dataDir, { recursive: true });
+    writeFileSync(registryFile, JSON.stringify([...paths]));
+  } catch {
+    return;
+  }
+}
+
+export function registerViewedMediaPath(path: string): void {
+  const normalized = normalizeViewedPath(path);
+  if (!normalized) return;
+  const paths = loadViewedPaths();
+  if (paths.has(normalized)) return;
+  paths.add(normalized);
+  while (paths.size > MAX_VIEWED_MEDIA_PATHS) {
+    const oldest = paths.values().next().value;
+    if (oldest === undefined) break;
+    paths.delete(oldest);
+  }
+  persistViewedPaths(paths);
+}
+
+export function isViewedMediaPath(path: string): boolean {
+  const normalized = normalizeViewedPath(path);
+  return normalized ? loadViewedPaths().has(normalized) : false;
+}
+
+export function resetViewedMediaPathsForTests(): void {
+  viewedPaths = undefined;
+}

--- a/tests/api/chat-process-activities.test.ts
+++ b/tests/api/chat-process-activities.test.ts
@@ -5,6 +5,7 @@ import {
   formatProcessActivityFromToolCall,
   type ProcessActivityInfo,
 } from "../../src/api/chat-process-activities";
+import { sanitizeProcessActivities } from "../../src/api/routes/_shared";
 
 describe("chat process activities", () => {
   test("formats paths and multiline commands without losing detail", () => {
@@ -199,5 +200,38 @@ describe("chat process activities", () => {
 
   test("returns no fallback for empty generic activity", () => {
     expect(buildFallbackProcessActivities([], "Thinking...", Number.NaN)).toBeUndefined();
+  });
+});
+
+describe("session read-path activity sanitization", () => {
+  test("keeps the viewed image and sandbox metadata when a session is reloaded", () => {
+    const sanitized = sanitizeProcessActivities([
+      {
+        id: "run:4",
+        phase: "result",
+        text: "Viewed an image",
+        timestamp: 1_788_758_258_991,
+        toolName: "image",
+        toolCallId: "chatcmpl-tool-b1ee513f165187f2",
+        imagePath: "/Users/carsen/.cybara/media/viewed/abc/render.png",
+        sandboxProvider: "host",
+      },
+      {
+        id: "run:5",
+        phase: "result",
+        text: "Ran ls",
+        timestamp: 1_788_758_259_000,
+        toolName: "exec",
+      },
+    ]);
+
+    expect(sanitized).toHaveLength(2);
+    expect(sanitized?.[0]).toMatchObject({
+      toolCallId: "chatcmpl-tool-b1ee513f165187f2",
+      imagePath: "/Users/carsen/.cybara/media/viewed/abc/render.png",
+      sandboxProvider: "host",
+    });
+    expect(sanitized?.[1].imagePath).toBeUndefined();
+    expect(sanitized?.[1].sandboxProvider).toBeUndefined();
   });
 });

--- a/tests/api/chat-process-activities.test.ts
+++ b/tests/api/chat-process-activities.test.ts
@@ -26,6 +26,19 @@ describe("chat process activities", () => {
     ).toBe("Ran bun test bun run typecheck");
   });
 
+  test("labels image views by phase instead of the generic tool name", () => {
+    const args = { image: "/tmp/renders/mug_side.png", prompt: "Describe the render" };
+    expect(
+      formatProcessActivityFromToolCall({ id: "image-1", name: "image", args, status: "executing" })
+    ).toBe("Viewing an image");
+    expect(
+      formatProcessActivityFromToolCall({ id: "image-1", name: "image", args, status: "completed" })
+    ).toBe("Viewed an image");
+    expect(
+      formatProcessActivityFromToolCall({ id: "image-1", name: "image", args, status: "failed" })
+    ).toBe("Image view failed");
+  });
+
   test("formats complete command activity without shortening it", () => {
     const command =
       "printf 'complete command activity remains fully visible across every client surface' >/dev/null";

--- a/tests/api/routes-sessions.test.ts
+++ b/tests/api/routes-sessions.test.ts
@@ -546,6 +546,50 @@ describe("Session API", () => {
     expect(Array.isArray(data)).toBe(true);
   });
 
+  test("marks the latest assistant response read without hiding later responses", async () => {
+    const suffix = Date.now();
+    const sessionId = `session-unread-${suffix}`;
+    const agentId = `session-unread-agent-${suffix}`;
+    try {
+      fixture.insertRawAgent(agentId, "Unread Agent", "{}");
+      fixture.insertRawSession(sessionId, agentId, [
+        { role: "user", content: "Work on this" },
+        { role: "assistant", content: "Finished" },
+      ]);
+
+      const before = await fixture.api("GET", "/api/sessions");
+      expect(
+        (before.data as Array<{ id: string; unread: boolean }>).find(
+          (session) => session.id === sessionId
+        )?.unread
+      ).toBe(true);
+
+      const marked = await fixture.api("PUT", `/api/sessions/${sessionId}/read`);
+      expect(marked.status).toBe(200);
+      expect(marked.data).toMatchObject({ success: true, session_id: sessionId, unread: false });
+
+      const after = await fixture.api("GET", "/api/sessions");
+      expect(
+        (after.data as Array<{ id: string; unread: boolean }>).find(
+          (session) => session.id === sessionId
+        )?.unread
+      ).toBe(false);
+
+      fixture.insertRawSession(sessionId, agentId, [
+        { role: "assistant", content: "Another response" },
+      ]);
+      const later = await fixture.api("GET", "/api/sessions");
+      expect(
+        (later.data as Array<{ id: string; unread: boolean }>).find(
+          (session) => session.id === sessionId
+        )?.unread
+      ).toBe(true);
+    } finally {
+      fixture.deleteRawSession(sessionId);
+      fixture.deleteRawAgent(agentId);
+    }
+  });
+
   test("session list and detail include provider/model metadata for the chat agent", async () => {
     const suffix = Date.now();
     const providerId = `session-provider-${suffix}`;

--- a/tests/api/routes-sessions.test.ts
+++ b/tests/api/routes-sessions.test.ts
@@ -568,6 +568,10 @@ describe("Session API", () => {
       expect(marked.status).toBe(200);
       expect(marked.data).toMatchObject({ success: true, session_id: sessionId, unread: false });
 
+      const repeated = await fixture.api("PUT", `/api/sessions/${sessionId}/read`);
+      expect(repeated.status).toBe(200);
+      expect(repeated.data).toMatchObject({ success: true, session_id: sessionId, unread: false });
+
       const after = await fixture.api("GET", "/api/sessions");
       expect(
         (after.data as Array<{ id: string; unread: boolean }>).find(

--- a/tests/core/agent-helper-modules.test.ts
+++ b/tests/core/agent-helper-modules.test.ts
@@ -10,9 +10,28 @@ import {
   DEFAULT_MODEL_MAX_OUTPUT_TOKENS,
 } from "../../src/core/agent-internals";
 import { canPreStartOpenAIToolCall } from "../../src/core/agent-provider-openai-compat-runtime";
-import { openAICompatClosingReasoningParams } from "../../src/core/llm/reasoning";
+import {
+  openAICompatClosingReasoningParams,
+  openAIReasoningContent,
+} from "../../src/core/llm/reasoning";
 
 describe("agent helper modules", () => {
+  test("falls back to reasoning channels when a closing reply has empty content", () => {
+    expect(openAIReasoningContent(undefined)).toBe("");
+    expect(openAIReasoningContent({ role: "assistant", content: "" })).toBe("");
+    expect(
+      openAIReasoningContent({ role: "assistant", content: null, reasoning: "Here is the model." })
+    ).toBe("Here is the model.");
+    expect(
+      openAIReasoningContent({
+        role: "assistant",
+        content: "",
+        reasoning_content: "  findings  ",
+        thinking: "ignored",
+      })
+    ).toBe("  findings  ");
+  });
+
   test("prestarts independent reads but validates mutations before execution", () => {
     expect(canPreStartOpenAIToolCall("read")).toBe(true);
     expect(canPreStartOpenAIToolCall("exec")).toBe(true);

--- a/tests/core/context-estimate.test.ts
+++ b/tests/core/context-estimate.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import {
+  estimateOpenAIRequestTokens,
+  estimateRequestValueChars,
+  IMAGE_TOKEN_ESTIMATE,
+  isImageContentBlock,
+} from "../../src/core/llm/context-estimate";
+import { CONTEXT_CHARS_PER_TOKEN_ESTIMATE } from "../../src/core/agent-internals";
+
+const base64Image = (chars: number) => `data:image/png;base64,${"a".repeat(chars)}`;
+
+describe("request context estimation", () => {
+  test("recognizes every provider image block shape", () => {
+    expect(isImageContentBlock({ type: "image", source: { type: "base64", data: "x" } })).toBe(
+      true
+    );
+    expect(isImageContentBlock({ type: "image_url", image_url: { url: "x" } })).toBe(true);
+    expect(isImageContentBlock({ type: "input_image", image_url: "x" })).toBe(true);
+    expect(isImageContentBlock({ type: "text", text: "x" })).toBe(false);
+    expect(isImageContentBlock("image")).toBe(false);
+  });
+
+  test("charges images by visual tokens instead of base64 length", () => {
+    const block = { type: "image_url", image_url: { url: base64Image(2_000_000) } };
+    expect(estimateRequestValueChars(block)).toBe(
+      IMAGE_TOKEN_ESTIMATE * CONTEXT_CHARS_PER_TOKEN_ESTIMATE
+    );
+  });
+
+  test("keeps four large image tool follow-ups within a one-million-token window", () => {
+    const followup = {
+      role: "user",
+      content: [
+        { type: "text", text: "Inspect the image returned by the file or image tool." },
+        { type: "image_url", image_url: { url: base64Image(1_730_000) } },
+        { type: "image_url", image_url: { url: base64Image(1_730_000) } },
+      ],
+    };
+    const request = {
+      model: "vision-model",
+      messages: [
+        { role: "system", content: "s".repeat(40_000) },
+        { role: "user", content: "render it" },
+        followup,
+        { role: "assistant", content: "rendering again" },
+        followup,
+      ],
+    };
+    const estimate = estimateOpenAIRequestTokens(request);
+    expect(estimate).toBeLessThan(40_000);
+    expect(estimate).toBeGreaterThan(4 * IMAGE_TOKEN_ESTIMATE);
+  });
+
+  test("still counts text content by length", () => {
+    const estimate = estimateOpenAIRequestTokens({
+      messages: [{ role: "user", content: "x".repeat(4_000) }],
+    });
+    expect(estimate).toBeGreaterThanOrEqual(1_000);
+    expect(estimate).toBeLessThan(1_100);
+  });
+});

--- a/tests/core/inline-images.test.ts
+++ b/tests/core/inline-images.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import {
+  countInlineImages,
+  DEFAULT_MAX_INLINE_IMAGES,
+  limitInlineImages,
+  parseProviderInlineImageLimit,
+} from "../../src/core/llm/inline-images";
+
+const imageBlock = (name: string) => ({
+  type: "image_url",
+  image_url: { url: `data:image/png;base64,${name}` },
+});
+
+const followup = (...names: string[]) => ({
+  role: "user",
+  content: [{ type: "text", text: "Inspect the image." }, ...names.map(imageBlock)],
+});
+
+describe("inline image limits", () => {
+  test("keeps the most recent images and replaces older ones with a note", () => {
+    const messages: Array<Record<string, unknown>> = [
+      { role: "system", content: "rules" },
+      followup("a", "b", "c", "d"),
+      { role: "assistant", content: "rendering again" },
+      followup("e"),
+      followup("f", "g", "h", "i"),
+    ];
+    expect(countInlineImages(messages)).toBe(9);
+    expect(limitInlineImages(messages, 8)).toBe(1);
+    expect(countInlineImages(messages)).toBe(8);
+    const first = messages[1].content as Array<Record<string, unknown>>;
+    expect(first[1].type).toBe("text");
+    expect(String(first[1].text)).toContain("omitted");
+    expect(first[2]).toEqual(imageBlock("b"));
+    const last = messages[4].content as Array<Record<string, unknown>>;
+    expect(last.slice(1)).toEqual(["f", "g", "h", "i"].map(imageBlock));
+  });
+
+  test("leaves requests within the limit untouched", () => {
+    const messages: Array<Record<string, unknown>> = [followup("a", "b")];
+    const before = JSON.stringify(messages);
+    expect(limitInlineImages(messages, DEFAULT_MAX_INLINE_IMAGES)).toBe(0);
+    expect(JSON.stringify(messages)).toBe(before);
+  });
+
+  test("parses provider image-limit rejections", () => {
+    expect(
+      parseProviderInlineImageLimit(
+        "API error in agentic loop: 400 - At most 8 image(s) may be provided in one prompt."
+      )
+    ).toBe(8);
+    expect(parseProviderInlineImageLimit("context window exceeded")).toBeUndefined();
+  });
+});

--- a/tests/core/media-files.test.ts
+++ b/tests/core/media-files.test.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "fs";
 import { join } from "path";
 import { cybaraDir } from "../../src/core/paths";
 import { resolveMediaFile } from "../../src/core/runtime/media-files";
-import { registerViewedMediaPath } from "../../src/core/viewed-media";
+import { snapshotViewedMedia } from "../../src/core/viewed-media";
 
 const screenshotsDir = join(cybaraDir, "screenshots");
 const mediaDir = join(cybaraDir, "media");
@@ -34,14 +34,16 @@ describe("resolveMediaFile", () => {
     if (existsSync(viewedDir)) rmSync(viewedDir, { recursive: true, force: true });
   });
 
-  test("serves images the agent viewed even outside the media roots", () => {
+  test("never serves files outside the media roots, even after the agent views them", () => {
     expect(resolveMediaFile(viewedPath).status).toBe(403);
-    registerViewedMediaPath(viewedPath);
-    const viewed = resolveMediaFile(viewedPath);
-    expect(viewed.status).toBe(200);
-    expect(viewed.contentType).toBe("image/png");
-    expect(viewed.bytes?.equals(pngBytes)).toBe(true);
+    const snapshot = snapshotViewedMedia(viewedPath);
+    expect(snapshot).toBeDefined();
+    expect(resolveMediaFile(viewedPath).status).toBe(403);
     expect(resolveMediaFile(unviewedPath).status).toBe(403);
+    const served = resolveMediaFile(snapshot!);
+    expect(served.status).toBe(200);
+    expect(served.contentType).toBe("image/png");
+    expect(served.bytes?.equals(pngBytes)).toBe(true);
   });
 
   test("serves a file inside an allowed subdir", () => {

--- a/tests/core/media-files.test.ts
+++ b/tests/core/media-files.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, test, beforeAll, afterAll } from "bun:test";
-import { mkdirSync, writeFileSync, rmSync, existsSync, symlinkSync } from "fs";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "fs";
 import { join } from "path";
-import { resolveMediaFile } from "../../src/core/runtime/media-files";
 import { cybaraDir } from "../../src/core/paths";
+import { resolveMediaFile } from "../../src/core/runtime/media-files";
+import { registerViewedMediaPath } from "../../src/core/viewed-media";
 
 const screenshotsDir = join(cybaraDir, "screenshots");
 const mediaDir = join(cybaraDir, "media");
@@ -12,6 +13,9 @@ const audioName = "test_media_files_tts.m4a";
 const audioPath = join(mediaDir, audioName);
 const pngBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
 const audioBytes = Buffer.from([0x00, 0x00, 0x00, 0x1c, 0x66, 0x74, 0x79, 0x70]);
+const viewedDir = join(cybaraDir, "test_media_files_viewed_outside");
+const viewedPath = join(viewedDir, "render.png");
+const unviewedPath = join(viewedDir, "other.png");
 
 describe("resolveMediaFile", () => {
   beforeAll(() => {
@@ -19,11 +23,25 @@ describe("resolveMediaFile", () => {
     mkdirSync(mediaDir, { recursive: true });
     writeFileSync(samplePath, pngBytes);
     writeFileSync(audioPath, audioBytes);
+    mkdirSync(viewedDir, { recursive: true });
+    writeFileSync(viewedPath, pngBytes);
+    writeFileSync(unviewedPath, pngBytes);
   });
 
   afterAll(() => {
     if (existsSync(samplePath)) rmSync(samplePath);
     if (existsSync(audioPath)) rmSync(audioPath);
+    if (existsSync(viewedDir)) rmSync(viewedDir, { recursive: true, force: true });
+  });
+
+  test("serves images the agent viewed even outside the media roots", () => {
+    expect(resolveMediaFile(viewedPath).status).toBe(403);
+    registerViewedMediaPath(viewedPath);
+    const viewed = resolveMediaFile(viewedPath);
+    expect(viewed.status).toBe(200);
+    expect(viewed.contentType).toBe("image/png");
+    expect(viewed.bytes?.equals(pngBytes)).toBe(true);
+    expect(resolveMediaFile(unviewedPath).status).toBe(403);
   });
 
   test("serves a file inside an allowed subdir", () => {

--- a/tests/core/plugins.test.ts
+++ b/tests/core/plugins.test.ts
@@ -1,12 +1,12 @@
 import { afterAll, describe, expect, test } from "bun:test";
-import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "fs";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 
 import {
-  installPluginFromPayload,
-  installLocalPluginFromPath,
   getBuiltinPluginCatalog,
+  installLocalPluginFromPath,
+  installPluginFromPayload,
   listInstalledPlugins,
   MAX_PLUGIN_EXPANDED_BYTES,
   parsePluginInstallPayload,
@@ -128,7 +128,7 @@ describe("plugin runtime", () => {
           .filter((plugin) => plugin.source === "bundled")
           .map((plugin) => [plugin.manifest.id, plugin.skillNames])
       );
-      expect(bundledSkills.get("blender-workflows")).toEqual(["blender-mcp"]);
+      expect(bundledSkills.get("blender-workflows")).toEqual(["blender-headless", "blender-mcp"]);
       expect(bundledSkills.get("browser-quality")).toEqual(["browser-qa"]);
       expect(bundledSkills.get("container-operations")).toEqual(["container-operations"]);
       expect(bundledSkills.get("data-workflows")).toEqual(["database-operations"]);

--- a/tests/core/session-unread-state.test.ts
+++ b/tests/core/session-unread-state.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { deleteSession, listSessions, markSessionRead } from "../../src/api/chat";
+import { persistSession, upsertPersistedSessionMessage } from "../../src/core/session-context";
+
+const createdSessionIds: string[] = [];
+
+function sessionId(): string {
+  return `test-unread-${Date.now()}-${crypto.randomUUID()}`;
+}
+
+async function unreadState(id: string): Promise<boolean | undefined> {
+  return (await listSessions()).find((session) => session.id === id)?.unread;
+}
+
+afterEach(async () => {
+  for (const id of createdSessionIds.splice(0)) await deleteSession(id);
+});
+
+describe("session unread state", () => {
+  test("tracks assistant responses after the durable read cursor", async () => {
+    const id = sessionId();
+    createdSessionIds.push(id);
+    await persistSession(id, "test-agent", []);
+
+    expect(await unreadState(id)).toBe(false);
+
+    await upsertPersistedSessionMessage(id, "test-agent", {
+      role: "assistant",
+      content: "First response",
+      timestamp: "2099-01-01T00:00:01.000Z",
+    });
+    expect(await unreadState(id)).toBe(true);
+
+    expect(markSessionRead(id)).toEqual({ found: true, unread: false });
+    expect(await unreadState(id)).toBe(false);
+
+    await upsertPersistedSessionMessage(id, "test-agent", {
+      role: "user",
+      content: "Follow-up",
+      timestamp: "2099-01-01T00:00:02.000Z",
+    });
+    expect(await unreadState(id)).toBe(false);
+
+    await upsertPersistedSessionMessage(id, "test-agent", {
+      role: "assistant",
+      content: "Second response",
+      timestamp: "2099-01-01T00:00:03.000Z",
+    });
+    expect(await unreadState(id)).toBe(true);
+  });
+
+  test("does not acknowledge unknown sessions", () => {
+    expect(markSessionRead("missing-session")).toEqual({ found: false, unread: false });
+    expect(markSessionRead(" ")).toEqual({ found: false, unread: false });
+  });
+});

--- a/tests/core/session-unread-state.test.ts
+++ b/tests/core/session-unread-state.test.ts
@@ -33,6 +33,7 @@ describe("session unread state", () => {
 
     expect(markSessionRead(id)).toEqual({ found: true, unread: false });
     expect(await unreadState(id)).toBe(false);
+    expect(markSessionRead(id)).toEqual({ found: true, unread: false });
 
     await upsertPersistedSessionMessage(id, "test-agent", {
       role: "user",
@@ -47,6 +48,16 @@ describe("session unread state", () => {
       timestamp: "2099-01-01T00:00:03.000Z",
     });
     expect(await unreadState(id)).toBe(true);
+  });
+
+  test("acknowledges an existing empty session idempotently", async () => {
+    const id = sessionId();
+    createdSessionIds.push(id);
+    await persistSession(id, "test-agent", []);
+
+    expect(markSessionRead(id)).toEqual({ found: true, unread: false });
+    expect(markSessionRead(id)).toEqual({ found: true, unread: false });
+    expect(await unreadState(id)).toBe(false);
   });
 
   test("does not acknowledge unknown sessions", () => {

--- a/tests/core/text-tool-calls.test.ts
+++ b/tests/core/text-tool-calls.test.ts
@@ -5,6 +5,7 @@ import {
   hasTextToolCallMarkup,
   sanitizeAssistantContent,
   stripTextToolCallMarkup,
+  toOpenAIReplayMessageWithNormalizedToolCalls,
 } from "../../src/core/llm/text-tool-calls";
 import {
   MESSAGE_CONTENT_COMPACTION_NOTICE,
@@ -275,5 +276,34 @@ describe("leaked DSML block cleanup", () => {
     expect(stripTextToolCallMarkup("Working on it.\n<｜DSML｜tool we have: users")).toBe(
       "Working on it."
     );
+  });
+});
+
+describe("assistant tool call replay", () => {
+  test("replaces truncated native tool arguments so providers can parse the transcript", () => {
+    const message = {
+      role: "assistant",
+      content: "",
+      tool_calls: [
+        {
+          id: "call-ok",
+          type: "function",
+          function: { name: "read", arguments: '{"path":"/tmp/a.py"}' },
+        },
+        {
+          id: "call-cut",
+          type: "function",
+          function: { name: "write", arguments: '{"content": "import bpy\\nimport mat' },
+        },
+      ],
+    };
+    const replay = toOpenAIReplayMessageWithNormalizedToolCalls(message, [
+      { id: "call-ok", name: "read", args: { path: "/tmp/a.py" }, source: "native" },
+      { id: "call-cut", name: "write", args: {}, source: "native" },
+    ]);
+    const replayed = replay.tool_calls as Array<{ function: { arguments: string } }>;
+    expect(replayed[0].function.arguments).toBe('{"path":"/tmp/a.py"}');
+    expect(replayed[1].function.arguments).toBe("{}");
+    expect(message.tool_calls[1].function.arguments).toBe('{"content": "import bpy\\nimport mat');
   });
 });

--- a/tests/core/tool-transcript.test.ts
+++ b/tests/core/tool-transcript.test.ts
@@ -32,6 +32,39 @@ describe("LLM tool transcript compaction", () => {
     ).toBe(true);
   });
 
+  test("does not elide image follow-ups because of their base64 size", () => {
+    const imageBlock = {
+      type: "image_url",
+      image_url: { url: `data:image/png;base64,${"a".repeat(1_700_000)}` },
+    };
+    const messages: Array<Record<string, unknown>> = [
+      { role: "system", content: "system rules" },
+      { role: "user", content: "render and inspect" },
+      { role: "tool", tool_call_id: "call-1", content: JSON.stringify({ image: "/tmp/a.png" }) },
+      {
+        role: "user",
+        content: [{ type: "text", text: "Inspect the image." }, imageBlock, imageBlock],
+      },
+      { role: "assistant", content: "rendering again" },
+      { role: "tool", tool_call_id: "call-2", content: JSON.stringify({ image: "/tmp/b.png" }) },
+      {
+        role: "user",
+        content: [{ type: "text", text: "Inspect the image." }, imageBlock, imageBlock],
+      },
+      { role: "user", content: "what do you see?" },
+    ];
+
+    const elided = compactOpenAIChatTranscriptInPlace(messages, 120_000);
+
+    expect(elided).toBe(0);
+    const imageBlocks = messages.flatMap((message) =>
+      Array.isArray(message.content)
+        ? message.content.filter((block) => (block as { type?: string }).type === "image_url")
+        : []
+    );
+    expect(imageBlocks).toHaveLength(4);
+  });
+
   test("elides old OpenAI-compatible chat content without reordering messages", () => {
     const messages: Array<Record<string, unknown>> = [
       { role: "system", content: "system rules" },

--- a/tests/core/viewed-media.test.ts
+++ b/tests/core/viewed-media.test.ts
@@ -2,12 +2,23 @@ import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { basename, join } from "path";
 import { cybaraDir } from "../../src/core/paths";
-import { isViewedMediaSnapshot, snapshotViewedMedia } from "../../src/core/viewed-media";
+import {
+  configureViewedMediaSnapshotsForTests,
+  isViewedMediaSnapshot,
+  snapshotViewedMedia,
+  viewedMediaSnapshotCacheSizeForTests,
+} from "../../src/core/viewed-media";
 
 const renderDir = join(cybaraDir, "test_viewed_media_renders");
+const isolatedRoot = join(cybaraDir, "test_viewed_media_root");
 const renderPath = join(renderDir, "front_34.png");
 const secretPath = join(renderDir, "secret.txt");
 const pngBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1, 2, 3]);
+
+function defined<T>(value: T | undefined, label: string): T {
+  if (value === undefined) throw new Error(`${label} was undefined`);
+  return value;
+}
 
 describe("viewed media snapshots", () => {
   beforeAll(() => {
@@ -17,19 +28,21 @@ describe("viewed media snapshots", () => {
   });
 
   afterAll(() => {
-    if (existsSync(renderDir)) rmSync(renderDir, { recursive: true, force: true });
+    configureViewedMediaSnapshotsForTests();
+    for (const dir of [renderDir, isolatedRoot]) {
+      if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   test("copies viewed renders under the served media root so they survive deletion", () => {
-    const snapshot = snapshotViewedMedia(renderPath);
-    expect(snapshot).toBeDefined();
-    expect(isViewedMediaSnapshot(snapshot!)).toBe(true);
-    expect(snapshot!.startsWith(join(cybaraDir, "media", "viewed"))).toBe(true);
-    expect(basename(snapshot!)).toBe("front_34.png");
+    const snapshot = defined(snapshotViewedMedia(renderPath), "snapshot");
+    expect(isViewedMediaSnapshot(snapshot)).toBe(true);
+    expect(snapshot.startsWith(join(cybaraDir, "media", "viewed"))).toBe(true);
+    expect(basename(snapshot)).toBe("front_34.png");
     expect(snapshotViewedMedia(renderPath)).toBe(snapshot);
-    expect(snapshotViewedMedia(snapshot!)).toBe(snapshot);
+    expect(snapshotViewedMedia(snapshot)).toBe(snapshot);
     rmSync(renderPath);
-    expect(readFileSync(snapshot!).equals(pngBytes)).toBe(true);
+    expect(readFileSync(snapshot).equals(pngBytes)).toBe(true);
     expect(snapshotViewedMedia(renderPath)).toBeUndefined();
   });
 
@@ -39,5 +52,31 @@ describe("viewed media snapshots", () => {
     expect(snapshotViewedMedia("https://example.com/render.png")).toBeUndefined();
     expect(snapshotViewedMedia("   ")).toBeUndefined();
     expect(isViewedMediaSnapshot(secretPath)).toBe(false);
+  });
+
+  test("bounds the in-memory snapshot cache and forgets entries whose directory was pruned", () => {
+    if (existsSync(isolatedRoot)) rmSync(isolatedRoot, { recursive: true, force: true });
+    configureViewedMediaSnapshotsForTests({ maxDirs: 2, pruneEvery: 1, root: isolatedRoot });
+    const paths = ["one", "two", "three"].map((name) => {
+      const path = join(renderDir, `${name}.png`);
+      writeFileSync(path, Buffer.concat([pngBytes, Buffer.from(name)]));
+      return path;
+    });
+    const first = defined(snapshotViewedMedia(paths[0]), "first");
+    expect(first.startsWith(isolatedRoot)).toBe(true);
+    expect(snapshotViewedMedia(paths[0])).toBe(first);
+    expect(viewedMediaSnapshotCacheSizeForTests()).toBe(1);
+    const second = defined(snapshotViewedMedia(paths[1]), "second");
+    expect(viewedMediaSnapshotCacheSizeForTests()).toBe(2);
+    expect(existsSync(first)).toBe(true);
+    const third = defined(snapshotViewedMedia(paths[2]), "third");
+    expect(viewedMediaSnapshotCacheSizeForTests()).toBe(2);
+    expect(existsSync(first)).toBe(false);
+    expect(existsSync(second)).toBe(true);
+    expect(existsSync(third)).toBe(true);
+    const firstRecopied = defined(snapshotViewedMedia(paths[0]), "firstRecopied");
+    expect(firstRecopied).not.toBe(first);
+    expect(viewedMediaSnapshotCacheSizeForTests()).toBe(2);
+    configureViewedMediaSnapshotsForTests();
   });
 });

--- a/tests/core/viewed-media.test.ts
+++ b/tests/core/viewed-media.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { join } from "path";
+import { cybaraDir } from "../../src/core/paths";
+import { isViewedMediaPath, registerViewedMediaPath } from "../../src/core/viewed-media";
+
+describe("viewed media registry", () => {
+  test("remembers local image paths the agent viewed and ignores remote or inline sources", () => {
+    const viewed = join(cybaraDir, "test_viewed_media", "render.png");
+    expect(isViewedMediaPath(viewed)).toBe(false);
+    registerViewedMediaPath(viewed);
+    expect(isViewedMediaPath(viewed)).toBe(true);
+    expect(
+      isViewedMediaPath(
+        join(cybaraDir, "test_viewed_media", "..", "test_viewed_media", "render.png")
+      )
+    ).toBe(true);
+    registerViewedMediaPath("data:image/png;base64,AAAA");
+    registerViewedMediaPath("https://example.com/render.png");
+    expect(isViewedMediaPath("data:image/png;base64,AAAA")).toBe(false);
+    expect(isViewedMediaPath("https://example.com/render.png")).toBe(false);
+  });
+});

--- a/tests/core/viewed-media.test.ts
+++ b/tests/core/viewed-media.test.ts
@@ -1,9 +1,42 @@
-import { describe, expect, test } from "bun:test";
-import { join } from "path";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { basename, join } from "path";
 import { cybaraDir } from "../../src/core/paths";
-import { isViewedMediaPath, registerViewedMediaPath } from "../../src/core/viewed-media";
+import {
+  isViewedMediaPath,
+  isViewedMediaSnapshot,
+  registerViewedMediaPath,
+  snapshotViewedMedia,
+} from "../../src/core/viewed-media";
+
+const renderDir = join(cybaraDir, "test_viewed_media_renders");
+const renderPath = join(renderDir, "front_34.png");
+const pngBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1, 2, 3]);
 
 describe("viewed media registry", () => {
+  beforeAll(() => {
+    mkdirSync(renderDir, { recursive: true });
+    writeFileSync(renderPath, pngBytes);
+  });
+
+  afterAll(() => {
+    if (existsSync(renderDir)) rmSync(renderDir, { recursive: true, force: true });
+  });
+
+  test("snapshots viewed renders into the media dir and survives the original being deleted", () => {
+    const snapshot = snapshotViewedMedia(renderPath);
+    expect(snapshot).toBeDefined();
+    expect(isViewedMediaSnapshot(snapshot!)).toBe(true);
+    expect(snapshot!.startsWith(join(cybaraDir, "media", "viewed"))).toBe(true);
+    expect(basename(snapshot!)).toBe("front_34.png");
+    expect(snapshotViewedMedia(renderPath)).toBe(snapshot);
+    expect(snapshotViewedMedia(snapshot!)).toBe(snapshot);
+    rmSync(renderPath);
+    expect(readFileSync(snapshot!).equals(pngBytes)).toBe(true);
+    expect(snapshotViewedMedia(renderPath)).toBeUndefined();
+    expect(snapshotViewedMedia("data:image/png;base64,AAAA")).toBeUndefined();
+  });
+
   test("remembers local image paths the agent viewed and ignores remote or inline sources", () => {
     const viewed = join(cybaraDir, "test_viewed_media", "render.png");
     expect(isViewedMediaPath(viewed)).toBe(false);

--- a/tests/core/viewed-media.test.ts
+++ b/tests/core/viewed-media.test.ts
@@ -2,28 +2,25 @@ import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { basename, join } from "path";
 import { cybaraDir } from "../../src/core/paths";
-import {
-  isViewedMediaPath,
-  isViewedMediaSnapshot,
-  registerViewedMediaPath,
-  snapshotViewedMedia,
-} from "../../src/core/viewed-media";
+import { isViewedMediaSnapshot, snapshotViewedMedia } from "../../src/core/viewed-media";
 
 const renderDir = join(cybaraDir, "test_viewed_media_renders");
 const renderPath = join(renderDir, "front_34.png");
+const secretPath = join(renderDir, "secret.txt");
 const pngBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1, 2, 3]);
 
-describe("viewed media registry", () => {
+describe("viewed media snapshots", () => {
   beforeAll(() => {
     mkdirSync(renderDir, { recursive: true });
     writeFileSync(renderPath, pngBytes);
+    writeFileSync(secretPath, "top secret");
   });
 
   afterAll(() => {
     if (existsSync(renderDir)) rmSync(renderDir, { recursive: true, force: true });
   });
 
-  test("snapshots viewed renders into the media dir and survives the original being deleted", () => {
+  test("copies viewed renders under the served media root so they survive deletion", () => {
     const snapshot = snapshotViewedMedia(renderPath);
     expect(snapshot).toBeDefined();
     expect(isViewedMediaSnapshot(snapshot!)).toBe(true);
@@ -34,22 +31,13 @@ describe("viewed media registry", () => {
     rmSync(renderPath);
     expect(readFileSync(snapshot!).equals(pngBytes)).toBe(true);
     expect(snapshotViewedMedia(renderPath)).toBeUndefined();
-    expect(snapshotViewedMedia("data:image/png;base64,AAAA")).toBeUndefined();
   });
 
-  test("remembers local image paths the agent viewed and ignores remote or inline sources", () => {
-    const viewed = join(cybaraDir, "test_viewed_media", "render.png");
-    expect(isViewedMediaPath(viewed)).toBe(false);
-    registerViewedMediaPath(viewed);
-    expect(isViewedMediaPath(viewed)).toBe(true);
-    expect(
-      isViewedMediaPath(
-        join(cybaraDir, "test_viewed_media", "..", "test_viewed_media", "render.png")
-      )
-    ).toBe(true);
-    registerViewedMediaPath("data:image/png;base64,AAAA");
-    registerViewedMediaPath("https://example.com/render.png");
-    expect(isViewedMediaPath("data:image/png;base64,AAAA")).toBe(false);
-    expect(isViewedMediaPath("https://example.com/render.png")).toBe(false);
+  test("refuses non-image sources so only renderable media is ingested", () => {
+    expect(snapshotViewedMedia(secretPath)).toBeUndefined();
+    expect(snapshotViewedMedia("data:image/png;base64,AAAA")).toBeUndefined();
+    expect(snapshotViewedMedia("https://example.com/render.png")).toBeUndefined();
+    expect(snapshotViewedMedia("   ")).toBeUndefined();
+    expect(isViewedMediaSnapshot(secretPath)).toBe(false);
   });
 });

--- a/tests/mobile/chat-format.test.ts
+++ b/tests/mobile/chat-format.test.ts
@@ -1,15 +1,15 @@
 import { describe, expect, test } from "bun:test";
 import type { SessionMessageSummary } from "../../apps/mobile/src/lib/api";
 import {
-  MOBILE_CHAT_WORK_TIMELINE,
-  MOBILE_NATIVE_TEXT_RENDERING,
-  MOBILE_VISIBLE_CHAT_MESSAGE_LIMIT,
   buildMobileWorkTimeline,
   chatIsWaitingForAssistant,
   extractMobileMarkdownImages,
   formatMobileWorkedDuration,
   hasUnicodeTextFallback,
   latestVisibleChatMessages,
+  MOBILE_CHAT_WORK_TIMELINE,
+  MOBILE_NATIVE_TEXT_RENDERING,
+  MOBILE_VISIBLE_CHAT_MESSAGE_LIMIT,
   mobileGoalIterationNumber,
   shouldUseSelectableNativeText,
   splitMessageContent,
@@ -180,6 +180,14 @@ describe("mobile chat formatting", () => {
           args: { cmd: "ls -la && pwd" },
           startedAt: 27_000,
         },
+        {
+          id: "image-1",
+          name: "image",
+          status: "completed",
+          args: { image: "/tmp/renders/mug_side.png", prompt: "Describe the render" },
+          detail: "image complete",
+          startedAt: 27_000,
+        },
       ],
     });
 
@@ -188,6 +196,7 @@ describe("mobile chat formatting", () => {
       "I'll check the available tools and execute a concrete mobile app smoke test.",
       'Search complete for "mobile test tools"',
       "Ran ls -la && pwd",
+      "Viewed an image",
     ]);
   });
 

--- a/tests/shared/chat-activity-groups.test.ts
+++ b/tests/shared/chat-activity-groups.test.ts
@@ -2,6 +2,23 @@ import { describe, expect, test } from "bun:test";
 import { groupSharedActivities, type SharedActivityItem } from "../../shared/chat-activity-groups";
 
 describe("shared chat activity groups", () => {
+  test("folds consecutive image views into their own labelled group", () => {
+    const activities: SharedActivityItem[] = [
+      { id: "a", phase: "result", text: "Ran ls", toolName: "exec" },
+      { id: "b", phase: "result", text: "Viewed an image", toolName: "image" },
+      { id: "c", phase: "result", text: "Viewed an image", toolName: "image" },
+      { id: "d", phase: "result", text: "Viewed an image", toolName: "image" },
+      { id: "e", phase: "result", text: "Ran pwd", toolName: "exec" },
+    ];
+    const entries = groupSharedActivities(activities);
+    expect(
+      entries.map((entry) => (entry.type === "group" ? entry.label : entry.activity.id))
+    ).toEqual(["a", "Viewed 3 images", "e"]);
+    const group = entries[1];
+    expect(group.type === "group" && group.kind).toBe("view");
+    expect(group.type === "group" && group.items.map((item) => item.id)).toEqual(["b", "c", "d"]);
+  });
+
   test("assigns stable distinct ids when source activity ids are empty", () => {
     const activities: SharedActivityItem[] = [
       { id: "", phase: "result", text: "Read first", toolName: "read" },

--- a/tests/ui/chat-images.test.ts
+++ b/tests/ui/chat-images.test.ts
@@ -1,13 +1,15 @@
 import { describe, expect, test } from "bun:test";
 import {
   chatImageSrc,
-  chatMarkdownImageSrc,
   chatMarkdownImageSources,
+  chatMarkdownImageSrc,
   imageToolResultSrc,
   isHeicImage,
   isSupportedImageType,
   loadChatImageSource,
+  peekChatImageSource,
   requiresAuthenticatedImageFetch,
+  resetChatImageSourceCacheForTests,
   screenshotMediaSrc,
   toolOutputImageSources,
 } from "../../ui/src/lib/chatImages";
@@ -180,5 +182,34 @@ describe("chat image rendering", () => {
     expect(lightboxSource).toContain('aria-label="Zoom in"');
     expect(lightboxSource).toContain('aria-label="Download image"');
     expect(lightboxSource).toContain("onPointerMove={handlePointerMove}");
+  });
+});
+
+describe("chat image source cache", () => {
+  test("resolves a repeated authenticated image synchronously after the first load", async () => {
+    resetChatImageSourceCacheForTests();
+    const source = "/api/media?path=%2Ftmp%2Fcached.png";
+    expect(peekChatImageSource(source)).toBeUndefined();
+    let fetches = 0;
+    const fetcher = (async () => {
+      fetches += 1;
+      return new Response(new Blob(["png"], { type: "image/png" }), {
+        headers: { "Content-Type": "image/png" },
+      });
+    }) as typeof fetch;
+    const createObjectUrl = (blob: Blob) => `blob:cached-${blob.size}`;
+    const first = await loadChatImageSource(source, fetcher, createObjectUrl, () => undefined, {
+      cache: true,
+    });
+    expect(first.src).toBe("blob:cached-3");
+    expect(peekChatImageSource(source)).toBe("blob:cached-3");
+    expect(first.revoke).toBeUndefined();
+    const second = await loadChatImageSource(source, fetcher, createObjectUrl, () => undefined, {
+      cache: true,
+    });
+    expect(second.src).toBe(first.src);
+    expect(fetches).toBe(1);
+    resetChatImageSourceCacheForTests();
+    expect(peekChatImageSource(source)).toBeUndefined();
   });
 });

--- a/tests/ui/chat-live-activity-persistence.test.ts
+++ b/tests/ui/chat-live-activity-persistence.test.ts
@@ -174,7 +174,7 @@ describe("Chat live activity persistence", () => {
       'typeof event.timestamp === "number" && Number.isFinite(event.timestamp)'
     );
     expect(source).toMatch(
-      /appendLiveActivity\(\s*phase,\s*text,\s*payload\.toolName,\s*eventTimestamp,\s*payload\.toolCallId,\s*payload\.sandboxProvider,\s*imageSourceFromPath\(payload\.imagePath\),\s*imageAltFromPath\(payload\.imagePath\)\s*\);/
+      /appendLiveActivity\(\s*phase,\s*text,\s*payload\.toolName,\s*eventTimestamp,\s*payload\.toolCallId,\s*payload\.sandboxProvider,\s*imageSourceFromPath\(payload\.imagePath\),\s*imageAltFromPath\(payload\.imagePath\),\s*payload\.runId,\s*payload\.sequence\s*\);/
     );
   });
 

--- a/tests/ui/chat-live-activity-persistence.test.ts
+++ b/tests/ui/chat-live-activity-persistence.test.ts
@@ -8,8 +8,8 @@ import {
   buildPreSteeringActivityMessage,
   canUseNativeSpeechRecognition,
   formatToolIntent,
-  isSessionStatusSnapshotCurrent,
   isRawToolCallThought,
+  isSessionStatusSnapshotCurrent,
   pruneCanonicalizedLiveActivities,
   resolveDictationRuntime,
   resolveStatusSnapshotActivities,
@@ -174,7 +174,7 @@ describe("Chat live activity persistence", () => {
       'typeof event.timestamp === "number" && Number.isFinite(event.timestamp)'
     );
     expect(source).toMatch(
-      /appendLiveActivity\(\s*phase,\s*text,\s*payload\.toolName,\s*eventTimestamp,\s*payload\.toolCallId,\s*payload\.sandboxProvider\s*\);/
+      /appendLiveActivity\(\s*phase,\s*text,\s*payload\.toolName,\s*eventTimestamp,\s*payload\.toolCallId,\s*payload\.sandboxProvider,\s*imageSourceFromPath\(payload\.imagePath\),\s*imageAltFromPath\(payload\.imagePath\)\s*\);/
     );
   });
 

--- a/tests/ui/chat-workspace-panel.test.ts
+++ b/tests/ui/chat-workspace-panel.test.ts
@@ -122,15 +122,29 @@ describe("chat workspace panel", () => {
     expect(chatSource).toContain("shouldShowFloatingBrowserPreview");
     expect(floatingBrowserSource).toContain('ariaLabel="Open live browser preview"');
     expect(floatingPreviewFrameSource).toContain('role="button"');
-    expect(floatingPreviewFrameSource).toContain(
-      "onPointerDown={(event) => event.stopPropagation()}"
-    );
+    expect(floatingPreviewFrameSource).toContain("onPointerDown={stopControlGesture}");
     expect(floatingPreviewFrameSource).toContain("onKeyDown={(event) => event.stopPropagation()}");
     expect(floatingBrowserSource).not.toContain("Resize floating browser preview");
     expect(floatingBrowserSource).not.toContain("workspace-browser-nav-button");
     expect(floatingBrowserSource).toContain("<ChatWorkspaceBrowser");
     expect(floatingBrowserSource).toContain("thumbnail");
     expect(browserSource).toContain("thumbnail ? null");
+  });
+
+  test("closes and minimizes floating previews without opening their panel", () => {
+    expect(floatingPreviewFrameSource).toContain('data-floating-preview-control="close"');
+    expect(floatingPreviewFrameSource).toContain('data-floating-preview-control="minimize"');
+    expect(floatingPreviewFrameSource).toContain("function isControlTarget(");
+    expect(floatingPreviewFrameSource).toContain(
+      "if (!rect || event.button !== 0 || isControlTarget(event.target)) return;"
+    );
+    expect(floatingPreviewFrameSource).toContain("gestureRef.current = null;");
+    expect(floatingPreviewFrameSource).toContain(
+      "persistFloatingPreviewMinimized(storageKey, true)"
+    );
+    expect(floatingPreviewFrameSource).toContain("if (minimized) restore();");
+    expect(floatingBrowserSource).toContain("minimizedIcon=");
+    expect(floatingComputerSource).toContain("minimizedIcon=");
   });
 
   test("keeps active desktop work visible and focuses its app from the floating preview", () => {

--- a/tests/ui/floating-browser-preview.test.ts
+++ b/tests/ui/floating-browser-preview.test.ts
@@ -3,10 +3,13 @@ import {
   clampFloatingBrowserPreviewRect,
   defaultFloatingBrowserPreviewRect,
   FLOATING_COMPUTER_PREVIEW_STORAGE_KEY,
+  FLOATING_PREVIEW_MINIMIZED_SIZE,
   isFloatingBrowserPreviewClick,
   parseFloatingBrowserPreviewRect,
   persistFloatingPreviewHidden,
+  persistFloatingPreviewMinimized,
   readFloatingPreviewHidden,
+  readFloatingPreviewMinimized,
   shouldShowFloatingBrowserPreview,
 } from "../../ui/src/pages/chat/floatingBrowserPreviewModel";
 
@@ -112,6 +115,38 @@ describe("floating browser preview", () => {
     expect(isFloatingBrowserPreviewClick(4, 4)).toBe(true);
     expect(isFloatingBrowserPreviewClick(7, 0)).toBe(false);
     expect(isFloatingBrowserPreviewClick(24, 18)).toBe(false);
+  });
+
+  test("keeps a minimized preview as a small draggable puck inside the surface", () => {
+    const container = { width: 1200, height: 800 };
+    const minimized = {
+      width: FLOATING_PREVIEW_MINIMIZED_SIZE,
+      height: FLOATING_PREVIEW_MINIMIZED_SIZE,
+    };
+    const rect = defaultFloatingBrowserPreviewRect(container, 100, "right", minimized);
+    expect(rect.width).toBe(FLOATING_PREVIEW_MINIMIZED_SIZE);
+    expect(rect.height).toBe(FLOATING_PREVIEW_MINIMIZED_SIZE);
+    expect(rect.x + rect.width).toBeLessThanOrEqual(container.width);
+    expect(rect.y + rect.height).toBeLessThanOrEqual(container.height - 100);
+
+    const dragged = clampFloatingBrowserPreviewRect(
+      container,
+      { ...rect, x: -400, y: -400 },
+      100,
+      minimized
+    );
+    expect(dragged.width).toBe(FLOATING_PREVIEW_MINIMIZED_SIZE);
+    expect(dragged.x).toBeGreaterThan(0);
+    expect(dragged.y).toBeGreaterThan(0);
+  });
+
+  test("persists and reads the minimized flag per storage key", () => {
+    expect(readFloatingPreviewMinimized(FLOATING_COMPUTER_PREVIEW_STORAGE_KEY)).toBe(false);
+    persistFloatingPreviewMinimized(FLOATING_COMPUTER_PREVIEW_STORAGE_KEY, true);
+    expect(readFloatingPreviewMinimized(FLOATING_COMPUTER_PREVIEW_STORAGE_KEY)).toBe(true);
+    expect(readFloatingPreviewHidden(FLOATING_COMPUTER_PREVIEW_STORAGE_KEY)).toBe(false);
+    persistFloatingPreviewMinimized(FLOATING_COMPUTER_PREVIEW_STORAGE_KEY, false);
+    expect(readFloatingPreviewMinimized(FLOATING_COMPUTER_PREVIEW_STORAGE_KEY)).toBe(false);
   });
 
   test("persists and reads the hidden flag per storage key", () => {

--- a/tests/ui/image-viewed-activities.test.ts
+++ b/tests/ui/image-viewed-activities.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import {
+  buildActivitiesFromToolCalls,
+  enrichActivitiesWithToolCallDetails,
+  imageViewedSource,
+  type LiveActivityItem,
+} from "../../ui/src/lib/chatActivities";
+import { onOpenChatImageLightbox, openChatImageLightbox } from "../../ui/src/lib/chatImageLightbox";
+
+const PNG_DATA_URL =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+
+const intent = () => "Viewed an image";
+
+describe("image viewed activity sources", () => {
+  test("extracts image paths and data URLs from visual tool results", () => {
+    expect(imageViewedSource({ name: "read", result: { path: "/tmp/shot.png" } })).toBe(
+      "/api/media?path=%2Ftmp%2Fshot.png"
+    );
+    expect(imageViewedSource({ name: "image", result: { image: "/tmp/photo.jpeg" } })).toBe(
+      "/api/media?path=%2Ftmp%2Fphoto.jpeg"
+    );
+    expect(imageViewedSource({ name: "computer_use", result: { screenshot: PNG_DATA_URL } })).toBe(
+      PNG_DATA_URL
+    );
+    expect(
+      imageViewedSource({ name: "mobile_simulator", result: { filePath: "/tmp/ios.webp" } })
+    ).toBe("/api/media?path=%2Ftmp%2Fios.webp");
+  });
+
+  test("ignores non-image results, non-visual tools, and foreign data URLs", () => {
+    expect(imageViewedSource({ name: "read", result: { path: "/tmp/notes.md" } })).toBeUndefined();
+    expect(imageViewedSource({ name: "read", result: { path: "/tmp/shot" } })).toBeUndefined();
+    expect(imageViewedSource({ name: "exec", result: { path: "/tmp/shot.png" } })).toBeUndefined();
+    expect(
+      imageViewedSource({ name: "read", result: { path: "data:text/html;base64,PGI+" } })
+    ).toBeUndefined();
+    expect(imageViewedSource({ name: "read", result: "plain text" })).toBeUndefined();
+    expect(imageViewedSource({ name: "read", result: undefined })).toBeUndefined();
+  });
+
+  test("filesystem paths route through the gateway media endpoint", () => {
+    const activities = buildActivitiesFromToolCalls(
+      [
+        {
+          id: "call-media",
+          name: "read",
+          status: "completed",
+          arguments: { path: "/Users/carsen/screenshots/shot.png" },
+          result: { path: "/Users/carsen/screenshots/shot.png" },
+        },
+      ],
+      intent
+    );
+    expect(activities[0].imageSource).toBe(
+      "/api/media?path=" + encodeURIComponent("/Users/carsen/screenshots/shot.png")
+    );
+    expect(activities[0].imageAlt).toBe("shot.png");
+  });
+
+  test("build attaches thumbnail metadata to completed image views only", () => {
+    const activities = buildActivitiesFromToolCalls(
+      [
+        {
+          id: "call-1",
+          name: "read",
+          status: "completed",
+          arguments: { path: "/tmp/shot.png" },
+          result: { path: "/tmp/shot.png" },
+        },
+        {
+          id: "call-2",
+          name: "read",
+          status: "completed",
+          arguments: { path: "/tmp/notes.md" },
+          result: { path: "/tmp/notes.md" },
+        },
+        {
+          id: "call-3",
+          name: "read",
+          status: "executing",
+          arguments: { path: "/tmp/live.png" },
+        },
+      ],
+      intent
+    );
+    expect(activities).toHaveLength(3);
+    expect(activities[0].imageSource).toBe("/api/media?path=%2Ftmp%2Fshot.png");
+    expect(activities[0].imageAlt).toBe("shot.png");
+    expect(activities[1].imageSource).toBeUndefined();
+    expect(activities[2].imageSource).toBeUndefined();
+  });
+
+  test("enrich backfills thumbnail metadata onto matched activities", () => {
+    const activity: LiveActivityItem = {
+      id: "tool-call-9",
+      phase: "result",
+      text: "Viewed an image",
+      timestamp: 1,
+      toolName: "browser_screenshot",
+      toolCallId: "call-9",
+    };
+    const enriched = enrichActivitiesWithToolCallDetails(
+      [activity],
+      [{ id: "call-9", name: "browser_screenshot", result: { filePath: "/tmp/page.png" } }]
+    );
+    expect(enriched[0].imageSource).toBe("/api/media?path=%2Ftmp%2Fpage.png");
+    expect(enriched[0].imageAlt).toBe("page.png");
+  });
+});
+
+describe("chat image lightbox bridge", () => {
+  test("dispatches and receives lightbox open events", () => {
+    const received: Array<{ src: string; alt: string }> = [];
+    const off = onOpenChatImageLightbox((image) => received.push(image));
+    openChatImageLightbox(PNG_DATA_URL, "shot.png");
+    off();
+    openChatImageLightbox("ignored.png", "ignored");
+    expect(received).toEqual([{ src: PNG_DATA_URL, alt: "shot.png" }]);
+  });
+});
+
+describe("image viewed timeline contract", () => {
+  const timelineSource = readFileSync(
+    fileURLToPath(new URL("../../ui/src/pages/chat/ActivityTimeline.tsx", import.meta.url)),
+    "utf8"
+  );
+  const chatSource = readFileSync(
+    fileURLToPath(new URL("../../ui/src/pages/Chat.tsx", import.meta.url)),
+    "utf8"
+  );
+  const multiChatSource = readFileSync(
+    fileURLToPath(new URL("../../ui/src/pages/chat/MultiChatWorkspace.tsx", import.meta.url)),
+    "utf8"
+  );
+  const modelSource = readFileSync(
+    fileURLToPath(new URL("../../ui/src/pages/chat/chatModel.ts", import.meta.url)),
+    "utf8"
+  );
+
+  test("activity rows render thumbnails that open the lightbox", () => {
+    expect(timelineSource).toContain("ImageViewedThumbnail");
+    expect(timelineSource).toContain('data-testid="activity-image-viewed-thumbnail"');
+    expect(timelineSource).toContain("openChatImageLightbox");
+    expect(timelineSource).toContain("loadChatImageSource");
+    expect(timelineSource).toContain("event.stopPropagation()");
+  });
+
+  test("both chat hosts subscribe to the lightbox bridge", () => {
+    expect(chatSource).toContain("onOpenChatImageLightbox");
+    expect(chatSource).toContain("setImageLightbox({ images: [image], index: 0 })");
+    expect(multiChatSource).toContain("onOpenChatImageLightbox(setLightboxImage)");
+  });
+
+  test("persisted activity normalization keeps thumbnail metadata", () => {
+    expect(modelSource).toContain("imageSource");
+    expect(modelSource).toContain("imageAlt");
+  });
+});

--- a/tests/ui/image-viewed-activities.test.ts
+++ b/tests/ui/image-viewed-activities.test.ts
@@ -11,9 +11,11 @@ import {
   enrichActivitiesWithToolCallDetails,
   imageViewedSource,
   type LiveActivityItem,
+  mergeActivityLists,
 } from "../../ui/src/lib/chatActivities";
 import { onOpenChatImageLightbox, openChatImageLightbox } from "../../ui/src/lib/chatImageLightbox";
 import { formatToolIntent } from "../../ui/src/pages/chat/chatModel";
+import { formatIdeStatusEventText } from "../../ui/src/pages/ide/ideActivityHelpers";
 
 const PNG_DATA_URL =
   "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
@@ -119,6 +121,43 @@ describe("image viewed activity sources", () => {
     expect(activities[0].imageAlt).toBe("shot.png");
     expect(activities[1].imageSource).toBeUndefined();
     expect(activities[2].imageSource).toBeUndefined();
+  });
+
+  test("merging a cached activity with a fresh one keeps the viewed image", () => {
+    const cached: LiveActivityItem = {
+      id: "run:4",
+      phase: "result",
+      text: "Viewed an image",
+      timestamp: 10,
+      toolName: "image",
+      toolCallId: "chatcmpl-tool-b1",
+    };
+    const fresh: LiveActivityItem = {
+      ...cached,
+      imageSource: "/api/media?path=%2Ftmp%2Fsnap%2Frender.png",
+      imageAlt: "render.png",
+    };
+    const merged = mergeActivityLists([cached], [fresh]);
+    expect(merged).toHaveLength(1);
+    expect(merged[0].imageSource).toBe("/api/media?path=%2Ftmp%2Fsnap%2Frender.png");
+    expect(merged[0].imageAlt).toBe("render.png");
+  });
+
+  test("does not attach an unrelated render when ids do not correlate", () => {
+    const activity: LiveActivityItem = {
+      id: "tool-uncorrelated",
+      phase: "result",
+      text: "Viewed an image",
+      timestamp: 1,
+      toolName: "image",
+      toolCallId: "status-image-1",
+    };
+    const enriched = enrichActivitiesWithToolCallDetails(
+      [activity],
+      [{ id: "chatcmpl-tool-9", name: "image", result: { image: "/tmp/other.png" } }]
+    );
+    expect(enriched[0].imageSource).toBeUndefined();
+    expect(enriched[0].imageAlt).toBeUndefined();
   });
 
   test("enrich backfills thumbnail metadata onto matched activities", () => {
@@ -252,5 +291,15 @@ describe("image viewed activity labels", () => {
     expect(timelineSource).toContain("const hasImage = Boolean(activity.imageSource);");
     expect(timelineSource).toContain('data-testid="activity-image-icon"');
     expect(timelineSource).toContain('activity.phase === "result" && hasImage ? (');
+  });
+});
+
+describe("ide activity labels", () => {
+  test("labels image views instead of falling back to the tool name", () => {
+    expect(formatIdeStatusEventText("image", "start")).toBe("Viewing an image");
+    expect(formatIdeStatusEventText("image", "result")).toBe("Viewed an image");
+    expect(formatIdeStatusEventText("image", "result", "image complete")).toBe("Viewed an image");
+    expect(formatIdeStatusEventText("exec", "result", "Ran ls")).toBe("Ran ls");
+    expect(formatIdeStatusEventText("exec", "result")).toBe("exec complete");
   });
 });

--- a/tests/ui/image-viewed-activities.test.ts
+++ b/tests/ui/image-viewed-activities.test.ts
@@ -36,6 +36,28 @@ describe("image viewed activity sources", () => {
     ).toBe("/api/media?path=%2Ftmp%2Fios.webp");
   });
 
+  test("prefers the gateway snapshot of a viewed image over the original path", () => {
+    const activities = buildActivitiesFromToolCalls(
+      [
+        {
+          id: "call-snapshot",
+          name: "image",
+          status: "completed",
+          arguments: { image: "/Users/carsen/camera_model/renders/tt_06.png", prompt: "look" },
+          result: {
+            image: "/Users/carsen/camera_model/renders/tt_06.png",
+            snapshot: "/Users/carsen/.cybara/media/viewed/abc123/tt_06.png",
+          },
+        },
+      ],
+      intent
+    );
+    expect(activities[0].imageSource).toBe(
+      "/api/media?path=" + encodeURIComponent("/Users/carsen/.cybara/media/viewed/abc123/tt_06.png")
+    );
+    expect(activities[0].imageAlt).toBe("tt_06.png");
+  });
+
   test("ignores non-image results, non-visual tools, and foreign data URLs", () => {
     expect(imageViewedSource({ name: "read", result: { path: "/tmp/notes.md" } })).toBeUndefined();
     expect(imageViewedSource({ name: "read", result: { path: "/tmp/shot" } })).toBeUndefined();

--- a/tests/ui/image-viewed-activities.test.ts
+++ b/tests/ui/image-viewed-activities.test.ts
@@ -14,7 +14,7 @@ import {
   mergeActivityLists,
 } from "../../ui/src/lib/chatActivities";
 import { onOpenChatImageLightbox, openChatImageLightbox } from "../../ui/src/lib/chatImageLightbox";
-import { formatToolIntent } from "../../ui/src/pages/chat/chatModel";
+import { applyLiveActivityEvent, formatToolIntent } from "../../ui/src/pages/chat/chatModel";
 import { formatIdeStatusEventText } from "../../ui/src/pages/ide/ideActivityHelpers";
 
 const PNG_DATA_URL =
@@ -268,6 +268,57 @@ describe("image viewed activity labels", () => {
     expect(enriched[0].imageSource).toBe("/api/media?path=%2Ftmp%2Fmug_side.png");
   });
 
+  test("consecutive image views fold into a 'Viewed N images' group that reveals each thumbnail", () => {
+    const entries = groupSharedActivities([
+      { id: "1", phase: "result", text: "Viewed an image", toolName: "image" },
+      { id: "2", phase: "result", text: "Viewed an image", toolName: "image" },
+      { id: "3", phase: "result", text: "Viewed an image", toolName: "image" },
+    ]);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ type: "group", kind: "view", label: "Viewed 3 images" });
+    expect((entries[0] as { items: unknown[] }).items).toHaveLength(3);
+    expect(
+      groupSharedActivities([
+        { id: "1", phase: "result", text: "Ran pwd", toolName: "exec" },
+        { id: "2", phase: "result", text: "Ran echo hi", toolName: "exec" },
+        { id: "3", phase: "result", text: "Viewed an image", toolName: "image" },
+        { id: "4", phase: "result", text: "Viewed an image", toolName: "image" },
+      ]).map((entry) => (entry.type === "group" ? entry.label : "single"))
+    ).toEqual(["Ran 2 commands", "Viewed 2 images"]);
+  });
+
+  test("live activity ids match the gateway's runId:sequence scheme so rows survive completion", () => {
+    const started = applyLiveActivityEvent([], {
+      phase: "start",
+      text: "Viewing an image",
+      timestamp: 1_000,
+      toolName: "image",
+      toolCallId: "chatcmpl-tool-1",
+      runId: "run-abc",
+      sequence: 7,
+    });
+    expect(started[0].id).toBe("run-abc:7");
+    const completed = applyLiveActivityEvent(started, {
+      phase: "result",
+      text: "Viewed an image",
+      timestamp: 2_000,
+      toolName: "image",
+      toolCallId: "chatcmpl-tool-1",
+      imageSource: "/api/media?path=%2Ftmp%2Fa.png",
+      runId: "run-abc",
+      sequence: 8,
+    });
+    expect(completed).toHaveLength(1);
+    expect(completed[0].id).toBe("run-abc:7");
+    expect(completed[0].imageSource).toBe("/api/media?path=%2Ftmp%2Fa.png");
+    const fallback = applyLiveActivityEvent([], {
+      phase: "result",
+      text: "Ran ls",
+      toolName: "exec",
+    });
+    expect(fallback[0].id).toMatch(/^\d+-[a-z0-9]{6}$/);
+  });
+
   test("image views stay standalone rows instead of folding into command groups", () => {
     const entries = groupSharedActivities([
       { id: "1", phase: "result", text: "Ran ls", toolName: "exec" },
@@ -290,6 +341,19 @@ describe("image viewed activity labels", () => {
     expect(timelineSource).toContain('data-testid="activity-image-viewed-preview"');
     expect(timelineSource).toContain("const hasImage = Boolean(activity.imageSource);");
     expect(timelineSource).toContain('data-testid="activity-image-icon"');
+    expect(timelineSource).toContain("expanded && activity.imageSource");
+    expect(timelineSource).toContain('data-testid="activity-image-viewed-strip"');
+    expect(timelineSource).toContain('expanded && entry.kind === "view" ? (');
+    expect(timelineSource).not.toContain("revealImage");
+    expect(timelineSource).toContain("view: ImageIcon");
+    expect(timelineSource).toContain(
+      'const LIVE_OPEN_GROUP_KINDS: readonly ActivityGroupKind[] = ["view"];'
+    );
+    expect(timelineSource).toContain("openByDefault={LIVE_OPEN_GROUP_KINDS}");
+    expect(timelineSource).toContain(
+      "const expanded = openByDefault.includes(entry.kind) !== toggledGroups.has(entry.id);"
+    );
+    expect(timelineSource).toContain("peekChatImageSource(source) ?? null");
     expect(timelineSource).toContain('activity.phase === "result" && hasImage ? (');
   });
 });

--- a/tests/ui/image-viewed-activities.test.ts
+++ b/tests/ui/image-viewed-activities.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
+import { groupSharedActivities } from "../../shared/chat-activity-groups";
+import {
+  formatExpandedToolActivityDetail,
+  formatStructuredToolActivityDetail,
+} from "../../shared/tool-activity-detail";
 import {
   buildActivitiesFromToolCalls,
   enrichActivitiesWithToolCallDetails,
@@ -8,6 +13,7 @@ import {
   type LiveActivityItem,
 } from "../../ui/src/lib/chatActivities";
 import { onOpenChatImageLightbox, openChatImageLightbox } from "../../ui/src/lib/chatImageLightbox";
+import { formatToolIntent } from "../../ui/src/pages/chat/chatModel";
 
 const PNG_DATA_URL =
   "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
@@ -157,5 +163,72 @@ describe("image viewed timeline contract", () => {
   test("persisted activity normalization keeps thumbnail metadata", () => {
     expect(modelSource).toContain("imageSource");
     expect(modelSource).toContain("imageAlt");
+  });
+});
+
+describe("image viewed activity labels", () => {
+  const args = { image: "/tmp/mug_side.png", prompt: "Describe the render" };
+
+  test("shared formatter labels every image view phase", () => {
+    expect(formatStructuredToolActivityDetail("image", args, "start")).toBe("Viewing an image");
+    expect(formatStructuredToolActivityDetail("image", args, "result")).toBe("Viewed an image");
+    expect(formatStructuredToolActivityDetail("image", args, "blocked")).toBe("Image view blocked");
+    expect(formatStructuredToolActivityDetail("image", args, "error")).toBe("Image view failed");
+    expect(formatExpandedToolActivityDetail("image", args, "result")).toBe(
+      "Viewed an image\nImage: mug_side.png\nPrompt: Describe the render"
+    );
+    expect(formatExpandedToolActivityDetail("image", { image: PNG_DATA_URL }, "result")).toBe(
+      undefined
+    );
+  });
+
+  test("client intent prefers viewed labels over generic gateway fallbacks", () => {
+    expect(formatToolIntent("image", args, "start")).toBe("Viewing an image");
+    expect(formatToolIntent("image", args, "result", "image complete")).toBe("Viewed an image");
+    expect(formatToolIntent("exec", { command: "ls" }, "result", "Ran ls")).toBe("Ran ls");
+  });
+
+  test("enrichment upgrades persisted generic image labels and keeps thumbnails", () => {
+    const activity: LiveActivityItem = {
+      id: "tool-call-3",
+      phase: "result",
+      text: "image complete",
+      timestamp: 1,
+      toolName: "image",
+      toolCallId: "call-3",
+    };
+    const enriched = enrichActivitiesWithToolCallDetails(
+      [activity],
+      [{ id: "call-3", name: "image", args, result: { image: "/tmp/mug_side.png" } }]
+    );
+    expect(enriched[0].text).toBe("Viewed an image");
+    expect(enriched[0].fullText).toContain("Image: mug_side.png");
+    expect(enriched[0].fullText).toContain("Prompt: Describe the render");
+    expect(enriched[0].imageSource).toBe("/api/media?path=%2Ftmp%2Fmug_side.png");
+  });
+
+  test("image views stay standalone rows instead of folding into command groups", () => {
+    const entries = groupSharedActivities([
+      { id: "1", phase: "result", text: "Ran ls", toolName: "exec" },
+      { id: "2", phase: "result", text: "Viewed an image", toolName: "image" },
+      { id: "3", phase: "result", text: "Ran pwd", toolName: "exec" },
+    ]);
+    expect(entries.map((entry) => entry.type)).toEqual(["single", "single", "single"]);
+    expect(entries[1]).toEqual({
+      type: "single",
+      activity: { id: "2", phase: "result", text: "Viewed an image", toolName: "image" },
+    });
+  });
+
+  test("timeline reveals the thumbnail only once the row is expanded", () => {
+    const timelineSource = readFileSync(
+      fileURLToPath(new URL("../../ui/src/pages/chat/ActivityTimeline.tsx", import.meta.url)),
+      "utf8"
+    );
+    expect(timelineSource).toContain("expanded && activity.imageSource");
+    expect(timelineSource).toContain('data-testid="activity-image-viewed-preview"');
+    expect(timelineSource).toContain("const hasImage = Boolean(activity.imageSource);");
+    expect(timelineSource).toContain('data-testid="activity-image-icon"');
+    expect(timelineSource).toContain('activity.phase === "result" && hasImage ? (');
   });
 });

--- a/tests/ui/multi-chat-live-status.test.ts
+++ b/tests/ui/multi-chat-live-status.test.ts
@@ -8,6 +8,42 @@ import {
 } from "../../ui/src/pages/chat/multiChatLiveStatus";
 
 describe("multi-chat live status", () => {
+  test("attaches viewed image thumbnails to live tool completions", () => {
+    const started = projectMultiChatStatusEvent(undefined, {
+      type: "status",
+      sessionId: "session-image",
+      runId: "run-image",
+      sequence: 1,
+      status: "tool_executing",
+      timestamp: 1_000,
+      toolName: "image",
+      toolCallId: "image-1",
+      toolPhase: "start",
+      detail: "Viewing an image",
+    });
+    const completed = projectMultiChatStatusEvent(started, {
+      type: "status",
+      sessionId: "session-image",
+      runId: "run-image",
+      sequence: 2,
+      status: "tool_completed",
+      timestamp: 2_000,
+      toolName: "image",
+      toolCallId: "image-1",
+      toolPhase: "result",
+      detail: "Viewed an image",
+      imagePath: "/Users/carsen/camera_model/renders/front_34.png",
+    });
+
+    const viewed = completed?.activities.find((activity) => activity.toolName === "image");
+    expect(viewed?.phase).toBe("result");
+    expect(viewed?.text).toBe("Viewed an image");
+    expect(viewed?.imageSource).toBe(
+      "/api/media?path=" + encodeURIComponent("/Users/carsen/camera_model/renders/front_34.png")
+    );
+    expect(viewed?.imageAlt).toBe("front_34.png");
+  });
+
   test("keeps delegated waits visibly active in web and Tauri chat state", () => {
     const state = projectMultiChatStatusEvent(undefined, {
       type: "status",

--- a/tests/ui/unread-response-indicators.test.ts
+++ b/tests/ui/unread-response-indicators.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  DEFAULT_UNREAD_DOT_COLOR,
+  normalizeUnreadDotColor,
+  readUnreadDotColor,
+} from "../../ui/src/lib/unreadPreferences";
+
+const root = resolve(import.meta.dir, "../..");
+const source = (path: string): string => readFileSync(resolve(root, path), "utf8");
+
+describe("unread response indicators", () => {
+  test("normalizes the configurable dot color and has a safe default", () => {
+    expect(normalizeUnreadDotColor("#ABCDEF")).toBe("#abcdef");
+    expect(normalizeUnreadDotColor("red")).toBe(DEFAULT_UNREAD_DOT_COLOR);
+    expect(normalizeUnreadDotColor("#fff")).toBe(DEFAULT_UNREAD_DOT_COLOR);
+    expect(readUnreadDotColor()).toBe(DEFAULT_UNREAD_DOT_COLOR);
+  });
+
+  test("shows the configured dot to the right of unread bot and session names", () => {
+    const botSidebar = source("ui/src/pages/chat/BotSidebar.tsx");
+    const sessionSidebar = source("ui/src/pages/chat/SessionSidebar.tsx");
+
+    for (const sidebar of [botSidebar, sessionSidebar]) {
+      expect(sidebar).toContain('aria-label="Unread response"');
+      expect(sidebar).toContain("backgroundColor: unreadDotColor");
+    }
+    expect(botSidebar.indexOf("{bot.name}")).toBeLessThan(
+      botSidebar.indexOf("bot.session?.unread")
+    );
+    expect(sessionSidebar.indexOf("{displayTitle}")).toBeLessThan(
+      sessionSidebar.indexOf("session.unread && !isSessionSelected")
+    );
+  });
+
+  test("clears unread state immediately when a bot or session opens", () => {
+    const botSidebar = source("ui/src/pages/chat/BotSidebar.tsx");
+    const sessionSidebar = source("ui/src/pages/chat/SessionSidebar.tsx");
+    const chat = source("ui/src/pages/Chat.tsx");
+
+    expect(botSidebar).toContain("markBotReadImmediately(bot.session_id)");
+    expect(botSidebar).toContain("unread: false");
+    expect(sessionSidebar).toContain("markReadImmediately(sessionId)");
+    expect(sessionSidebar).toContain("sessionQueryClient.setQueriesData");
+    expect(chat).toContain("chatApi.markSessionRead(sessionId)");
+    expect(chat).toContain("typedMessages.length");
+  });
+
+  test("exposes the color picker in Appearance settings", () => {
+    const settings = source("ui/src/pages/settings/ThemeSettings.tsx");
+    expect(settings).toContain("Unread response color");
+    expect(settings).toContain('type="color"');
+    expect(settings).toContain("persistUnreadDotColor");
+  });
+});

--- a/tests/ui/unread-response-indicators.test.ts
+++ b/tests/ui/unread-response-indicators.test.ts
@@ -38,13 +38,15 @@ describe("unread response indicators", () => {
     const botSidebar = source("ui/src/pages/chat/BotSidebar.tsx");
     const sessionSidebar = source("ui/src/pages/chat/SessionSidebar.tsx");
     const chat = source("ui/src/pages/Chat.tsx");
+    const acknowledgement = source("ui/src/pages/chat/useSessionReadAcknowledgement.ts");
 
     expect(botSidebar).toContain("markBotReadImmediately(bot.session_id)");
     expect(botSidebar).toContain("unread: false");
     expect(sessionSidebar).toContain("markReadImmediately(sessionId)");
     expect(sessionSidebar).toContain("sessionQueryClient.setQueriesData");
-    expect(chat).toContain("chatApi.markSessionRead(sessionId)");
-    expect(chat).toContain("typedMessages.length");
+    expect(chat).toContain("useSessionReadAcknowledgement(sessionId, typedMessages.length)");
+    expect(acknowledgement).toContain("chatApi.markSessionRead(sessionId)");
+    expect(acknowledgement).toContain("[messageCount, queryClient, sessionId]");
   });
 
   test("exposes the color picker in Appearance settings", () => {

--- a/tests/ui/unread-response-indicators.test.ts
+++ b/tests/ui/unread-response-indicators.test.ts
@@ -6,6 +6,7 @@ import {
   normalizeUnreadDotColor,
   readUnreadDotColor,
 } from "../../ui/src/lib/unreadPreferences";
+import { latestAssistantMessageKey } from "../../ui/src/pages/chat/chatModel";
 
 const root = resolve(import.meta.dir, "../..");
 const source = (path: string): string => readFileSync(resolve(root, path), "utf8");
@@ -44,9 +45,40 @@ describe("unread response indicators", () => {
     expect(botSidebar).toContain("unread: false");
     expect(sessionSidebar).toContain("markReadImmediately(sessionId)");
     expect(sessionSidebar).toContain("sessionQueryClient.setQueriesData");
-    expect(chat).toContain("useSessionReadAcknowledgement(sessionId, typedMessages.length)");
+    expect(chat).toContain("useSessionReadAcknowledgement(sessionId, assistantReadKey)");
+    expect(chat).toContain("latestAssistantMessageKey(typedMessages)");
     expect(acknowledgement).toContain("chatApi.markSessionRead(sessionId)");
-    expect(acknowledgement).toContain("[messageCount, queryClient, sessionId]");
+    expect(acknowledgement).toContain("[latestAssistantMessageKey, queryClient, sessionId]");
+    expect(acknowledgement).toContain("acknowledgedRef.current === acknowledgementKey");
+    expect(acknowledgement).not.toContain("messageCount");
+  });
+
+  test("acknowledges reads only when the latest assistant message advances", () => {
+    expect(latestAssistantMessageKey([])).toBeNull();
+    expect(latestAssistantMessageKey([{ role: "user", content: "hi" }])).toBeNull();
+    const conversation = [
+      { role: "user" as const, content: "hi" },
+      { role: "assistant" as const, content: "one", message_id: "m-1" },
+      { role: "user" as const, content: "again" },
+    ];
+    expect(latestAssistantMessageKey(conversation)).toBe("m-1");
+    expect(
+      latestAssistantMessageKey([...conversation, { role: "user" as const, content: "and again" }])
+    ).toBe("m-1");
+    expect(
+      latestAssistantMessageKey([
+        ...conversation,
+        { role: "assistant" as const, content: "two", message_id: "m-2" },
+      ])
+    ).toBe("m-2");
+    expect(
+      latestAssistantMessageKey([
+        { role: "assistant" as const, content: "streaming", timestamp: "2099-01-01T00:00:00.000Z" },
+      ])
+    ).toBe("2099-01-01T00:00:00.000Z");
+    expect(latestAssistantMessageKey([{ role: "assistant" as const, content: "bare" }])).toBe(
+      "assistant-0"
+    );
   });
 
   test("exposes the color picker in Appearance settings", () => {

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1411,6 +1411,7 @@ export const chatApi = {
         pinned?: boolean;
         room?: SessionRoomConfig | null;
         message_count?: number;
+        unread?: boolean;
         last_message?: { role: string; content: string };
       }[]
     >("/sessions" + (suffix ? `?${suffix}` : ""));
@@ -1630,6 +1631,11 @@ export const chatApi = {
     }>(`/sessions/${encodeURIComponent(sessionId)}/artifacts/${encodeURIComponent(artifactName)}`, {
       method: "DELETE",
     }),
+  markSessionRead: (id: string) =>
+    fetchApi<{ success: boolean; session_id: string; unread: false }>(
+      `/sessions/${encodeURIComponent(id)}/read`,
+      { method: "PUT" }
+    ),
   deleteSession: (id: string) => fetchApi<void>("/sessions/" + id, { method: "DELETE" }),
 };
 
@@ -1920,6 +1926,7 @@ export const sessionsApi = {
         pinned?: boolean;
         room?: SessionRoomConfig | null;
         message_count?: number;
+        unread?: boolean;
         last_message?: { role: string; content: string };
       }[]
     >("/sessions" + (suffix ? `?${suffix}` : ""));

--- a/ui/src/lib/chatActivities.ts
+++ b/ui/src/lib/chatActivities.ts
@@ -19,6 +19,8 @@ export interface LiveActivityItem {
   toolCallId?: string;
   sandboxProvider?: string;
   fullText?: string;
+  imageSource?: string;
+  imageAlt?: string;
 }
 
 export interface ToolCallLike {
@@ -31,6 +33,96 @@ export interface ToolCallLike {
   started_at?: number | string;
   timeline_index?: number;
   duration?: number | string;
+}
+
+const imageViewedToolNames = new Set([
+  "image",
+  "browser",
+  "browser_screenshot",
+  "computer_use",
+  "mobile_simulator",
+  "read",
+]);
+
+const imageDataUrlPattern =
+  /^data:image\/(?:png|jpeg|jpg|gif|webp|heic|heif);base64,[A-Za-z0-9+/]+=*$/;
+
+function isImagePath(value: string): boolean {
+  return /\.(?:png|jpe?g|gif|webp|hei[cf])$/i.test(value.replace(/[?#].*$/, ""));
+}
+
+function gatewayMediaUrl(path: string): string {
+  const base =
+    typeof import.meta !== "undefined" && import.meta.env?.BASE_URL
+      ? import.meta.env.BASE_URL.replace(/\/$/, "")
+      : "";
+  return `${base}/api/media?path=${encodeURIComponent(path)}`;
+}
+
+function toLoadableImageSource(value: string): string | undefined {
+  if (value.startsWith("data:")) return imageDataUrlPattern.test(value) ? value : undefined;
+  if (/^https?:\/\//i.test(value)) return isImagePath(value) ? value : undefined;
+  if (/^file:\/\//i.test(value)) {
+    try {
+      return gatewayMediaUrl(decodeURIComponent(new URL(value).pathname));
+    } catch {
+      return undefined;
+    }
+  }
+  if (value.includes("/api/media?path=")) return isImagePath(value) ? value : undefined;
+  if (!value.startsWith("/")) return undefined;
+  return isImagePath(value) ? gatewayMediaUrl(value) : undefined;
+}
+
+export function imageViewedSource(call: ToolCallLike): string | undefined {
+  if (!imageViewedToolNames.has(call.name)) return undefined;
+  if (!isObjectRecord(call.result)) return undefined;
+  const candidates = [
+    call.result.image,
+    call.result.path,
+    call.result.filePath,
+    call.result.screenshot,
+  ];
+  for (const candidate of candidates) {
+    if (typeof candidate !== "string") continue;
+    const trimmed = candidate.trim();
+    if (!trimmed) continue;
+    const source = toLoadableImageSource(trimmed);
+    if (source) return source;
+  }
+  return undefined;
+}
+
+function rawImageViewedPath(call: ToolCallLike): string | undefined {
+  if (!isObjectRecord(call.result)) return undefined;
+  for (const candidate of [
+    call.result.image,
+    call.result.path,
+    call.result.filePath,
+    call.result.screenshot,
+  ]) {
+    if (typeof candidate === "string" && candidate.trim()) return candidate.trim();
+  }
+  return undefined;
+}
+
+function imageViewedAlt(args: Record<string, unknown>, source: string): string {
+  if (typeof args.path === "string" && args.path.trim()) return toDisplayPath(args.path);
+  if (typeof args.filePath === "string" && args.filePath.trim())
+    return toDisplayPath(args.filePath);
+  return toDisplayPath(source);
+}
+
+function applyImageViewedMetadata(
+  activity: LiveActivityItem,
+  call: ToolCallLike,
+  args: Record<string, unknown>
+): LiveActivityItem {
+  if (activity.phase !== "result") return activity;
+  const source = imageViewedSource(call);
+  if (!source) return activity;
+  const altSource = rawImageViewedPath(call) ?? source;
+  return { ...activity, imageSource: source, imageAlt: imageViewedAlt(args, altSource) };
 }
 
 function normalizeText(value: string): string {
@@ -280,7 +372,7 @@ export function buildActivitiesFromToolCalls(
         ? fallbackBase + call.timeline_index
         : fallbackBase + index);
 
-    activities.push({
+    const activity: LiveActivityItem = {
       id: call.id ? `tool-${call.id}` : `tool-${index}-${call.name}`,
       phase,
       text: trimmedText,
@@ -288,7 +380,8 @@ export function buildActivitiesFromToolCalls(
       toolName: call.name,
       toolCallId: call.id,
       sandboxProvider: resolveToolCallSandboxProvider(call),
-    });
+    };
+    activities.push(applyImageViewedMetadata(activity, call, args));
   }
 
   return activities;
@@ -339,10 +432,13 @@ export function enrichActivitiesWithToolCallDetails(
     );
     const text = structuredText || activity.text;
     const fullText = formatExpandedToolActivityDetail(call.name, args, activity.phase, call.result);
+    const withImage = applyImageViewedMetadata(activity, call, args);
     if (!fullText || equivalentActivityText(text, fullText)) {
+      if (withImage !== activity)
+        return { ...withImage, text: text === activity.text ? withImage.text : text };
       return text === activity.text ? activity : { ...activity, text };
     }
-    return { ...activity, text, fullText };
+    return { ...withImage, text, fullText };
   });
 }
 

--- a/ui/src/lib/chatActivities.ts
+++ b/ui/src/lib/chatActivities.ts
@@ -89,6 +89,7 @@ export function imageViewedSource(call: ToolCallLike): string | undefined {
   if (!imageViewedToolNames.has(call.name)) return undefined;
   if (!isObjectRecord(call.result)) return undefined;
   const candidates = [
+    call.result.snapshot,
     call.result.image,
     call.result.path,
     call.result.filePath,

--- a/ui/src/lib/chatActivities.ts
+++ b/ui/src/lib/chatActivities.ts
@@ -128,9 +128,11 @@ function imageViewedAlt(args: Record<string, unknown>, source: string): string {
 function applyImageViewedMetadata(
   activity: LiveActivityItem,
   call: ToolCallLike,
-  args: Record<string, unknown>
+  args: Record<string, unknown>,
+  correlated = true
 ): LiveActivityItem {
   if (activity.phase !== "result") return activity;
+  if (!correlated && !activity.imageSource) return activity;
   const source = imageViewedSource(call);
   if (!source) return activity;
   const altSource = rawImageViewedPath(call) ?? source;
@@ -444,7 +446,12 @@ export function enrichActivitiesWithToolCallDetails(
     );
     const text = structuredText || activity.text;
     const fullText = formatExpandedToolActivityDetail(call.name, args, activity.phase, call.result);
-    const withImage = applyImageViewedMetadata(activity, call, args);
+    const withImage = applyImageViewedMetadata(
+      activity,
+      call,
+      args,
+      Boolean(callById && callById === call)
+    );
     if (!fullText || equivalentActivityText(text, fullText)) {
       if (withImage !== activity)
         return { ...withImage, text: text === activity.text ? withImage.text : text };
@@ -489,16 +496,36 @@ export function mergeActivityLists(
   const seenSemantic = new Set<string>();
   const merged: LiveActivityItem[] = [];
 
+  const positions = new Map<string, number>();
+  const backfillImageMetadata = (key: string, activity: LiveActivityItem): void => {
+    const index = positions.get(key);
+    if (index === undefined) return;
+    const kept = merged[index];
+    if (!kept || kept.imageSource || !activity.imageSource) return;
+    merged[index] = {
+      ...kept,
+      imageSource: activity.imageSource,
+      imageAlt: kept.imageAlt || activity.imageAlt,
+    };
+  };
   const pushUnique = (activity: LiveActivityItem) => {
     if (hasCompletionForStart(activity)) {
       return;
     }
     const exactKey = activityDedupKey(activity);
-    if (seen.has(exactKey)) return;
     const semanticKey = semanticActivityDedupKey(activity);
-    if (seenSemantic.has(semanticKey)) return;
+    if (seen.has(exactKey)) {
+      backfillImageMetadata(exactKey, activity);
+      return;
+    }
+    if (seenSemantic.has(semanticKey)) {
+      backfillImageMetadata(semanticKey, activity);
+      return;
+    }
     seen.add(exactKey);
     seenSemantic.add(semanticKey);
+    positions.set(exactKey, merged.length);
+    positions.set(semanticKey, merged.length);
     merged.push(activity);
   };
 

--- a/ui/src/lib/chatActivities.ts
+++ b/ui/src/lib/chatActivities.ts
@@ -74,6 +74,17 @@ function toLoadableImageSource(value: string): string | undefined {
   return isImagePath(value) ? gatewayMediaUrl(value) : undefined;
 }
 
+export function imageSourceFromPath(value: string | undefined): string | undefined {
+  const trimmed = typeof value === "string" ? value.trim() : "";
+  return trimmed ? toLoadableImageSource(trimmed) : undefined;
+}
+
+export function imageAltFromPath(value: string | undefined): string | undefined {
+  const trimmed = typeof value === "string" ? value.trim() : "";
+  if (!trimmed || trimmed.startsWith("data:")) return undefined;
+  return toDisplayPath(trimmed.replace(/[?#].*$/, ""));
+}
+
 export function imageViewedSource(call: ToolCallLike): string | undefined {
   if (!imageViewedToolNames.has(call.name)) return undefined;
   if (!isObjectRecord(call.result)) return undefined;

--- a/ui/src/lib/chatImageLightbox.ts
+++ b/ui/src/lib/chatImageLightbox.ts
@@ -1,0 +1,30 @@
+import type { ChatLightboxImage } from "@/pages/chat/ChatImageLightbox";
+
+const OPEN_CHAT_LIGHTBOX_EVENT = "cybara:open-chat-lightbox";
+
+function supportsEvents(): boolean {
+  return (
+    typeof globalThis.addEventListener === "function" &&
+    typeof globalThis.dispatchEvent === "function" &&
+    typeof globalThis.CustomEvent === "function"
+  );
+}
+
+export function openChatImageLightbox(src: string, alt: string): void {
+  if (!supportsEvents()) return;
+  globalThis.dispatchEvent(
+    new CustomEvent<ChatLightboxImage>(OPEN_CHAT_LIGHTBOX_EVENT, {
+      detail: { src, alt },
+    })
+  );
+}
+
+export function onOpenChatImageLightbox(listener: (image: ChatLightboxImage) => void): () => void {
+  if (!supportsEvents()) return () => undefined;
+  const handler = (event: Event): void => {
+    const detail = (event as CustomEvent<ChatLightboxImage>).detail;
+    if (detail && typeof detail.src === "string") listener(detail);
+  };
+  globalThis.addEventListener(OPEN_CHAT_LIGHTBOX_EVENT, handler);
+  return () => globalThis.removeEventListener(OPEN_CHAT_LIGHTBOX_EVENT, handler);
+}

--- a/ui/src/lib/chatImages.ts
+++ b/ui/src/lib/chatImages.ts
@@ -1,7 +1,7 @@
 import { apiFetch, withGatewayBasePath } from "@/lib/auth";
 import {
-  loadAuthenticatedMediaSource,
   type LoadedAuthenticatedMediaSource,
+  loadAuthenticatedMediaSource,
   requiresAuthenticatedMediaFetch,
 } from "@/lib/authenticatedMedia";
 import type { ChatImageAttachment } from "@/types";
@@ -74,13 +74,48 @@ export function requiresAuthenticatedImageFetch(source: string): boolean {
   return requiresAuthenticatedMediaFetch(source);
 }
 
+const MAX_CACHED_IMAGE_SOURCES = 200;
+const cachedImageSources = new Map<string, LoadedChatImageSource>();
+const pendingImageSources = new Map<string, Promise<LoadedChatImageSource>>();
+
+function rememberImageSource(source: string, loaded: LoadedChatImageSource): LoadedChatImageSource {
+  cachedImageSources.delete(source);
+  cachedImageSources.set(source, loaded);
+  while (cachedImageSources.size > MAX_CACHED_IMAGE_SOURCES) {
+    const oldest = cachedImageSources.keys().next().value;
+    if (oldest === undefined) break;
+    cachedImageSources.get(oldest)?.revoke?.();
+    cachedImageSources.delete(oldest);
+  }
+  return { src: loaded.src };
+}
+
+export function peekChatImageSource(source: string): string | undefined {
+  return cachedImageSources.get(source)?.src;
+}
+
+export function resetChatImageSourceCacheForTests(): void {
+  for (const loaded of cachedImageSources.values()) loaded.revoke?.();
+  cachedImageSources.clear();
+  pendingImageSources.clear();
+}
+
 export async function loadChatImageSource(
   source: string,
   fetcher: typeof apiFetch = apiFetch,
   createObjectUrl: (blob: Blob) => string = URL.createObjectURL,
-  revokeObjectUrl: (url: string) => void = URL.revokeObjectURL
+  revokeObjectUrl: (url: string) => void = URL.revokeObjectURL,
+  options?: { cache?: boolean }
 ): Promise<LoadedChatImageSource> {
-  return loadAuthenticatedMediaSource(
+  const cacheable =
+    (options?.cache ?? fetcher === apiFetch) && requiresAuthenticatedImageFetch(source);
+  if (cacheable) {
+    const cached = cachedImageSources.get(source);
+    if (cached) return { src: cached.src };
+    const pending = pendingImageSources.get(source);
+    if (pending) return pending;
+  }
+  const request = loadAuthenticatedMediaSource(
     source,
     "image/",
     fetcher,
@@ -88,6 +123,12 @@ export async function loadChatImageSource(
     revokeObjectUrl,
     "Image"
   );
+  if (!cacheable) return request;
+  const shared = request
+    .then((loaded) => rememberImageSource(source, loaded))
+    .finally(() => pendingImageSources.delete(source));
+  pendingImageSources.set(source, shared);
+  return shared;
 }
 
 export function chatMarkdownImageSources(content: string): string[] {

--- a/ui/src/lib/status-stream.ts
+++ b/ui/src/lib/status-stream.ts
@@ -21,6 +21,7 @@ export interface StatusActivity {
   toolName?: string;
   toolCallId?: string;
   sandboxProvider?: string;
+  imagePath?: string;
 }
 
 export interface PendingChatMessage {
@@ -59,6 +60,7 @@ export interface StatusStreamStatusEvent {
   toolName?: string;
   toolCallId?: string;
   sandboxProvider?: string;
+  imagePath?: string;
   toolPhase?: "start" | "result" | "error" | "blocked";
   durationMs?: number;
   pendingChatId?: string;

--- a/ui/src/lib/unreadPreferences.ts
+++ b/ui/src/lib/unreadPreferences.ts
@@ -1,0 +1,49 @@
+import { useSyncExternalStore } from "react";
+
+export const DEFAULT_UNREAD_DOT_COLOR = "#38bdf8";
+const UNREAD_DOT_COLOR_KEY = "cybara-unread-dot-color";
+const UNREAD_DOT_COLOR_EVENT = "cybara:unread-dot-color-changed";
+const HEX_COLOR = /^#[0-9a-f]{6}$/i;
+
+export function normalizeUnreadDotColor(value: unknown): string {
+  return typeof value === "string" && HEX_COLOR.test(value.trim())
+    ? value.trim().toLowerCase()
+    : DEFAULT_UNREAD_DOT_COLOR;
+}
+
+export function readUnreadDotColor(): string {
+  if (typeof window === "undefined") return DEFAULT_UNREAD_DOT_COLOR;
+  try {
+    return normalizeUnreadDotColor(window.localStorage.getItem(UNREAD_DOT_COLOR_KEY));
+  } catch {
+    return DEFAULT_UNREAD_DOT_COLOR;
+  }
+}
+
+export function persistUnreadDotColor(color: string): void {
+  const normalized = normalizeUnreadDotColor(color);
+  try {
+    window.localStorage.setItem(UNREAD_DOT_COLOR_KEY, normalized);
+    window.dispatchEvent(new CustomEvent(UNREAD_DOT_COLOR_EVENT));
+  } catch {
+    return;
+  }
+}
+
+function subscribeUnreadDotColor(onChange: () => void): () => void {
+  const listener = (): void => onChange();
+  window.addEventListener(UNREAD_DOT_COLOR_EVENT, listener);
+  window.addEventListener("storage", listener);
+  return () => {
+    window.removeEventListener(UNREAD_DOT_COLOR_EVENT, listener);
+    window.removeEventListener("storage", listener);
+  };
+}
+
+export function useUnreadDotColor(): string {
+  return useSyncExternalStore(
+    subscribeUnreadDotColor,
+    readUnreadDotColor,
+    () => DEFAULT_UNREAD_DOT_COLOR
+  );
+}

--- a/ui/src/pages/Chat.tsx
+++ b/ui/src/pages/Chat.tsx
@@ -53,6 +53,7 @@ import { GoalPanel } from "./chat/GoalPanel";
 import { isVisibleChatTranscriptMessage } from "./chat/goalLoopPresentation";
 import { useSessionGoal } from "./chat/useSessionGoal";
 import { normalizeToolApprovalMode, type ToolApprovalMode } from "./chat/ChatFollowUpControls";
+import { onOpenChatImageLightbox } from "@/lib/chatImageLightbox";
 import { ChatImageLightbox } from "./chat/ChatImageLightbox";
 import { chatHorizontalPaddingClassName } from "./chat/chatAppearanceLayout";
 import { type ChatLinkOpenOptions, routeChatLink } from "./chat/chatLinkRouting";
@@ -239,6 +240,10 @@ export function Chat() {
     setImageLightbox,
     speakingMessageIndex,
   } = useChatMessageActions();
+  useEffect(
+    () => onOpenChatImageLightbox((image) => setImageLightbox({ images: [image], index: 0 })),
+    [setImageLightbox]
+  );
   const imageInputRef = useRef<HTMLInputElement>(null);
   const [revertTarget, setRevertTarget] = useState<RevertTarget | null>(null);
   const [forkingMessageIndex, setForkingMessageIndex] = useState<number | null>(null);

--- a/ui/src/pages/Chat.tsx
+++ b/ui/src/pages/Chat.tsx
@@ -1,3 +1,7 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { ArrowDown, Loader2, RotateCcw } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate } from "react-router";
 import { LocalFolderPickerModal } from "@/components/LocalFolderPickerModal";
 import { Button, Modal } from "@/components/ui";
 import { useAgentSummaries, useInfo, useSubagents, useUpdateAgentReasoning } from "@/hooks/useApi";
@@ -7,8 +11,6 @@ import {
   useLoadSession,
   useUpdateSessionAgent,
 } from "@/hooks/useChat";
-import { ChatRoomBanner, roomComposerLabel, useCurrentRoom } from "./chat/RoomBanner";
-import { useComposerAgents, useCurrentBot } from "./chat/useChatBotContext";
 import { canShareNearbySession, useNearbyStatus } from "@/hooks/useNearbyStatus";
 import { chatApi, providerPlansApi, settingsApi } from "@/lib/api";
 import {
@@ -24,70 +26,65 @@ import {
   mergeActivityLists,
   suppressRecoveredWebFailureActivities,
 } from "@/lib/chatActivities";
+import { onOpenChatImageLightbox } from "@/lib/chatImageLightbox";
 import { useI18n } from "@/lib/i18n";
 import { type PendingChatMessage, type StatusSessionSnapshot } from "@/lib/status-stream";
 import { cn } from "@/lib/utils";
 import { useUIStore } from "@/stores/uiStore";
 import type { ProviderPlanStatusResponse, SessionContextUsage, SessionTokenUsage } from "@/types";
 import { openExternal } from "@/utils/openExternal";
-import { useQueryClient } from "@tanstack/react-query";
-import { ArrowDown, Loader2, RotateCcw } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useNavigate } from "react-router";
 import {
   resolveSessionEventOrder,
   type SessionEventCursor,
   type SessionEventIdentity,
 } from "../../../shared/session-event-order";
 import { ArtifactViewerPanel } from "./chat/ArtifactViewerPanel";
+import { hasMixedAssistantAuthors } from "./chat/assistantAuthors";
 import { parseTimestampMs } from "./chat/assistantMetaModel";
 import { MODEL_ROUTER_SELECTOR_VALUE } from "./chat/ChatAgentControls";
 import { ChatComposer, type ChatComposerProps } from "./chat/ChatComposer";
 import { ChatEmptyState } from "./chat/ChatEmptyState";
-import { GoalPanel } from "./chat/GoalPanel";
-import { isVisibleChatTranscriptMessage } from "./chat/goalLoopPresentation";
-import { useSessionGoal } from "./chat/useSessionGoal";
-import { useSessionReadAcknowledgement } from "./chat/useSessionReadAcknowledgement";
 import { normalizeToolApprovalMode, type ToolApprovalMode } from "./chat/ChatFollowUpControls";
-import { onOpenChatImageLightbox } from "@/lib/chatImageLightbox";
 import { ChatImageLightbox } from "./chat/ChatImageLightbox";
+import { ChatMessageTimeline } from "./chat/ChatMessageTimeline";
+import { ChatPageHeader } from "./chat/ChatPageHeader";
+import { ChatSessionLoadingState } from "./chat/ChatSessionLoadingState";
+import { ChatWorkspaceDock } from "./chat/ChatWorkspaceDock";
 import { chatHorizontalPaddingClassName } from "./chat/chatAppearanceLayout";
 import { type ChatLinkOpenOptions, routeChatLink } from "./chat/chatLinkRouting";
-import { ChatMessageTimeline } from "./chat/ChatMessageTimeline";
 import {
   type ChatMessage,
   extractLatestPlanFromMessages,
   formatToolIntent,
   getLegacyMessageProcessKey,
   getMessageProcessKey,
+  latestAssistantMessageKey,
   normalizeMessageProcessActivities,
   PENDING_CAPTURE_TIMEOUT_MS,
   type PendingProcessCapture,
   persistMessageProcessMap,
   persistSessionId,
   persistWorkspaceDir,
+  type RevertTarget,
   readPersistedMessageProcessMap,
   readPersistedSessionId,
   readPersistedWorkspaceDir,
-  type RevertTarget,
   type SessionStatusResponse,
   type SessionStatusSnapshot,
   shouldShowSessionPlanInComposer,
 } from "./chat/chatModel";
-import { ChatPageHeader } from "./chat/ChatPageHeader";
-import { buildMultiChatPath } from "./chat/multiChatLayout";
 import { parseInitialChatRoute } from "./chat/chatRoute";
-import { ChatSessionLoadingState } from "./chat/ChatSessionLoadingState";
-import { ChatWorkspaceDock } from "./chat/ChatWorkspaceDock";
 import { FloatingBrowserPreview } from "./chat/FloatingBrowserPreview";
 import { FloatingComputerPreview } from "./chat/FloatingComputerPreview";
 import { shouldShowFloatingBrowserPreview } from "./chat/floatingBrowserPreviewModel";
-import { useFloatingPreviewActivity } from "./chat/useFloatingPreviewActivity";
-import { hasMixedAssistantAuthors } from "./chat/assistantAuthors";
+import { GoalPanel } from "./chat/GoalPanel";
+import { isVisibleChatTranscriptMessage } from "./chat/goalLoopPresentation";
 import { clearCachedLiveSessionState, isLiveSessionRunning } from "./chat/liveSessionState";
+import { buildMultiChatPath } from "./chat/multiChatLayout";
 import { NearbyShareModal } from "./chat/NearbyShareModal";
 import { PendingApprovalsBanner } from "./chat/PendingApprovalsBanner";
 import { normalizePendingChatMessages } from "./chat/pendingQueueState";
+import { ChatRoomBanner, roomComposerLabel, useCurrentRoom } from "./chat/RoomBanner";
 import {
   isStoppedRunSuppressed,
   markStoppedRun,
@@ -96,6 +93,7 @@ import {
 import { useArtifactViewer } from "./chat/useArtifactViewer";
 import { useBotRoster } from "./chat/useBotRoster";
 import { useChatAttachments } from "./chat/useChatAttachments";
+import { useComposerAgents, useCurrentBot } from "./chat/useChatBotContext";
 import { useChatCapabilityPicker } from "./chat/useChatCapabilityPicker";
 import { useChatDictation } from "./chat/useChatDictation";
 import { useChatFileDropSurface } from "./chat/useChatFileDropSurface";
@@ -106,7 +104,10 @@ import { useChatScroll } from "./chat/useChatScroll";
 import { useChatWorkspaceActions } from "./chat/useChatWorkspaceActions";
 import { useChatWorkspaceTabs } from "./chat/useChatWorkspaceTabs";
 import { useEnvironmentGitBranches } from "./chat/useEnvironmentGitBranches";
+import { useFloatingPreviewActivity } from "./chat/useFloatingPreviewActivity";
 import { useSessionFileChanges } from "./chat/useSessionFileChanges";
+import { useSessionGoal } from "./chat/useSessionGoal";
+import { useSessionReadAcknowledgement } from "./chat/useSessionReadAcknowledgement";
 
 type LiveStatusSnapshotLike = StatusSessionSnapshot | SessionStatusSnapshot;
 
@@ -147,7 +148,8 @@ export function Chat() {
   const goalController = useSessionGoal(sessionId || undefined);
   const { data: environmentSubagents = [] } = useSubagents(sessionId);
   const typedMessages = messages as ChatMessage[];
-  useSessionReadAcknowledgement(sessionId, typedMessages.length);
+  const assistantReadKey = useMemo(() => latestAssistantMessageKey(typedMessages), [typedMessages]);
+  useSessionReadAcknowledgement(sessionId, assistantReadKey);
   const currentBot = useCurrentBot(botRoster, sessionId);
   const currentRoom = useCurrentRoom(sessionId);
   const composerAgents = useComposerAgents(agents, currentBot);

--- a/ui/src/pages/Chat.tsx
+++ b/ui/src/pages/Chat.tsx
@@ -631,11 +631,15 @@ export function Chat() {
   useEffect(() => {
     if (sessionId) {
       persistSessionId(sessionId);
-      void chatApi.markSessionRead(sessionId).then(() => {
-        void queryClient.invalidateQueries({ queryKey: ["sessions"] });
-        void queryClient.invalidateQueries({ queryKey: ["bots"] });
-      });
     }
+  }, [sessionId]);
+
+  useEffect(() => {
+    if (!sessionId) return;
+    void chatApi.markSessionRead(sessionId).then(() => {
+      void queryClient.invalidateQueries({ queryKey: ["sessions"] });
+      void queryClient.invalidateQueries({ queryKey: ["bots"] });
+    });
   }, [queryClient, sessionId, typedMessages.length]);
 
   useEffect(() => {

--- a/ui/src/pages/Chat.tsx
+++ b/ui/src/pages/Chat.tsx
@@ -52,6 +52,7 @@ import { ChatEmptyState } from "./chat/ChatEmptyState";
 import { GoalPanel } from "./chat/GoalPanel";
 import { isVisibleChatTranscriptMessage } from "./chat/goalLoopPresentation";
 import { useSessionGoal } from "./chat/useSessionGoal";
+import { useSessionReadAcknowledgement } from "./chat/useSessionReadAcknowledgement";
 import { normalizeToolApprovalMode, type ToolApprovalMode } from "./chat/ChatFollowUpControls";
 import { onOpenChatImageLightbox } from "@/lib/chatImageLightbox";
 import { ChatImageLightbox } from "./chat/ChatImageLightbox";
@@ -161,6 +162,7 @@ export function Chat() {
   const goalController = useSessionGoal(sessionId || undefined);
   const { data: environmentSubagents = [] } = useSubagents(sessionId);
   const typedMessages = messages as ChatMessage[];
+  useSessionReadAcknowledgement(sessionId, typedMessages.length);
   const currentBot = useCurrentBot(botRoster, sessionId);
   const currentRoom = useCurrentRoom(sessionId);
   const composerAgents = useComposerAgents(agents, currentBot);
@@ -633,14 +635,6 @@ export function Chat() {
       persistSessionId(sessionId);
     }
   }, [sessionId]);
-
-  useEffect(() => {
-    if (!sessionId) return;
-    void chatApi.markSessionRead(sessionId).then(() => {
-      void queryClient.invalidateQueries({ queryKey: ["sessions"] });
-      void queryClient.invalidateQueries({ queryKey: ["bots"] });
-    });
-  }, [queryClient, sessionId, typedMessages.length]);
 
   useEffect(() => {
     let active = true;

--- a/ui/src/pages/Chat.tsx
+++ b/ui/src/pages/Chat.tsx
@@ -631,8 +631,12 @@ export function Chat() {
   useEffect(() => {
     if (sessionId) {
       persistSessionId(sessionId);
+      void chatApi.markSessionRead(sessionId).then(() => {
+        void queryClient.invalidateQueries({ queryKey: ["sessions"] });
+        void queryClient.invalidateQueries({ queryKey: ["bots"] });
+      });
     }
-  }, [sessionId]);
+  }, [queryClient, sessionId, typedMessages.length]);
 
   useEffect(() => {
     let active = true;

--- a/ui/src/pages/Chat.tsx
+++ b/ui/src/pages/Chat.tsx
@@ -10,7 +10,7 @@ import {
 import { ChatRoomBanner, roomComposerLabel, useCurrentRoom } from "./chat/RoomBanner";
 import { useComposerAgents, useCurrentBot } from "./chat/useChatBotContext";
 import { canShareNearbySession, useNearbyStatus } from "@/hooks/useNearbyStatus";
-import { botsApi, chatApi, extractApiError, providerPlansApi, settingsApi } from "@/lib/api";
+import { chatApi, providerPlansApi, settingsApi } from "@/lib/api";
 import {
   APP_HOTKEY_EVENT,
   type AppHotkeyActionId,
@@ -28,14 +28,9 @@ import { useI18n } from "@/lib/i18n";
 import { type PendingChatMessage, type StatusSessionSnapshot } from "@/lib/status-stream";
 import { cn } from "@/lib/utils";
 import { useUIStore } from "@/stores/uiStore";
-import type {
-  BotRosterItem,
-  ProviderPlanStatusResponse,
-  SessionContextUsage,
-  SessionTokenUsage,
-} from "@/types";
+import type { ProviderPlanStatusResponse, SessionContextUsage, SessionTokenUsage } from "@/types";
 import { openExternal } from "@/utils/openExternal";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQueryClient } from "@tanstack/react-query";
 import { ArrowDown, Loader2, RotateCcw } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router";
@@ -99,6 +94,7 @@ import {
   type StoppedRunSuppressions,
 } from "./chat/stopSuppression";
 import { useArtifactViewer } from "./chat/useArtifactViewer";
+import { useBotRoster } from "./chat/useBotRoster";
 import { useChatAttachments } from "./chat/useChatAttachments";
 import { useChatCapabilityPicker } from "./chat/useChatCapabilityPicker";
 import { useChatDictation } from "./chat/useChatDictation";
@@ -123,18 +119,7 @@ export function Chat() {
   const { data: agents = [] } = useAgentSummaries();
   const updateAgentReasoning = useUpdateAgentReasoning();
   const { data: info } = useInfo();
-  const { data: botRoster = [] } = useQuery<BotRosterItem[]>({
-    queryKey: ["bots"],
-    queryFn: async () => {
-      const response = await botsApi.list();
-      if (!response.success || !response.data) {
-        throw new Error(extractApiError(response, "Could not load bots"));
-      }
-      return response.data.bots;
-    },
-    staleTime: 5_000,
-    refetchInterval: 10_000,
-  });
+  const botRoster = useBotRoster();
   const [initialChatRoute] = useState(() => parseInitialChatRoute(window.location.search));
   const [selectedAgentId, setSelectedAgentId] = useState<string | undefined>(
     initialChatRoute.agentId ?? undefined

--- a/ui/src/pages/chat/ActivityTimeline.tsx
+++ b/ui/src/pages/chat/ActivityTimeline.tsx
@@ -18,6 +18,8 @@ import {
 import { Badge } from "@/components/ui";
 import { cn } from "@/lib/utils";
 import type { Subagent } from "@/hooks/useApi";
+import { loadChatImageSource } from "@/lib/chatImages";
+import { openChatImageLightbox } from "@/lib/chatImageLightbox";
 import {
   formatSandboxProviderLabel,
   getLatestInFlightStep,
@@ -42,6 +44,61 @@ const GROUP_ICONS: Record<ActivityGroupKind, LucideIcon> = {
   fetch: Globe2,
   command: SquareTerminal,
 };
+
+function ImageViewedThumbnail({ source, alt }: { source: string; alt: string }) {
+  const [displaySource, setDisplaySource] = useState<string | null>(null);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    let revoke: (() => void) | undefined;
+    setFailed(false);
+    setDisplaySource(null);
+    void loadChatImageSource(source)
+      .then((loaded) => {
+        if (!active) {
+          loaded.revoke?.();
+          return;
+        }
+        revoke = loaded.revoke;
+        setDisplaySource(loaded.src);
+      })
+      .catch(() => {
+        if (active) setFailed(true);
+      });
+    return () => {
+      active = false;
+      revoke?.();
+    };
+  }, [source]);
+
+  if (failed) return null;
+  return (
+    <button
+      type="button"
+      data-testid="activity-image-viewed-thumbnail"
+      aria-label={`Open ${alt}`}
+      title={`View ${alt}`}
+      onClick={(event) => {
+        event.stopPropagation();
+        if (displaySource) openChatImageLightbox(displaySource, alt);
+      }}
+      disabled={!displaySource}
+      className={cn(
+        "block h-14 w-20 shrink-0 overflow-hidden rounded-md border border-white/10 bg-black/30",
+        displaySource && "cursor-zoom-in transition-opacity hover:opacity-90"
+      )}
+    >
+      {displaySource ? (
+        <img src={displaySource} alt={alt} className="h-full w-full object-cover" />
+      ) : (
+        <span className="flex h-full w-full items-center justify-center">
+          <Loader2 className="h-3.5 w-3.5 animate-spin text-gray-500" />
+        </span>
+      )}
+    </button>
+  );
+}
 
 function ActivityRow({ activity }: { activity: LiveActivityItem }) {
   const [expanded, setExpanded] = useState(false);
@@ -105,6 +162,12 @@ function ActivityRow({ activity }: { activity: LiveActivityItem }) {
       ) : (
         <div className="min-w-0 flex-1 flex items-center gap-2">{textContent}</div>
       )}
+      {activity.imageSource ? (
+        <ImageViewedThumbnail
+          source={activity.imageSource}
+          alt={activity.imageAlt || "Viewed image"}
+        />
+      ) : null}
     </div>
   );
 }

--- a/ui/src/pages/chat/ActivityTimeline.tsx
+++ b/ui/src/pages/chat/ActivityTimeline.tsx
@@ -25,7 +25,7 @@ import {
   mergeActivityLists,
 } from "@/lib/chatActivities";
 import { openChatImageLightbox } from "@/lib/chatImageLightbox";
-import { loadChatImageSource } from "@/lib/chatImages";
+import { loadChatImageSource, peekChatImageSource } from "@/lib/chatImages";
 import { cn } from "@/lib/utils";
 import { formatWorkedDuration } from "./assistantMetaModel";
 import {
@@ -44,17 +44,22 @@ const GROUP_ICONS: Record<ActivityGroupKind, LucideIcon> = {
   edit: Pencil,
   fetch: Globe2,
   command: SquareTerminal,
+  view: ImageIcon,
 };
 
+const LIVE_OPEN_GROUP_KINDS: readonly ActivityGroupKind[] = ["view"];
+
 function ImageViewedThumbnail({ source, alt }: { source: string; alt: string }) {
-  const [displaySource, setDisplaySource] = useState<string | null>(null);
+  const [displaySource, setDisplaySource] = useState<string | null>(
+    () => peekChatImageSource(source) ?? null
+  );
   const [failed, setFailed] = useState(false);
 
   useEffect(() => {
     let active = true;
     let revoke: (() => void) | undefined;
     setFailed(false);
-    setDisplaySource(null);
+    if (!peekChatImageSource(source)) setDisplaySource(null);
     void loadChatImageSource(source)
       .then((loaded) => {
         if (!active) {
@@ -188,12 +193,18 @@ function ActivityRow({ activity }: { activity: LiveActivityItem }) {
   );
 }
 
-export function GroupedActivityRows({ activities }: { activities: LiveActivityItem[] }) {
-  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
+export function GroupedActivityRows({
+  activities,
+  openByDefault = [],
+}: {
+  activities: LiveActivityItem[];
+  openByDefault?: readonly ActivityGroupKind[];
+}) {
+  const [toggledGroups, setToggledGroups] = useState<Set<string>>(new Set());
   const entries = groupActivitiesForDisplay(activities);
 
   const toggleGroup = (id: string) => {
-    setExpandedGroups((previous) => {
+    setToggledGroups((previous) => {
       const next = new Set(previous);
       if (next.has(id)) {
         next.delete(id);
@@ -210,7 +221,7 @@ export function GroupedActivityRows({ activities }: { activities: LiveActivityIt
         if (entry.type === "single") {
           return <ActivityRow key={entry.activity.id} activity={entry.activity} />;
         }
-        const expanded = expandedGroups.has(entry.id);
+        const expanded = openByDefault.includes(entry.kind) !== toggledGroups.has(entry.id);
         const GroupIcon = GROUP_ICONS[entry.kind];
         const inFlight = entry.items.some((activity) => activity.phase === "start");
         return (
@@ -238,13 +249,30 @@ export function GroupedActivityRows({ activities }: { activities: LiveActivityIt
                 <ChevronRight className="w-3 h-3 text-gray-600 flex-shrink-0" />
               )}
             </button>
-            {expanded && (
+            {expanded && entry.kind === "view" ? (
+              <div
+                className="ml-[5px] mt-1.5 flex flex-wrap gap-2 border-l border-white/10 pl-2.5"
+                data-testid="activity-image-viewed-strip"
+              >
+                {entry.items.map((activity) =>
+                  activity.imageSource ? (
+                    <ImageViewedThumbnail
+                      key={activity.id}
+                      source={activity.imageSource}
+                      alt={activity.imageAlt || "Viewed image"}
+                    />
+                  ) : (
+                    <ActivityRow key={activity.id} activity={activity} />
+                  )
+                )}
+              </div>
+            ) : expanded ? (
               <div className="ml-[5px] mt-1 space-y-1 border-l border-white/10 pl-2.5">
                 {entry.items.map((activity) => (
                   <ActivityRow key={activity.id} activity={activity} />
                 ))}
               </div>
-            )}
+            ) : null}
           </div>
         );
       })}
@@ -351,7 +379,9 @@ export function LiveActivityTimeline({
   return (
     <div className="space-y-1">
       <LiveWorkedDuration startedAtMs={startedAtMs} />
-      {visibleActivities.length > 0 && <GroupedActivityRows activities={visibleActivities} />}
+      {visibleActivities.length > 0 && (
+        <GroupedActivityRows activities={visibleActivities} openByDefault={LIVE_OPEN_GROUP_KINDS} />
+      )}
       {displayCurrentStep ? (
         <LiveStatusIndicator
           text={displayCurrentStep}

--- a/ui/src/pages/chat/ActivityTimeline.tsx
+++ b/ui/src/pages/chat/ActivityTimeline.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from "react";
 import {
   AlertTriangle,
   ArrowRightLeft,
@@ -9,32 +8,34 @@ import {
   FileText,
   Folder,
   Globe2,
+  ImageIcon,
   Loader2,
+  type LucideIcon,
   Pencil,
   Search,
   SquareTerminal,
-  type LucideIcon,
 } from "lucide-react";
+import { useEffect, useState } from "react";
 import { Badge } from "@/components/ui";
-import { cn } from "@/lib/utils";
 import type { Subagent } from "@/hooks/useApi";
-import { loadChatImageSource } from "@/lib/chatImages";
+import {
+  type ActivityGroupKind,
+  groupActivitiesForDisplay,
+  type LiveActivityItem,
+  mergeActivityLists,
+} from "@/lib/chatActivities";
 import { openChatImageLightbox } from "@/lib/chatImageLightbox";
+import { loadChatImageSource } from "@/lib/chatImages";
+import { cn } from "@/lib/utils";
+import { formatWorkedDuration } from "./assistantMetaModel";
 import {
   formatSandboxProviderLabel,
   getLatestInFlightStep,
   isGenericStatusLabel,
   isRawToolCallThought,
 } from "./chatModel";
-import {
-  groupActivitiesForDisplay,
-  type ActivityGroupKind,
-  mergeActivityLists,
-  type LiveActivityItem,
-} from "@/lib/chatActivities";
-import { SubagentIcon } from "./SubagentIcon";
-import { formatWorkedDuration } from "./assistantMetaModel";
 import { LiveStatusIndicator, LiveStatusOrb, LiveStatusText } from "./LiveStatusIndicator";
+import { SubagentIcon } from "./SubagentIcon";
 
 const GROUP_ICONS: Record<ActivityGroupKind, LucideIcon> = {
   read: FileText,
@@ -85,7 +86,7 @@ function ImageViewedThumbnail({ source, alt }: { source: string; alt: string }) 
       }}
       disabled={!displaySource}
       className={cn(
-        "block h-14 w-20 shrink-0 overflow-hidden rounded-md border border-white/10 bg-black/30",
+        "block h-28 w-44 shrink-0 overflow-hidden rounded-md border border-white/10 bg-black/30",
         displaySource && "cursor-zoom-in transition-opacity hover:opacity-90"
       )}
     >
@@ -111,7 +112,8 @@ function ActivityRow({ activity }: { activity: LiveActivityItem }) {
     );
   }
   const fullText = activity.fullText?.trim();
-  const expandable = Boolean(fullText && fullText !== activity.text.trim());
+  const hasImage = Boolean(activity.imageSource);
+  const expandable = Boolean(fullText && fullText !== activity.text.trim()) || hasImage;
   const content = expanded && fullText ? fullText : activity.text;
   const textContent = (
     <>
@@ -127,46 +129,60 @@ function ActivityRow({ activity }: { activity: LiveActivityItem }) {
           {formatSandboxProviderLabel(activity.sandboxProvider)}
         </span>
       )}
-      {expandable &&
-        (expanded ? (
-          <ChevronDown className="h-3 w-3 shrink-0 text-current opacity-60" />
-        ) : (
-          <ChevronRight className="h-3 w-3 shrink-0 text-current opacity-60" />
-        ))}
+      {expandable && (
+        <span className="flex h-[1.5em] shrink-0 items-center">
+          {expanded ? (
+            <ChevronDown className="h-3 w-3 text-current opacity-60" />
+          ) : (
+            <ChevronRight className="h-3 w-3 text-current opacity-60" />
+          )}
+        </span>
+      )}
     </>
   );
 
   return (
-    <div className="chat-activity-text flex items-start gap-2 px-0.5 text-gray-400">
-      <span className="flex h-[1.5em] shrink-0 items-center" data-testid="activity-row-icon">
-        {activity.toolName === "sessions_transfer" || activity.toolName === "__steering" ? (
-          <ArrowRightLeft className="h-3 w-3 text-current opacity-70" />
-        ) : activity.phase === "start" ? (
-          <LiveStatusOrb state="solving" size={20} className="opacity-70" />
-        ) : activity.phase === "result" ? (
-          <CheckCircle2 className="h-3 w-3 text-current opacity-70" />
+    <div>
+      <div className="chat-activity-text flex items-start gap-2 px-0.5 text-gray-400">
+        <span className="flex h-[1.5em] shrink-0 items-center" data-testid="activity-row-icon">
+          {activity.toolName === "sessions_transfer" || activity.toolName === "__steering" ? (
+            <ArrowRightLeft className="h-3 w-3 text-current opacity-70" />
+          ) : activity.phase === "start" ? (
+            <LiveStatusOrb state="solving" size={20} className="opacity-70" />
+          ) : activity.phase === "result" && hasImage ? (
+            <ImageIcon
+              className="h-3 w-3 text-current opacity-70"
+              data-testid="activity-image-icon"
+            />
+          ) : activity.phase === "result" ? (
+            <CheckCircle2 className="h-3 w-3 text-current opacity-70" />
+          ) : (
+            <AlertTriangle className="h-3 w-3 text-current opacity-70" />
+          )}
+        </span>
+        {expandable ? (
+          <button
+            type="button"
+            onClick={() => setExpanded((value) => !value)}
+            className="min-w-0 flex-1 cursor-pointer text-left text-inherit"
+            aria-expanded={expanded}
+            title={
+              expanded ? "Collapse" : hasImage ? "Show the viewed image" : "Show full tool call"
+            }
+          >
+            <span className="flex min-w-0 items-start gap-2">{textContent}</span>
+          </button>
         ) : (
-          <AlertTriangle className="h-3 w-3 text-current opacity-70" />
+          <div className="min-w-0 flex-1 flex items-center gap-2">{textContent}</div>
         )}
-      </span>
-      {expandable ? (
-        <button
-          type="button"
-          onClick={() => setExpanded((value) => !value)}
-          className="min-w-0 flex-1 cursor-pointer text-left text-inherit"
-          aria-expanded={expanded}
-          title={expanded ? "Collapse tool call" : "Show full tool call"}
-        >
-          <span className="flex min-w-0 items-start gap-2">{textContent}</span>
-        </button>
-      ) : (
-        <div className="min-w-0 flex-1 flex items-center gap-2">{textContent}</div>
-      )}
-      {activity.imageSource ? (
-        <ImageViewedThumbnail
-          source={activity.imageSource}
-          alt={activity.imageAlt || "Viewed image"}
-        />
+      </div>
+      {expanded && activity.imageSource ? (
+        <div className="ml-5 mt-1.5" data-testid="activity-image-viewed-preview">
+          <ImageViewedThumbnail
+            source={activity.imageSource}
+            alt={activity.imageAlt || "Viewed image"}
+          />
+        </div>
       ) : null}
     </div>
   );

--- a/ui/src/pages/chat/BotSidebar.tsx
+++ b/ui/src/pages/chat/BotSidebar.tsx
@@ -22,13 +22,15 @@ import {
   Wrench,
   X,
 } from "lucide-react";
-import { useDeferredValue, useMemo, useState, type ChangeEvent } from "react";
+import { useDeferredValue, useEffect, useMemo, useRef, useState, type ChangeEvent } from "react";
 import { useNavigate } from "react-router";
 import { Button, ConfirmDialog, Input, Modal, Select, Textarea } from "@/components/ui";
 import { useAgentSummaries, useDeleteSession, useProviders } from "@/hooks/useApi";
-import { botsApi, extractApiError } from "@/lib/api";
+import { botsApi, chatApi, extractApiError } from "@/lib/api";
 import { useI18n } from "@/lib/i18n";
 import { cn, formatRelativeTime } from "@/lib/utils";
+import { useUnreadDotColor } from "@/lib/unreadPreferences";
+import { connectStatusStream } from "@/lib/status-stream";
 import type { BotRosterItem } from "@/types";
 import { BotAvatar } from "./BotAvatar";
 import { resolveBotBaseAgentId, selectableBotBaseAgents } from "./botAgentSelection";
@@ -88,6 +90,7 @@ export function BotSidebar({
 }: BotSidebarProps) {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const unreadDotColor = useUnreadDotColor();
   const { t } = useI18n();
   const { data: providers = [] } = useProviders();
   const agentsQuery = useAgentSummaries();
@@ -109,6 +112,7 @@ export function BotSidebar({
   const [role, setRole] = useState<BotRoleId | "">("");
   const [teamBotIds, setTeamBotIds] = useState<string[]>([]);
   const deferredQuery = useDeferredValue(query);
+  const botsRefreshTimerRef = useRef<number | null>(null);
   const activeIds = useMemo(() => new Set(activeSessionIds), [activeSessionIds]);
   const botsQuery = useQuery({
     queryKey: ["bots"],
@@ -123,6 +127,30 @@ export function BotSidebar({
     refetchInterval: 10_000,
   });
   const allBots = botsQuery.data ?? [];
+  const refetchBots = botsQuery.refetch;
+  useEffect(() => {
+    const disconnect = connectStatusStream({
+      onEvent: (event) => {
+        if (!event || typeof event !== "object") return;
+        if (
+          event.type !== "status" &&
+          event.type !== "snapshot" &&
+          event.type !== "task_completed"
+        ) {
+          return;
+        }
+        if (botsRefreshTimerRef.current !== null) window.clearTimeout(botsRefreshTimerRef.current);
+        botsRefreshTimerRef.current = window.setTimeout(() => {
+          void refetchBots();
+          botsRefreshTimerRef.current = null;
+        }, 600);
+      },
+    });
+    return () => {
+      disconnect();
+      if (botsRefreshTimerRef.current !== null) window.clearTimeout(botsRefreshTimerRef.current);
+    };
+  }, [refetchBots]);
   const { data: allSessions = [] } = useSessions();
   const roomSessionList = useMemo(
     () => allSessions.filter((session) => isRoomSessionId(session.id)),
@@ -158,6 +186,17 @@ export function BotSidebar({
     void queryClient.invalidateQueries({ queryKey: ["agents"] });
   };
 
+  const markBotReadImmediately = (sessionId: string): void => {
+    queryClient.setQueryData<BotRosterItem[]>(["bots"], (bots) =>
+      bots?.map((bot) =>
+        bot.session_id === sessionId && bot.session
+          ? { ...bot, session: { ...bot.session, unread: false } }
+          : bot
+      )
+    );
+    void chatApi.markSessionRead(sessionId).then(refreshBots).catch(refreshBots);
+  };
+
   const openBot = useMutation({
     mutationFn: async (id: string) => {
       const response = await botsApi.ensureSession(id);
@@ -170,6 +209,7 @@ export function BotSidebar({
       refreshBots();
       navigate(buildSessionChatPath(sessionId));
     },
+    onError: refreshBots,
   });
   const createBot = useMutation({
     mutationFn: async () => {
@@ -468,7 +508,10 @@ export function BotSidebar({
                   >
                     <button
                       type="button"
-                      onClick={() => openBot.mutate(bot.id)}
+                      onClick={() => {
+                        markBotReadImmediately(bot.session_id);
+                        openBot.mutate(bot.id);
+                      }}
                       className="flex min-w-0 flex-1 items-center gap-2.5 rounded-xl px-2 py-2 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(var(--accent-primary),0.45)]"
                     >
                       <BotAvatar bot={bot} active={active} />
@@ -480,6 +523,14 @@ export function BotSidebar({
                           <span className="min-w-0 flex-1 truncate text-[13px] font-semibold text-[var(--text-primary)]">
                             {bot.name}
                           </span>
+                          {bot.session?.unread && !selected ? (
+                            <span
+                              className="h-2.5 w-2.5 shrink-0 rounded-full shadow-[0_0_0_2px_rgba(255,255,255,0.12)]"
+                              style={{ backgroundColor: unreadDotColor }}
+                              aria-label="Unread response"
+                              title="Unread response"
+                            />
+                          ) : null}
                           {bot.session?.updated_at ? (
                             <span className="shrink-0 text-[10px] text-[var(--text-subtle)]">
                               {formatRelativeTime(bot.session.updated_at).replace(" ago", "")}

--- a/ui/src/pages/chat/ChatImagePreview.tsx
+++ b/ui/src/pages/chat/ChatImagePreview.tsx
@@ -1,6 +1,10 @@
 import { ImageOff, LoaderCircle } from "lucide-react";
 import { useEffect, useState } from "react";
-import { loadChatImageSource, requiresAuthenticatedImageFetch } from "@/lib/chatImages";
+import {
+  loadChatImageSource,
+  peekChatImageSource,
+  requiresAuthenticatedImageFetch,
+} from "@/lib/chatImages";
 import { cn } from "@/lib/utils";
 
 interface ChatImagePreviewProps {
@@ -22,8 +26,8 @@ export function ChatImagePreview({
   containerClassName,
   onOpen,
 }: ChatImagePreviewProps) {
-  const [displaySource, setDisplaySource] = useState(() =>
-    requiresAuthenticatedImageFetch(source) ? "" : source
+  const [displaySource, setDisplaySource] = useState(
+    () => peekChatImageSource(source) ?? (requiresAuthenticatedImageFetch(source) ? "" : source)
   );
   const [failed, setFailed] = useState(false);
 
@@ -31,7 +35,9 @@ export function ChatImagePreview({
     let active = true;
     let revoke: (() => void) | undefined;
     setFailed(false);
-    setDisplaySource(requiresAuthenticatedImageFetch(source) ? "" : source);
+    setDisplaySource(
+      peekChatImageSource(source) ?? (requiresAuthenticatedImageFetch(source) ? "" : source)
+    );
     void loadChatImageSource(source)
       .then((loaded) => {
         if (!active) {

--- a/ui/src/pages/chat/FloatingBrowserPreview.tsx
+++ b/ui/src/pages/chat/FloatingBrowserPreview.tsx
@@ -1,5 +1,5 @@
+import { Eye, Globe } from "lucide-react";
 import { type ReactElement, useCallback, useState } from "react";
-import { Eye } from "lucide-react";
 import { ChatWorkspaceBrowser } from "./ChatWorkspaceBrowser";
 import { FloatingPreviewFrame } from "./FloatingPreviewFrame";
 import {
@@ -55,6 +55,9 @@ export function FloatingBrowserPreview({
     <FloatingPreviewFrame
       ariaLabel="Open live browser preview"
       bottomInset={bottomInset}
+      minimizeLabel="Minimize browser preview"
+      minimizedIcon={<Globe className="h-4 w-4" strokeWidth={2.2} />}
+      minimizedLabel="Restore browser preview"
       onActivate={onExpand}
       onHide={hide}
       storageKey={FLOATING_BROWSER_PREVIEW_STORAGE_KEY}

--- a/ui/src/pages/chat/FloatingComputerPreview.tsx
+++ b/ui/src/pages/chat/FloatingComputerPreview.tsx
@@ -1,14 +1,14 @@
-import { Eye, Loader2 } from "lucide-react";
+import { Eye, Loader2, MonitorSmartphone } from "lucide-react";
 import { type ReactElement, useCallback, useState } from "react";
 import { apiFetch } from "@/lib/auth";
 import { ChatWorkspaceComputer } from "./ChatWorkspaceComputer";
 import { FloatingPreviewFrame } from "./FloatingPreviewFrame";
-import { isComputerFocusUnavailableError } from "./floatingPreviewActivityModel";
 import {
   FLOATING_COMPUTER_PREVIEW_STORAGE_KEY,
   persistFloatingPreviewHidden,
   readFloatingPreviewHidden,
 } from "./floatingBrowserPreviewModel";
+import { isComputerFocusUnavailableError } from "./floatingPreviewActivityModel";
 
 interface FloatingComputerPreviewProps {
   bottomInset: number;
@@ -91,6 +91,9 @@ export function FloatingComputerPreview({
       ariaLabel={label}
       bottomInset={bottomInset}
       horizontal="left"
+      minimizeLabel="Minimize computer preview"
+      minimizedIcon={<MonitorSmartphone className="h-4 w-4" strokeWidth={2.2} />}
+      minimizedLabel="Restore computer preview"
       onActivate={focusApp}
       onHide={hide}
       storageKey={FLOATING_COMPUTER_PREVIEW_STORAGE_KEY}

--- a/ui/src/pages/chat/FloatingPreviewFrame.tsx
+++ b/ui/src/pages/chat/FloatingPreviewFrame.tsx
@@ -1,3 +1,4 @@
+import { Minus, X } from "lucide-react";
 import {
   type KeyboardEvent,
   type MouseEvent,
@@ -6,19 +7,22 @@ import {
   type ReactNode,
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from "react";
-import { X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import {
   clampFloatingBrowserPreviewRect,
   defaultFloatingBrowserPreviewRect,
-  isFloatingBrowserPreviewClick,
-  persistFloatingPreviewRect,
-  readFloatingPreviewRect,
+  FLOATING_PREVIEW_MINIMIZED_SIZE,
   type FloatingBrowserPreviewRect,
   type FloatingBrowserPreviewSize,
+  isFloatingBrowserPreviewClick,
+  persistFloatingPreviewMinimized,
+  persistFloatingPreviewRect,
+  readFloatingPreviewMinimized,
+  readFloatingPreviewRect,
 } from "./floatingBrowserPreviewModel";
 
 interface FloatingPreviewFrameProps {
@@ -27,6 +31,9 @@ interface FloatingPreviewFrameProps {
   children: ReactNode;
   hideLabel?: string;
   horizontal?: "left" | "right";
+  minimizeLabel?: string;
+  minimizedIcon: ReactNode;
+  minimizedLabel?: string;
   onActivate: () => void;
   onHide: () => void;
   storageKey: string;
@@ -42,6 +49,8 @@ interface FloatingPreviewGesture {
   moved: boolean;
 }
 
+const CONTROL_ATTRIBUTE = "data-floating-preview-control";
+
 function containerSize(element: HTMLElement | null): FloatingBrowserPreviewSize {
   const bounds = element?.getBoundingClientRect();
   return {
@@ -50,12 +59,19 @@ function containerSize(element: HTMLElement | null): FloatingBrowserPreviewSize 
   };
 }
 
+function isControlTarget(target: EventTarget | null): boolean {
+  return target instanceof Element && !!target.closest(`[${CONTROL_ATTRIBUTE}]`);
+}
+
 export function FloatingPreviewFrame({
   ariaLabel,
   bottomInset,
   children,
-  hideLabel = "Hide preview",
+  hideLabel = "Close preview",
   horizontal = "right",
+  minimizeLabel = "Minimize preview",
+  minimizedIcon,
+  minimizedLabel = "Restore preview",
   onActivate,
   onHide,
   storageKey,
@@ -67,26 +83,35 @@ export function FloatingPreviewFrame({
   const containerSizeRef = useRef<FloatingBrowserPreviewSize>({ width: 0, height: 0 });
   const [rect, setRect] = useState<FloatingBrowserPreviewRect | null>(null);
   const [dragging, setDragging] = useState(false);
+  const [minimized, setMinimized] = useState(() => readFloatingPreviewMinimized(storageKey));
+
+  const preferredSize = useMemo(
+    () =>
+      minimized
+        ? { width: FLOATING_PREVIEW_MINIMIZED_SIZE, height: FLOATING_PREVIEW_MINIMIZED_SIZE }
+        : undefined,
+    [minimized]
+  );
 
   const commitRect = useCallback(
     (next: FloatingBrowserPreviewRect): void => {
       setRect(next);
-      persistFloatingPreviewRect(storageKey, next);
+      if (!minimized) persistFloatingPreviewRect(storageKey, next);
     },
-    [storageKey]
+    [minimized, storageKey]
   );
 
   useEffect(() => {
     const container = frameRef.current?.parentElement;
     if (!container) return;
     const update = (): void => {
-      const size = containerSize(container);
-      containerSizeRef.current = size;
+      const bounds = containerSize(container);
+      containerSizeRef.current = bounds;
       setRect((current) => {
         const source = current ?? readFloatingPreviewRect(storageKey);
         return source
-          ? clampFloatingBrowserPreviewRect(size, source, bottomInset)
-          : defaultFloatingBrowserPreviewRect(size, bottomInset, horizontal);
+          ? clampFloatingBrowserPreviewRect(bounds, source, bottomInset, preferredSize)
+          : defaultFloatingBrowserPreviewRect(bounds, bottomInset, horizontal, preferredSize);
       });
     };
     update();
@@ -97,7 +122,7 @@ export function FloatingPreviewFrame({
     const observer = new ResizeObserver(update);
     observer.observe(container);
     return () => observer.disconnect();
-  }, [bottomInset, horizontal, storageKey]);
+  }, [bottomInset, horizontal, preferredSize, storageKey]);
 
   const updateGesture = useCallback(
     (pointerId: number, clientX: number, clientY: number): void => {
@@ -114,12 +139,18 @@ export function FloatingPreviewFrame({
             x: gesture.origin.x + deltaX,
             y: gesture.origin.y + deltaY,
           },
-          bottomInset
+          bottomInset,
+          preferredSize
         )
       );
     },
-    [bottomInset]
+    [bottomInset, preferredSize]
   );
+
+  const restore = useCallback((): void => {
+    persistFloatingPreviewMinimized(storageKey, false);
+    setMinimized(false);
+  }, [storageKey]);
 
   const finishGesture = useCallback(
     (pointerId: number): void => {
@@ -128,12 +159,14 @@ export function FloatingPreviewFrame({
       gestureRef.current = null;
       setDragging(false);
       setRect((current) => {
-        if (current) persistFloatingPreviewRect(storageKey, current);
+        if (current && !minimized) persistFloatingPreviewRect(storageKey, current);
         return current;
       });
-      if (!gesture.moved) onActivate();
+      if (gesture.moved) return;
+      if (minimized) restore();
+      else onActivate();
     },
-    [onActivate, storageKey]
+    [minimized, onActivate, restore, storageKey]
   );
 
   useEffect(() => {
@@ -153,7 +186,7 @@ export function FloatingPreviewFrame({
 
   const beginGesture = useCallback(
     (event: PointerEvent<HTMLElement>): void => {
-      if (!rect || event.button !== 0) return;
+      if (!rect || event.button !== 0 || isControlTarget(event.target)) return;
       event.preventDefault();
       event.stopPropagation();
       event.currentTarget.setPointerCapture(event.pointerId);
@@ -171,10 +204,11 @@ export function FloatingPreviewFrame({
 
   const handleKeyDown = useCallback(
     (event: KeyboardEvent<HTMLElement>): void => {
-      if (!rect) return;
+      if (!rect || isControlTarget(event.target)) return;
       if (event.key === "Enter" || event.key === " ") {
         event.preventDefault();
-        onActivate();
+        if (minimized) restore();
+        else onActivate();
         return;
       }
       const distance = event.shiftKey ? 32 : 12;
@@ -194,62 +228,112 @@ export function FloatingPreviewFrame({
         clampFloatingBrowserPreviewRect(
           containerSizeRef.current,
           { ...rect, x: rect.x + delta.x, y: rect.y + delta.y },
-          bottomInset
+          bottomInset,
+          preferredSize
         )
       );
     },
-    [bottomInset, commitRect, onActivate, rect]
+    [bottomInset, commitRect, minimized, onActivate, preferredSize, rect, restore]
   );
+
+  const stopControlGesture = useCallback((event: PointerEvent<HTMLButtonElement>): void => {
+    event.stopPropagation();
+  }, []);
 
   const handleHide = useCallback(
     (event: MouseEvent<HTMLButtonElement>): void => {
+      event.preventDefault();
       event.stopPropagation();
+      gestureRef.current = null;
+      setDragging(false);
       onHide();
     },
     [onHide]
   );
 
+  const handleMinimize = useCallback(
+    (event: MouseEvent<HTMLButtonElement>): void => {
+      event.preventDefault();
+      event.stopPropagation();
+      gestureRef.current = null;
+      setDragging(false);
+      persistFloatingPreviewMinimized(storageKey, true);
+      setMinimized(true);
+    },
+    [storageKey]
+  );
+
+  const fallbackStyle = {
+    [horizontal]: 16,
+    bottom: Math.max(16, bottomInset + 16),
+    width: minimized ? FLOATING_PREVIEW_MINIMIZED_SIZE : "min(260px, calc(100% - 24px))",
+    height: minimized ? FLOATING_PREVIEW_MINIMIZED_SIZE : "min(180px, calc(100% - 48px))",
+  } as const;
+
   return (
     <section
       ref={frameRef}
-      aria-label={ariaLabel}
+      aria-label={minimized ? minimizedLabel : ariaLabel}
       className={cn(
-        "glass-strong absolute z-40 min-h-0 touch-none overflow-hidden rounded-[16px] border border-[var(--glass-border)] shadow-[0_16px_48px_rgba(0,0,0,0.46)] outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--accent-primary))]",
+        "glass-strong absolute z-40 min-h-0 touch-none overflow-hidden border border-[var(--glass-border)] shadow-[0_16px_48px_rgba(0,0,0,0.46)] outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--accent-primary))]",
+        minimized ? "rounded-full" : "rounded-[16px]",
         dragging
           ? "cursor-grabbing select-none shadow-[0_22px_58px_rgba(0,0,0,0.56)]"
           : "cursor-grab transition-[box-shadow,transform] duration-150 hover:-translate-y-0.5"
       )}
+      data-minimized={minimized ? "true" : "false"}
       data-testid={testId}
       onKeyDown={handleKeyDown}
       onPointerDown={beginGesture}
       role="button"
       style={
-        rect
-          ? { left: rect.x, top: rect.y, width: rect.width, height: rect.height }
-          : {
-              [horizontal]: 16,
-              bottom: Math.max(16, bottomInset + 16),
-              width: "min(260px, calc(100% - 24px))",
-              height: "min(180px, calc(100% - 48px))",
-            }
+        rect ? { left: rect.x, top: rect.y, width: rect.width, height: rect.height } : fallbackStyle
       }
       tabIndex={0}
-      title={title}
+      title={minimized ? minimizedLabel : title}
     >
-      <div className="pointer-events-none h-full min-h-0 select-none" aria-hidden="true">
-        {children}
-      </div>
-      <button
-        type="button"
-        aria-label={hideLabel}
-        className="pointer-events-auto absolute right-2 top-2 z-50 flex h-6 w-6 items-center justify-center rounded-full border border-[var(--glass-border)] bg-black/45 text-white/80 transition-opacity duration-150 hover:bg-black/70 hover:text-white focus-visible:opacity-100"
-        onClick={handleHide}
-        onKeyDown={(event) => event.stopPropagation()}
-        onPointerDown={(event) => event.stopPropagation()}
-        title={hideLabel}
-      >
-        <X className="h-3.5 w-3.5" strokeWidth={2.4} />
-      </button>
+      {minimized ? (
+        <span
+          className="pointer-events-none flex h-full w-full items-center justify-center text-white/85"
+          data-testid={`${testId}-minimized`}
+        >
+          {minimizedIcon}
+        </span>
+      ) : (
+        <>
+          <div className="pointer-events-none h-full min-h-0 select-none" aria-hidden="true">
+            {children}
+          </div>
+          <div className="absolute right-1.5 top-1.5 z-50 flex items-center gap-1">
+            <button
+              type="button"
+              aria-label={minimizeLabel}
+              className="pointer-events-auto flex h-7 w-7 items-center justify-center rounded-full border border-[var(--glass-border)] bg-black/45 text-white/80 transition-colors duration-150 hover:bg-black/70 hover:text-white"
+              data-floating-preview-control="minimize"
+              data-testid={`${testId}-minimize`}
+              onClick={handleMinimize}
+              onKeyDown={(event) => event.stopPropagation()}
+              onPointerDown={stopControlGesture}
+              title={minimizeLabel}
+            >
+              <Minus className="h-3.5 w-3.5" strokeWidth={2.4} />
+            </button>
+            <button
+              type="button"
+              aria-label={hideLabel}
+              className="pointer-events-auto flex h-7 w-7 items-center justify-center rounded-full border border-[var(--glass-border)] bg-black/45 text-white/80 transition-colors duration-150 hover:bg-black/70 hover:text-white"
+              data-floating-preview-control="close"
+              data-testid={`${testId}-close`}
+              onClick={handleHide}
+              onKeyDown={(event) => event.stopPropagation()}
+              onPointerDown={stopControlGesture}
+              title={hideLabel}
+            >
+              <X className="h-3.5 w-3.5" strokeWidth={2.4} />
+            </button>
+          </div>
+        </>
+      )}
     </section>
   );
 }

--- a/ui/src/pages/chat/MultiChatWorkspace.tsx
+++ b/ui/src/pages/chat/MultiChatWorkspace.tsx
@@ -55,6 +55,7 @@ import {
   type ToolApprovalMode,
 } from "./ChatFollowUpControls";
 import type { ChatLightboxImage } from "./ChatImageLightbox";
+import { onOpenChatImageLightbox } from "@/lib/chatImageLightbox";
 import { ChatImageLightbox } from "./ChatImageLightbox";
 import { ChatMessageTimeline } from "./ChatMessageTimeline";
 import { isVisibleChatTranscriptMessage } from "./goalLoopPresentation";
@@ -961,6 +962,7 @@ export function MultiChatWorkspace() {
   const [pickerTargetIndex, setPickerTargetIndex] = useState<number | null>(null);
   const [openEnvironmentIds, setOpenEnvironmentIds] = useState<Set<string>>(() => new Set());
   const [lightboxImage, setLightboxImage] = useState<ChatLightboxImage | null>(null);
+  useEffect(() => onOpenChatImageLightbox(setLightboxImage), []);
   const [toolApprovalMode, setToolApprovalMode] = useState<ToolApprovalMode>("ask");
   const [savingToolApprovalMode, setSavingToolApprovalMode] = useState(false);
   const initializedRef = useRef(false);

--- a/ui/src/pages/chat/SessionSidebar.tsx
+++ b/ui/src/pages/chat/SessionSidebar.tsx
@@ -28,6 +28,7 @@ import {
 } from "react";
 import { createPortal } from "react-dom";
 import { useNavigate } from "react-router";
+import { useQueryClient } from "@tanstack/react-query";
 import { Button, Modal } from "@/components/ui";
 import { useTasks } from "@/hooks/useApi";
 import {
@@ -39,8 +40,10 @@ import {
   useSessions,
 } from "@/hooks/useChat";
 import { apiFetch } from "@/lib/auth";
+import { chatApi } from "@/lib/api";
 import { useI18n } from "@/lib/i18n";
 import { connectStatusStream } from "@/lib/status-stream";
+import { useUnreadDotColor } from "@/lib/unreadPreferences";
 import { cn } from "@/lib/utils";
 import type { SessionContextUsage, SessionTokenUsage, Task } from "@/types";
 import type { ChatMessage } from "./chatModel";
@@ -284,7 +287,9 @@ export function SessionsPanel({
 }: SessionsPanelProps) {
   const navigate = useNavigate();
   const { t } = useI18n();
+  const unreadDotColor = useUnreadDotColor();
   const { data: allSessions, isLoading, refetch } = useSessions();
+  const sessionQueryClient = useQueryClient();
   const sessions = useMemo(
     () => allSessions?.filter((session) => !isRoomSessionId(session.id)),
     [allSessions]
@@ -460,7 +465,22 @@ export function SessionsPanel({
     [onLoadSession]
   );
 
+  const markReadImmediately = (sessionId: string): void => {
+    sessionQueryClient.setQueriesData<Array<ChatSidebarSession>>(
+      { queryKey: ["sessions"] },
+      (sessions) =>
+        sessions?.map((session) =>
+          session.id === sessionId ? { ...session, unread: false } : session
+        )
+    );
+    void chatApi
+      .markSessionRead(sessionId)
+      .then(() => refetch())
+      .catch(() => refetch());
+  };
+
   const handleLoadSession = async (sessionId: string) => {
+    markReadImmediately(sessionId);
     if (placement === "main") {
       navigate(`/chat?session=${encodeURIComponent(sessionId)}`);
       return;
@@ -850,6 +870,14 @@ export function SessionsPanel({
                                 <span className="min-w-0 flex-1 truncate leading-none">
                                   {displayTitle}
                                 </span>
+                                {session.unread && !isSessionSelected ? (
+                                  <span
+                                    className="h-2.5 w-2.5 shrink-0 rounded-full shadow-[0_0_0_2px_rgba(255,255,255,0.12)]"
+                                    style={{ backgroundColor: unreadDotColor }}
+                                    aria-label="Unread response"
+                                    title="Unread response"
+                                  />
+                                ) : null}
                                 <span className="ml-1 flex h-full w-8 shrink-0 items-center justify-end text-[12px] font-medium leading-none text-gray-500">
                                   {isSessionActive ? (
                                     <Loader2 className="h-3 w-3 animate-spin text-gray-400" />

--- a/ui/src/pages/chat/chatModel.ts
+++ b/ui/src/pages/chat/chatModel.ts
@@ -572,6 +572,8 @@ export function normalizePersistedLiveActivityItem(value: unknown): LiveActivity
     toolName: typeof candidate.toolName === "string" ? candidate.toolName : undefined,
     toolCallId: typeof candidate.toolCallId === "string" ? candidate.toolCallId : undefined,
     sandboxProvider: normalizeSandboxProviderValue(candidate.sandboxProvider),
+    imageSource: typeof candidate.imageSource === "string" ? candidate.imageSource : undefined,
+    imageAlt: typeof candidate.imageAlt === "string" ? candidate.imageAlt : undefined,
   };
 }
 

--- a/ui/src/pages/chat/chatModel.ts
+++ b/ui/src/pages/chat/chatModel.ts
@@ -1,5 +1,7 @@
 import {
   finalizeCompletedActivities,
+  imageAltFromPath,
+  imageSourceFromPath,
   type LiveActivityItem,
   mergeActivityLists,
   normalizeActivityTextForPhase,
@@ -12,6 +14,7 @@ import type {
   SessionPlanSnapshot,
 } from "@/types";
 import { isGenericChatStatusLabel } from "../../../../shared/chat-status";
+import { formatStructuredToolActivityDetail } from "../../../../shared/tool-activity-detail";
 export interface ToolCall {
   id: string;
   name: string;
@@ -112,6 +115,7 @@ export interface StatusStreamEvent {
   toolName?: string;
   toolCallId?: string;
   sandboxProvider?: string;
+  imagePath?: string;
   toolPhase?: "start" | "result" | "error" | "blocked";
   durationMs?: number;
   type?: string;
@@ -125,6 +129,7 @@ export interface SessionStatusActivity {
   toolName?: string;
   toolCallId?: string;
   sandboxProvider?: string;
+  imagePath?: string;
 }
 
 export interface SessionStatusSnapshot {
@@ -835,6 +840,8 @@ export function applyLiveActivityEvent(
     toolName?: string;
     toolCallId?: string;
     sandboxProvider?: string;
+    imageSource?: string;
+    imageAlt?: string;
   }
 ): LiveActivityItem[] {
   const trimmed = event.text.trim();
@@ -878,6 +885,8 @@ export function applyLiveActivityEvent(
           toolName: normalizedToolName || candidate.toolName,
           toolCallId: normalizedToolCallId,
           sandboxProvider: normalizedSandboxProvider || candidate.sandboxProvider,
+          imageSource: event.imageSource || candidate.imageSource,
+          imageAlt: event.imageAlt || candidate.imageAlt,
         };
         return sortAndMergeActivities(updated);
       }
@@ -896,6 +905,8 @@ export function applyLiveActivityEvent(
           toolName: normalizedToolName,
           toolCallId: normalizedToolCallId || candidate.toolCallId,
           sandboxProvider: normalizedSandboxProvider || candidate.sandboxProvider,
+          imageSource: event.imageSource || candidate.imageSource,
+          imageAlt: event.imageAlt || candidate.imageAlt,
         };
         return sortAndMergeActivities(updated);
       }
@@ -913,6 +924,8 @@ export function applyLiveActivityEvent(
         toolName: normalizedToolName || candidate.toolName,
         toolCallId: normalizedToolCallId || candidate.toolCallId,
         sandboxProvider: normalizedSandboxProvider || candidate.sandboxProvider,
+        imageSource: event.imageSource || candidate.imageSource,
+        imageAlt: event.imageAlt || candidate.imageAlt,
       };
       return sortAndMergeActivities(updated);
     }
@@ -944,6 +957,8 @@ export function applyLiveActivityEvent(
       toolName: normalizedToolName || undefined,
       toolCallId: normalizedToolCallId || undefined,
       sandboxProvider: normalizedSandboxProvider,
+      imageSource: event.imageSource,
+      imageAlt: event.imageAlt,
     },
   ]);
 }
@@ -1031,6 +1046,8 @@ export function formatToolIntent(
   phase: "start" | "result" | "error" | "blocked",
   fallbackDetail?: string
 ): string {
+  const structuredDetail = formatStructuredToolActivityDetail(toolName, args, phase);
+  if (structuredDetail) return structuredDetail;
   if (fallbackDetail && fallbackDetail.trim()) {
     const normalizedFallback = fallbackDetail.trim();
     if (!isGenericStatusLabel(normalizedFallback)) {
@@ -1237,6 +1254,8 @@ export function toLiveActivityItems(
       toolName: activity.toolName,
       toolCallId: activity.toolCallId,
       sandboxProvider: normalizeSandboxProviderValue(activity.sandboxProvider),
+      imageSource: imageSourceFromPath(activity.imagePath),
+      imageAlt: imageAltFromPath(activity.imagePath),
     }));
 }
 

--- a/ui/src/pages/chat/chatModel.ts
+++ b/ui/src/pages/chat/chatModel.ts
@@ -577,8 +577,18 @@ export function normalizePersistedLiveActivityItem(value: unknown): LiveActivity
     toolName: typeof candidate.toolName === "string" ? candidate.toolName : undefined,
     toolCallId: typeof candidate.toolCallId === "string" ? candidate.toolCallId : undefined,
     sandboxProvider: normalizeSandboxProviderValue(candidate.sandboxProvider),
-    imageSource: typeof candidate.imageSource === "string" ? candidate.imageSource : undefined,
-    imageAlt: typeof candidate.imageAlt === "string" ? candidate.imageAlt : undefined,
+    imageSource:
+      typeof candidate.imageSource === "string"
+        ? candidate.imageSource
+        : imageSourceFromPath(
+            typeof candidate.imagePath === "string" ? candidate.imagePath : undefined
+          ),
+    imageAlt:
+      typeof candidate.imageAlt === "string"
+        ? candidate.imageAlt
+        : imageAltFromPath(
+            typeof candidate.imagePath === "string" ? candidate.imagePath : undefined
+          ),
   };
 }
 

--- a/ui/src/pages/chat/chatModel.ts
+++ b/ui/src/pages/chat/chatModel.ts
@@ -13,8 +13,17 @@ import type {
   SessionPlanItem,
   SessionPlanSnapshot,
 } from "@/types";
-import { isGenericChatStatusLabel } from "../../../../shared/chat-status";
 import { formatStructuredToolActivityDetail } from "../../../../shared/tool-activity-detail";
+import { isGenericStatusLabel, normalizeSandboxProviderValue } from "./liveActivityModel";
+
+export {
+  applyLiveActivityEvent,
+  formatSandboxProviderLabel,
+  getLatestInFlightStep,
+  isGenericStatusLabel,
+  isMeaningfulThoughtDetail,
+  normalizeSandboxProviderValue,
+} from "./liveActivityModel";
 export interface ToolCall {
   id: string;
   name: string;
@@ -820,159 +829,6 @@ export function toActivityPath(path: string): string {
   return segments[segments.length - 1] || normalized;
 }
 
-export function isGenericStatusLabel(detail: string): boolean {
-  return isGenericChatStatusLabel(detail);
-}
-
-export function isMeaningfulThoughtDetail(detail: string): boolean {
-  const normalized = detail.trim().toLowerCase();
-  if (!normalized) return false;
-  return !isGenericStatusLabel(normalized);
-}
-
-export function getLatestInFlightStep(activities: LiveActivityItem[]): string | null {
-  for (let index = activities.length - 1; index >= 0; index -= 1) {
-    const activity = activities[index];
-    if (!activity || activity.phase !== "start") continue;
-    const step = activity.text?.trim() || "";
-    if (!step || isGenericStatusLabel(step)) continue;
-    return step;
-  }
-  return null;
-}
-
-export function applyLiveActivityEvent(
-  previous: LiveActivityItem[],
-  event: {
-    phase: "start" | "result" | "error" | "blocked";
-    text: string;
-    timestamp?: number;
-    toolName?: string;
-    toolCallId?: string;
-    sandboxProvider?: string;
-    imageSource?: string;
-    imageAlt?: string;
-  }
-): LiveActivityItem[] {
-  const trimmed = event.text.trim();
-  if (!trimmed) return previous;
-
-  const normalizedText = normalizeActivityTextForPhase(trimmed, event.phase);
-  if (isGenericStatusLabel(normalizedText)) return previous;
-  const nextTimestamp =
-    typeof event.timestamp === "number" && Number.isFinite(event.timestamp)
-      ? event.timestamp
-      : Date.now();
-  const normalizedToolName =
-    typeof event.toolName === "string" ? event.toolName.trim().toLowerCase() : "";
-  const normalizedToolCallId =
-    typeof event.toolCallId === "string" && event.toolCallId.trim()
-      ? event.toolCallId.trim().toLowerCase()
-      : "";
-  const normalizedSandboxProvider = normalizeSandboxProviderValue(event.sandboxProvider);
-  const nextId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-  const sortAndMergeActivities = (items: LiveActivityItem[]): LiveActivityItem[] =>
-    mergeActivityLists(
-      [],
-      [...items].sort((left, right) =>
-        left.timestamp === right.timestamp
-          ? left.id.localeCompare(right.id)
-          : left.timestamp - right.timestamp
-      )
-    );
-
-  if (event.phase !== "start") {
-    if (normalizedToolCallId) {
-      for (let index = previous.length - 1; index >= 0; index -= 1) {
-        const candidate = previous[index];
-        if (candidate.phase !== "start") continue;
-        if ((candidate.toolCallId || "").trim().toLowerCase() !== normalizedToolCallId) continue;
-        const updated = [...previous];
-        updated[index] = {
-          ...candidate,
-          phase: event.phase,
-          text: normalizedText,
-          toolName: normalizedToolName || candidate.toolName,
-          toolCallId: normalizedToolCallId,
-          sandboxProvider: normalizedSandboxProvider || candidate.sandboxProvider,
-          imageSource: event.imageSource || candidate.imageSource,
-          imageAlt: event.imageAlt || candidate.imageAlt,
-        };
-        return sortAndMergeActivities(updated);
-      }
-    }
-
-    if (normalizedToolName) {
-      for (let index = previous.length - 1; index >= 0; index -= 1) {
-        const candidate = previous[index];
-        if (candidate.phase !== "start") continue;
-        if ((candidate.toolName || "").trim().toLowerCase() !== normalizedToolName) continue;
-        const updated = [...previous];
-        updated[index] = {
-          ...candidate,
-          phase: event.phase,
-          text: normalizedText,
-          toolName: normalizedToolName,
-          toolCallId: normalizedToolCallId || candidate.toolCallId,
-          sandboxProvider: normalizedSandboxProvider || candidate.sandboxProvider,
-          imageSource: event.imageSource || candidate.imageSource,
-          imageAlt: event.imageAlt || candidate.imageAlt,
-        };
-        return sortAndMergeActivities(updated);
-      }
-    }
-
-    for (let index = previous.length - 1; index >= 0; index -= 1) {
-      const candidate = previous[index];
-      if (candidate.phase !== "start") continue;
-      if (normalizeActivityTextForPhase(candidate.text, event.phase) !== normalizedText) continue;
-      const updated = [...previous];
-      updated[index] = {
-        ...candidate,
-        phase: event.phase,
-        text: normalizedText,
-        toolName: normalizedToolName || candidate.toolName,
-        toolCallId: normalizedToolCallId || candidate.toolCallId,
-        sandboxProvider: normalizedSandboxProvider || candidate.sandboxProvider,
-        imageSource: event.imageSource || candidate.imageSource,
-        imageAlt: event.imageAlt || candidate.imageAlt,
-      };
-      return sortAndMergeActivities(updated);
-    }
-  }
-
-  const previousLast = previous[previous.length - 1];
-  if (
-    previousLast &&
-    previousLast.phase === event.phase &&
-    normalizeActivityTextForPhase(previousLast.text, event.phase) === normalizedText &&
-    (normalizedToolCallId
-      ? (previousLast.toolCallId || "").trim().toLowerCase() === normalizedToolCallId
-      : true) &&
-    (normalizedToolName
-      ? (previousLast.toolName || "").trim().toLowerCase() === normalizedToolName
-      : true) &&
-    nextTimestamp - previousLast.timestamp < 750
-  ) {
-    return previous;
-  }
-
-  return sortAndMergeActivities([
-    ...previous,
-    {
-      id: nextId,
-      phase: event.phase,
-      text: normalizedText,
-      timestamp: nextTimestamp,
-      toolName: normalizedToolName || undefined,
-      toolCallId: normalizedToolCallId || undefined,
-      sandboxProvider: normalizedSandboxProvider,
-      imageSource: event.imageSource,
-      imageAlt: event.imageAlt,
-    },
-  ]);
-}
-
 export function normalizeSnapshotActivities(
   activities: LiveActivityItem[],
   status: string
@@ -1269,6 +1125,18 @@ export function toLiveActivityItems(
     }));
 }
 
+export function latestAssistantMessageKey(messages: readonly ChatMessage[]): string | null {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (message?.role !== "assistant") continue;
+    const messageId = typeof message.message_id === "string" ? message.message_id.trim() : "";
+    if (messageId) return messageId;
+    const timestamp = typeof message.timestamp === "string" ? message.timestamp.trim() : "";
+    return timestamp || `assistant-${index}`;
+  }
+  return null;
+}
+
 export function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
 }
@@ -1291,28 +1159,6 @@ export function tryParseJsonRecord(value: unknown): unknown {
   } catch {
     return value;
   }
-}
-
-export function normalizeSandboxProviderValue(value: unknown): string | undefined {
-  if (typeof value !== "string") return undefined;
-  const normalized = value.trim().toLowerCase();
-  if (
-    normalized === "apple_sandbox" ||
-    normalized === "podman" ||
-    normalized === "docker" ||
-    normalized === "host"
-  ) {
-    return normalized;
-  }
-  return undefined;
-}
-
-export function formatSandboxProviderLabel(provider: string): string {
-  if (provider === "apple_sandbox") return "Apple Sandbox";
-  if (provider === "podman") return "Podman";
-  if (provider === "docker") return "Docker";
-  if (provider === "host") return "Host";
-  return provider;
 }
 
 export function resolveToolCallSandboxProvider(toolCall: ToolCall): string | undefined {

--- a/ui/src/pages/chat/floatingBrowserPreviewModel.ts
+++ b/ui/src/pages/chat/floatingBrowserPreviewModel.ts
@@ -25,6 +25,7 @@ export const FLOATING_BROWSER_PREVIEW_GAP = 12;
 export const FLOATING_BROWSER_PREVIEW_WIDTH = 260;
 export const FLOATING_BROWSER_PREVIEW_HEIGHT = 180;
 export const FLOATING_BROWSER_PREVIEW_CLICK_DISTANCE = 6;
+export const FLOATING_PREVIEW_MINIMIZED_SIZE = 44;
 
 function finitePositive(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value) && value > 0;
@@ -64,31 +65,32 @@ export function parseFloatingBrowserPreviewRect(
 export function defaultFloatingBrowserPreviewRect(
   container: FloatingBrowserPreviewSize,
   bottomInset: number,
-  horizontal: "left" | "right" = "right"
+  horizontal: "left" | "right" = "right",
+  preferredSize?: FloatingBrowserPreviewSize
 ): FloatingBrowserPreviewRect {
+  const width = preferredSize?.width ?? FLOATING_BROWSER_PREVIEW_WIDTH;
+  const height = preferredSize?.height ?? FLOATING_BROWSER_PREVIEW_HEIGHT;
   return clampFloatingBrowserPreviewRect(
     container,
     {
       x:
         horizontal === "left"
           ? FLOATING_BROWSER_PREVIEW_GAP
-          : container.width - FLOATING_BROWSER_PREVIEW_WIDTH - FLOATING_BROWSER_PREVIEW_GAP,
-      y:
-        container.height -
-        Math.max(0, bottomInset) -
-        FLOATING_BROWSER_PREVIEW_HEIGHT -
-        FLOATING_BROWSER_PREVIEW_GAP,
-      width: FLOATING_BROWSER_PREVIEW_WIDTH,
-      height: FLOATING_BROWSER_PREVIEW_HEIGHT,
+          : container.width - width - FLOATING_BROWSER_PREVIEW_GAP,
+      y: container.height - Math.max(0, bottomInset) - height - FLOATING_BROWSER_PREVIEW_GAP,
+      width,
+      height,
     },
-    bottomInset
+    bottomInset,
+    preferredSize
   );
 }
 
 export function clampFloatingBrowserPreviewRect(
   container: FloatingBrowserPreviewSize,
   rect: FloatingBrowserPreviewRect,
-  bottomInset: number
+  bottomInset: number,
+  preferredSize?: FloatingBrowserPreviewSize
 ): FloatingBrowserPreviewRect {
   const containerWidth = Math.max(0, container.width);
   const containerHeight = Math.max(0, container.height);
@@ -98,8 +100,8 @@ export function clampFloatingBrowserPreviewRect(
     0,
     containerHeight - reservedBottom - FLOATING_BROWSER_PREVIEW_GAP * 2
   );
-  const width = Math.min(maximumWidth, FLOATING_BROWSER_PREVIEW_WIDTH);
-  const height = Math.min(maximumHeight, FLOATING_BROWSER_PREVIEW_HEIGHT);
+  const width = Math.min(maximumWidth, preferredSize?.width ?? FLOATING_BROWSER_PREVIEW_WIDTH);
+  const height = Math.min(maximumHeight, preferredSize?.height ?? FLOATING_BROWSER_PREVIEW_HEIGHT);
   const maximumX = Math.max(
     FLOATING_BROWSER_PREVIEW_GAP,
     containerWidth - width - FLOATING_BROWSER_PREVIEW_GAP
@@ -164,6 +166,23 @@ export function persistFloatingPreviewRect(
 ): void {
   try {
     window.localStorage.setItem(storageKey, JSON.stringify(rect));
+  } catch {
+    return;
+  }
+}
+
+export function readFloatingPreviewMinimized(storageKey: string): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(`${storageKey}:minimized`) === "true";
+  } catch {
+    return false;
+  }
+}
+
+export function persistFloatingPreviewMinimized(storageKey: string, minimized: boolean): void {
+  try {
+    window.localStorage.setItem(`${storageKey}:minimized`, minimized ? "true" : "false");
   } catch {
     return;
   }

--- a/ui/src/pages/chat/liveActivityModel.ts
+++ b/ui/src/pages/chat/liveActivityModel.ts
@@ -1,0 +1,189 @@
+import {
+  type LiveActivityItem,
+  mergeActivityLists,
+  normalizeActivityTextForPhase,
+} from "@/lib/chatActivities";
+import { isGenericChatStatusLabel } from "../../../../shared/chat-status";
+
+export function isGenericStatusLabel(detail: string): boolean {
+  return isGenericChatStatusLabel(detail);
+}
+
+export function isMeaningfulThoughtDetail(detail: string): boolean {
+  const normalized = detail.trim().toLowerCase();
+  if (!normalized) return false;
+  return !isGenericStatusLabel(normalized);
+}
+
+export function getLatestInFlightStep(activities: LiveActivityItem[]): string | null {
+  for (let index = activities.length - 1; index >= 0; index -= 1) {
+    const activity = activities[index];
+    if (!activity || activity.phase !== "start") continue;
+    const step = activity.text?.trim() || "";
+    if (!step || isGenericStatusLabel(step)) continue;
+    return step;
+  }
+  return null;
+}
+
+export function applyLiveActivityEvent(
+  previous: LiveActivityItem[],
+  event: {
+    phase: "start" | "result" | "error" | "blocked";
+    text: string;
+    timestamp?: number;
+    toolName?: string;
+    toolCallId?: string;
+    sandboxProvider?: string;
+    imageSource?: string;
+    imageAlt?: string;
+    runId?: string;
+    sequence?: number;
+  }
+): LiveActivityItem[] {
+  const trimmed = event.text.trim();
+  if (!trimmed) return previous;
+
+  const normalizedText = normalizeActivityTextForPhase(trimmed, event.phase);
+  if (isGenericStatusLabel(normalizedText)) return previous;
+  const nextTimestamp =
+    typeof event.timestamp === "number" && Number.isFinite(event.timestamp)
+      ? event.timestamp
+      : Date.now();
+  const normalizedToolName =
+    typeof event.toolName === "string" ? event.toolName.trim().toLowerCase() : "";
+  const normalizedToolCallId =
+    typeof event.toolCallId === "string" && event.toolCallId.trim()
+      ? event.toolCallId.trim().toLowerCase()
+      : "";
+  const normalizedSandboxProvider = normalizeSandboxProviderValue(event.sandboxProvider);
+  const nextId =
+    typeof event.runId === "string" &&
+    event.runId.trim() &&
+    typeof event.sequence === "number" &&
+    Number.isFinite(event.sequence)
+      ? `${event.runId.trim()}:${event.sequence}`
+      : `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const sortAndMergeActivities = (items: LiveActivityItem[]): LiveActivityItem[] =>
+    mergeActivityLists(
+      [],
+      [...items].sort((left, right) =>
+        left.timestamp === right.timestamp
+          ? left.id.localeCompare(right.id)
+          : left.timestamp - right.timestamp
+      )
+    );
+
+  if (event.phase !== "start") {
+    if (normalizedToolCallId) {
+      for (let index = previous.length - 1; index >= 0; index -= 1) {
+        const candidate = previous[index];
+        if (candidate.phase !== "start") continue;
+        if ((candidate.toolCallId || "").trim().toLowerCase() !== normalizedToolCallId) continue;
+        const updated = [...previous];
+        updated[index] = {
+          ...candidate,
+          phase: event.phase,
+          text: normalizedText,
+          toolName: normalizedToolName || candidate.toolName,
+          toolCallId: normalizedToolCallId,
+          sandboxProvider: normalizedSandboxProvider || candidate.sandboxProvider,
+          imageSource: event.imageSource || candidate.imageSource,
+          imageAlt: event.imageAlt || candidate.imageAlt,
+        };
+        return sortAndMergeActivities(updated);
+      }
+    }
+
+    if (normalizedToolName) {
+      for (let index = previous.length - 1; index >= 0; index -= 1) {
+        const candidate = previous[index];
+        if (candidate.phase !== "start") continue;
+        if ((candidate.toolName || "").trim().toLowerCase() !== normalizedToolName) continue;
+        const updated = [...previous];
+        updated[index] = {
+          ...candidate,
+          phase: event.phase,
+          text: normalizedText,
+          toolName: normalizedToolName,
+          toolCallId: normalizedToolCallId || candidate.toolCallId,
+          sandboxProvider: normalizedSandboxProvider || candidate.sandboxProvider,
+          imageSource: event.imageSource || candidate.imageSource,
+          imageAlt: event.imageAlt || candidate.imageAlt,
+        };
+        return sortAndMergeActivities(updated);
+      }
+    }
+
+    for (let index = previous.length - 1; index >= 0; index -= 1) {
+      const candidate = previous[index];
+      if (candidate.phase !== "start") continue;
+      if (normalizeActivityTextForPhase(candidate.text, event.phase) !== normalizedText) continue;
+      const updated = [...previous];
+      updated[index] = {
+        ...candidate,
+        phase: event.phase,
+        text: normalizedText,
+        toolName: normalizedToolName || candidate.toolName,
+        toolCallId: normalizedToolCallId || candidate.toolCallId,
+        sandboxProvider: normalizedSandboxProvider || candidate.sandboxProvider,
+        imageSource: event.imageSource || candidate.imageSource,
+        imageAlt: event.imageAlt || candidate.imageAlt,
+      };
+      return sortAndMergeActivities(updated);
+    }
+  }
+
+  const previousLast = previous[previous.length - 1];
+  if (
+    previousLast &&
+    previousLast.phase === event.phase &&
+    normalizeActivityTextForPhase(previousLast.text, event.phase) === normalizedText &&
+    (normalizedToolCallId
+      ? (previousLast.toolCallId || "").trim().toLowerCase() === normalizedToolCallId
+      : true) &&
+    (normalizedToolName
+      ? (previousLast.toolName || "").trim().toLowerCase() === normalizedToolName
+      : true) &&
+    nextTimestamp - previousLast.timestamp < 750
+  ) {
+    return previous;
+  }
+
+  return sortAndMergeActivities([
+    ...previous,
+    {
+      id: nextId,
+      phase: event.phase,
+      text: normalizedText,
+      timestamp: nextTimestamp,
+      toolName: normalizedToolName || undefined,
+      toolCallId: normalizedToolCallId || undefined,
+      sandboxProvider: normalizedSandboxProvider,
+      imageSource: event.imageSource,
+      imageAlt: event.imageAlt,
+    },
+  ]);
+}
+
+export function normalizeSandboxProviderValue(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const normalized = value.trim().toLowerCase();
+  if (
+    normalized === "apple_sandbox" ||
+    normalized === "podman" ||
+    normalized === "docker" ||
+    normalized === "host"
+  ) {
+    return normalized;
+  }
+  return undefined;
+}
+
+export function formatSandboxProviderLabel(provider: string): string {
+  if (provider === "apple_sandbox") return "Apple Sandbox";
+  if (provider === "podman") return "Podman";
+  if (provider === "docker") return "Docker";
+  if (provider === "host") return "Host";
+  return provider;
+}

--- a/ui/src/pages/chat/multiChatLiveStatus.ts
+++ b/ui/src/pages/chat/multiChatLiveStatus.ts
@@ -1,10 +1,9 @@
-import type { LiveActivityItem } from "@/lib/chatActivities";
+import { imageAltFromPath, imageSourceFromPath, type LiveActivityItem } from "@/lib/chatActivities";
 import {
   type StatusSessionSnapshot,
   type StatusStreamStatusEvent,
   type StreamAgentStatus,
 } from "@/lib/status-stream";
-import { isRunEndingStatus, isSteeringHandoffStatus } from "./sessionRunStatus";
 import {
   applyLiveActivityEvent,
   formatToolIntent,
@@ -16,6 +15,7 @@ import {
   resolveStatusSnapshotActivities,
   toLiveActivityItems,
 } from "./chatModel";
+import { isRunEndingStatus, isSteeringHandoffStatus } from "./sessionRunStatus";
 
 export type MultiChatLiveStatusValue = "thinking" | "generating" | "compacting" | "idle";
 
@@ -160,6 +160,8 @@ export function projectMultiChatStatusEvent(
       toolName: event.toolName,
       toolCallId: event.toolCallId,
       sandboxProvider: event.sandboxProvider,
+      imageSource: imageSourceFromPath(event.imagePath),
+      imageAlt: imageAltFromPath(event.imagePath),
     });
     liveStatus = "thinking";
     currentStep =

--- a/ui/src/pages/chat/multiChatLiveStatus.ts
+++ b/ui/src/pages/chat/multiChatLiveStatus.ts
@@ -162,6 +162,8 @@ export function projectMultiChatStatusEvent(
       sandboxProvider: event.sandboxProvider,
       imageSource: imageSourceFromPath(event.imagePath),
       imageAlt: imageAltFromPath(event.imagePath),
+      runId: event.runId,
+      sequence: event.sequence,
     });
     liveStatus = "thinking";
     currentStep =

--- a/ui/src/pages/chat/sessionGrouping.ts
+++ b/ui/src/pages/chat/sessionGrouping.ts
@@ -13,6 +13,7 @@ export interface ChatSidebarSession {
   updated_at?: string;
   workspace_dir?: string | null;
   pinned?: boolean;
+  unread?: boolean;
   message_count?: number;
   last_message?: { role: string; content: string } | null;
 }

--- a/ui/src/pages/chat/useBotRoster.ts
+++ b/ui/src/pages/chat/useBotRoster.ts
@@ -1,0 +1,20 @@
+import { botsApi, extractApiError } from "@/lib/api";
+import type { BotRosterItem } from "@/types";
+import { useQuery } from "@tanstack/react-query";
+
+export function useBotRoster(): BotRosterItem[] {
+  return (
+    useQuery<BotRosterItem[]>({
+      queryKey: ["bots"],
+      queryFn: async () => {
+        const response = await botsApi.list();
+        if (!response.success || !response.data) {
+          throw new Error(extractApiError(response, "Could not load bots"));
+        }
+        return response.data.bots;
+      },
+      staleTime: 5_000,
+      refetchInterval: 10_000,
+    }).data ?? []
+  );
+}

--- a/ui/src/pages/chat/useChatLiveSessionRuntime.ts
+++ b/ui/src/pages/chat/useChatLiveSessionRuntime.ts
@@ -1,7 +1,15 @@
+import {
+  type Dispatch,
+  type RefObject,
+  type SetStateAction,
+  useCallback,
+  useEffect,
+  useRef,
+} from "react";
 import type { LoadedChatSession } from "@/hooks/useChat";
 import { chatApi } from "@/lib/api";
 import type { LiveActivityItem } from "@/lib/chatActivities";
-import { mergeActivityLists } from "@/lib/chatActivities";
+import { imageAltFromPath, imageSourceFromPath, mergeActivityLists } from "@/lib/chatActivities";
 import {
   loadLatestTranscript,
   loadPersistedCompletion,
@@ -14,16 +22,8 @@ import {
   type StatusStreamStatusEvent,
   type StatusStreamTokenEvent,
 } from "@/lib/status-stream";
-import { isDelegatedWaitStatusLabel } from "../../../../shared/chat-status";
 import type { SessionContextUsage, SessionTokenUsage } from "@/types";
-import {
-  type Dispatch,
-  type RefObject,
-  type SetStateAction,
-  useCallback,
-  useEffect,
-  useRef,
-} from "react";
+import { isDelegatedWaitStatusLabel } from "../../../../shared/chat-status";
 import type { SessionEventIdentity } from "../../../../shared/session-event-order";
 import {
   applyLiveActivityEvent,
@@ -53,7 +53,6 @@ import {
   readCachedOptimisticPendingMessages,
   writeCachedOptimisticPendingMessages,
 } from "./pendingQueueCache";
-import { isRunEndingStatus, isSteeringHandoffStatus } from "./sessionRunStatus";
 import {
   materializedPendingChatIds,
   mergePendingChatMessages,
@@ -61,6 +60,7 @@ import {
   removeHandedOffPendingChatMessage,
   resolveHandedOffPendingChatId,
 } from "./pendingQueueState";
+import { isRunEndingStatus, isSteeringHandoffStatus } from "./sessionRunStatus";
 
 type LiveStatusSnapshotLike = StatusSessionSnapshot | SessionStatusSnapshot;
 type LiveStatus = "thinking" | "generating" | "compacting" | "idle";
@@ -227,7 +227,9 @@ export function useChatLiveSessionRuntime({
       toolName?: string,
       eventTimestamp?: number,
       toolCallId?: string,
-      sandboxProvider?: string
+      sandboxProvider?: string,
+      imageSource?: string,
+      imageAlt?: string
     ) => {
       const applyEvent = (previous: LiveActivityItem[]): LiveActivityItem[] =>
         applyLiveActivityEvent(previous, {
@@ -237,6 +239,8 @@ export function useChatLiveSessionRuntime({
           toolName,
           toolCallId,
           sandboxProvider,
+          imageSource,
+          imageAlt,
         });
 
       runActivityBufferRef.current = applyEvent(runActivityBufferRef.current);
@@ -1186,7 +1190,9 @@ export function useChatLiveSessionRuntime({
             payload.toolName,
             eventTimestamp,
             payload.toolCallId,
-            payload.sandboxProvider
+            payload.sandboxProvider,
+            imageSourceFromPath(payload.imagePath),
+            imageAltFromPath(payload.imagePath)
           );
           if (phase === "start") {
             setLiveStatus("thinking");

--- a/ui/src/pages/chat/useChatLiveSessionRuntime.ts
+++ b/ui/src/pages/chat/useChatLiveSessionRuntime.ts
@@ -229,7 +229,9 @@ export function useChatLiveSessionRuntime({
       toolCallId?: string,
       sandboxProvider?: string,
       imageSource?: string,
-      imageAlt?: string
+      imageAlt?: string,
+      runId?: string,
+      sequence?: number
     ) => {
       const applyEvent = (previous: LiveActivityItem[]): LiveActivityItem[] =>
         applyLiveActivityEvent(previous, {
@@ -241,6 +243,8 @@ export function useChatLiveSessionRuntime({
           sandboxProvider,
           imageSource,
           imageAlt,
+          runId,
+          sequence,
         });
 
       runActivityBufferRef.current = applyEvent(runActivityBufferRef.current);
@@ -1192,7 +1196,9 @@ export function useChatLiveSessionRuntime({
             payload.toolCallId,
             payload.sandboxProvider,
             imageSourceFromPath(payload.imagePath),
-            imageAltFromPath(payload.imagePath)
+            imageAltFromPath(payload.imagePath),
+            payload.runId,
+            payload.sequence
           );
           if (phase === "start") {
             setLiveStatus("thinking");

--- a/ui/src/pages/chat/useSessionReadAcknowledgement.ts
+++ b/ui/src/pages/chat/useSessionReadAcknowledgement.ts
@@ -1,18 +1,22 @@
-import { chatApi } from "@/lib/api";
 import { useQueryClient } from "@tanstack/react-query";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
+import { chatApi } from "@/lib/api";
 
 export function useSessionReadAcknowledgement(
   sessionId: string | null,
-  messageCount: number
+  latestAssistantMessageKey: string | null
 ): void {
   const queryClient = useQueryClient();
+  const acknowledgedRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (!sessionId) return;
+    const acknowledgementKey = `${sessionId}:${latestAssistantMessageKey ?? ""}`;
+    if (acknowledgedRef.current === acknowledgementKey) return;
+    acknowledgedRef.current = acknowledgementKey;
     void chatApi.markSessionRead(sessionId).then(() => {
       void queryClient.invalidateQueries({ queryKey: ["sessions"] });
       void queryClient.invalidateQueries({ queryKey: ["bots"] });
     });
-  }, [messageCount, queryClient, sessionId]);
+  }, [latestAssistantMessageKey, queryClient, sessionId]);
 }

--- a/ui/src/pages/chat/useSessionReadAcknowledgement.ts
+++ b/ui/src/pages/chat/useSessionReadAcknowledgement.ts
@@ -1,0 +1,18 @@
+import { chatApi } from "@/lib/api";
+import { useQueryClient } from "@tanstack/react-query";
+import { useEffect } from "react";
+
+export function useSessionReadAcknowledgement(
+  sessionId: string | null,
+  messageCount: number
+): void {
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (!sessionId) return;
+    void chatApi.markSessionRead(sessionId).then(() => {
+      void queryClient.invalidateQueries({ queryKey: ["sessions"] });
+      void queryClient.invalidateQueries({ queryKey: ["bots"] });
+    });
+  }, [messageCount, queryClient, sessionId]);
+}

--- a/ui/src/pages/ide/ideActivityHelpers.ts
+++ b/ui/src/pages/ide/ideActivityHelpers.ts
@@ -1,8 +1,9 @@
-import type { ToolCallLike, LiveActivityItem } from "@/lib/chatActivities";
+import type { LiveActivityItem, ToolCallLike } from "@/lib/chatActivities";
 import { normalizeActivityTextForPhase } from "@/lib/chatActivities";
 import { isGenericChatStatusLabel } from "../../../../shared/chat-status";
+import { formatStructuredToolActivityDetail } from "../../../../shared/tool-activity-detail";
 import { isPlainRecord } from "./ideDiffHelpers";
-import type { IdeProcessActivity, IdePendingFileDiff, IdeChatMessage } from "./ideTypes";
+import type { IdeChatMessage, IdePendingFileDiff, IdeProcessActivity } from "./ideTypes";
 
 export function getIdeToolCallArgs(toolCall: ToolCallLike): Record<string, unknown> | null {
   if (isPlainRecord(toolCall.args)) return toolCall.args;
@@ -186,6 +187,10 @@ export function formatIdeStatusEventText(
   phase: "start" | "result" | "error" | "blocked",
   detail?: string
 ): string {
+  const structuredDetail = toolName
+    ? formatStructuredToolActivityDetail(toolName, {}, phase)
+    : undefined;
+  if (structuredDetail) return structuredDetail;
   const normalizedDetail = typeof detail === "string" ? detail.trim() : "";
   if (normalizedDetail && !isGenericIdeStatusLabel(normalizedDetail)) {
     return normalizeActivityTextForPhase(normalizedDetail, phase);

--- a/ui/src/pages/settings/ThemeSettings.tsx
+++ b/ui/src/pages/settings/ThemeSettings.tsx
@@ -4,6 +4,7 @@ import { useIdentity, useUpdateIdentity, type IdentityConfig } from "@/hooks/use
 import { settingsApi } from "@/lib/api";
 import { useI18n, languageOptions } from "@/lib/i18n";
 import { persistPetEnabled, readPetEnabled } from "@/lib/petPreferences";
+import { persistUnreadDotColor, readUnreadDotColor } from "@/lib/unreadPreferences";
 import { cn } from "@/lib/settingsFormat";
 import {
   customThemeConfigPayload,
@@ -67,6 +68,7 @@ export function ThemeSettings() {
   const [savingAccent, setSavingAccent] = useState<ThemeAccent | null>(null);
   const [draftTheme, setDraftTheme] = useState<CustomThemeBundle | null>(null);
   const [petEnabled, setPetEnabled] = useState(() => readPetEnabled());
+  const [unreadDotColor, setUnreadDotColor] = useState(() => readUnreadDotColor());
   const fileInputRef = useRef<HTMLInputElement>(null);
   const identityThemeRef = useRef<{ initialized: boolean; value: unknown }>({
     initialized: false,
@@ -513,6 +515,32 @@ export function ThemeSettings() {
               }))}
             />
           </div>
+        </section>
+
+        <section className="flex items-center justify-between gap-4 border-t border-[var(--surface-border)] pt-5">
+          <div>
+            <span className="text-sm text-[var(--text-secondary)]">Unread response color</span>
+            <p className="mt-1 text-xs text-[var(--text-muted)]">
+              Used for the dot shown to the right of agents with unread responses.
+            </p>
+          </div>
+          <label className="flex items-center gap-2">
+            <input
+              type="color"
+              value={unreadDotColor}
+              onChange={(event) => {
+                setUnreadDotColor(event.target.value);
+                persistUnreadDotColor(event.target.value);
+              }}
+              className="h-8 w-10 cursor-pointer rounded-md border border-[var(--surface-border)] bg-transparent p-0.5"
+              aria-label="Unread response color"
+            />
+            <span
+              className="h-2.5 w-2.5 rounded-full"
+              style={{ backgroundColor: unreadDotColor }}
+              aria-hidden="true"
+            />
+          </label>
         </section>
 
         <section className="flex items-center justify-between gap-4 border-t border-[var(--surface-border)] pt-5">

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -72,6 +72,7 @@ export interface BotRosterItem {
     title?: string | null;
     updated_at?: string;
     message_count?: number;
+    unread?: boolean;
     last_message?: { role: string; content: string } | null;
   } | null;
 }


### PR DESCRIPTION


<!-- GITZILLA_SUMMARY -->
> [!NOTE]
> **Medium Risk**
>
> **Overview**
> This PR introduces image-viewed activity tracking and a chat image lightbox experience across the stack. On the backend, three new core modules are added—`viewed-media` for recording and dismissing image views, `inline-images` for managing inline image attachments, and `context-estimate` for reasoning about context usage—along with corresponding database tables, API endpoints, and agent/tool plumbing that record image-view events in activity streams and runtime state. The UI layer gains a chat image lightbox, unread-response indicators, session read acknowledgement, and updates to `ActivityTimeline`, `FloatingPreviewFrame`, `MultiChatWorkspace`, and related models to surface inline images and image-viewed activities, with new shared types in `chat-activity-groups` and `tool-activity-detail`. Test coverage is expanded with new suites for the added modules and UI flows, while supporting refactors streamline `chatModel`, agent provider runtimes, and computer-use handling.
>
> <sup>Written by [Gitzilla](https://gitzilla.ai) for commit 418bac6. This will update automatically on new runs. Configure in the [Gitzilla dashboard](https://gitzilla.ai/dashboard).</sup>
<!-- /GITZILLA_SUMMARY -->