### PR TITLE
Desktop: preserve external gateway ownership during reconnects

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Cybara",
     "slug": "cybara-mobile",
-    "version": "1.0.1719",
+    "version": "1.0.2295",
     "orientation": "portrait",
     "scheme": "cybara",
     "icon": "./assets/cybara.png",
@@ -26,7 +26,7 @@
           "NSAllowsLocalNetworking": true
         }
       },
-      "buildNumber": "1001719"
+      "buildNumber": "1002295"
     },
     "android": {
       "package": "com.ck.cybara",
@@ -39,7 +39,7 @@
         "foregroundImage": "./assets/cybara-adaptive-foreground.png",
         "backgroundColor": "#071016"
       },
-      "versionCode": 1001719
+      "versionCode": 1002295
     },
     "plugins": [
       [

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Cybara",
     "slug": "cybara-mobile",
-    "version": "1.0.2295",
+    "version": "1.0.2310",
     "orientation": "portrait",
     "scheme": "cybara",
     "icon": "./assets/cybara.png",
@@ -26,7 +26,7 @@
           "NSAllowsLocalNetworking": true
         }
       },
-      "buildNumber": "1002295"
+      "buildNumber": "1002310"
     },
     "android": {
       "package": "com.ck.cybara",
@@ -39,7 +39,7 @@
         "foregroundImage": "./assets/cybara-adaptive-foreground.png",
         "backgroundColor": "#071016"
       },
-      "versionCode": 1002295
+      "versionCode": 1002310
     },
     "plugins": [
       [

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -55,9 +55,9 @@ Cybara Desktop has two explicit gateway ownership modes:
 - **Managed Local** — the desktop launched the bundled gateway and may stop or restart that owned process.
 - **Attached External** — the desktop discovered a healthy pre-existing gateway and must never start, stop, replace, or kill a gateway as fallback.
 
-A loopback address does not imply local ownership. `127.0.0.1:4269` may be a user-managed private-network, SSH, or VPN forward to a central gateway. When Desktop first attaches to a pre-existing gateway, it stores both the external intent and that gateway's stable instance identity in desktop-local application data.
+A loopback address does not imply local ownership. `127.0.0.1:4269` may be a user-managed private-network, SSH, or VPN forward to a central gateway. When Desktop first attaches to a pre-existing gateway, it stores both the external intent and that gateway's identity-capability identifier in desktop-local application data. The identifier detects accidental replacement at the endpoint; authentication remains the security boundary.
 
-If an attached external gateway or forward disappears, Desktop enters a disconnected/reconnecting screen and probes the same endpoint with bounded exponential backoff. It does not start the bundled sidecar even when the port becomes free. Reconnection succeeds only when the same compatible gateway identity returns. A non-Cybara service, an incompatible gateway, or a different Cybara gateway at that endpoint fails closed with an actionable message.
+If an attached external gateway or forward disappears, Desktop enters a disconnected/reconnecting screen and probes the same endpoint with bounded exponential backoff. It does not start the bundled sidecar even when the port becomes free. Reconnection succeeds only when the same compatible gateway identifier returns. A non-Cybara service, an incompatible gateway, or a different Cybara gateway at that endpoint fails closed with an actionable message.
 
 External intent survives desktop restarts. Restarting Desktop while the forward is unavailable remains remote-only and cannot create a replacement local gateway. To abandon the external gateway, choose **Use local gateway** explicitly. Desktop requires port 4269 to be free before changing ownership and starting the bundled sidecar.
 

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -50,19 +50,18 @@ publishes notarized builds (see [Signing & Notarization (maintainers)](#signing-
 
 ## Central Gateway Attachment
 
-Cybara desktop shells can attach to a healthy gateway already listening on the configured loopback port instead of starting their bundled sidecar. The loopback endpoint may be local or supplied by a user-managed private-network, SSH, or VPN forward; Cybara does not depend on the forwarding technology.
+Cybara Desktop has two explicit gateway ownership modes:
 
-The gateway is authoritative for its web runtime and API behavior. The Tauri shell loads the attached gateway's own web UI, while native clients use the gateway's published API compatibility contract. Desktop and gateway patch releases therefore do not need to match exactly:
+- **Managed Local** — the desktop launched the bundled gateway and may stop or restart that owned process.
+- **Attached External** — the desktop discovered a healthy pre-existing gateway and must never start, stop, replace, or kill a gateway as fallback.
 
-- same-major release drift attaches when the gateway API contract is compatible;
-- a future gateway can publish a minimum client API version and require an older native client to update;
-- different major versions, malformed compatibility metadata, and missing gateway versions fail closed with both versions and an actionable explanation;
-- an unrelated or unresponsive service remains an occupied-port error rather than being treated as Cybara;
-- desktop shells never downgrade themselves, replace an external gateway, or install software based only on an unauthenticated health response.
+A loopback address does not imply local ownership. `127.0.0.1:4269` may be a user-managed private-network, SSH, or VPN forward to a central gateway. When Desktop first attaches to a pre-existing gateway, it stores both the external intent and that gateway's stable instance identity in desktop-local application data.
 
-A bundled sidecar remains desktop-managed. A pre-existing gateway remains externally managed: the shell attaches and monitors liveness but does not terminate or update it. Reconciliation runs when attaching or reconnecting, not through continuous release polling.
+If an attached external gateway or forward disappears, Desktop enters a disconnected/reconnecting screen and probes the same endpoint with bounded exponential backoff. It does not start the bundled sidecar even when the port becomes free. Reconnection succeeds only when the same compatible gateway identity returns. A non-Cybara service, an incompatible gateway, or a different Cybara gateway at that endpoint fails closed with an actionable message.
 
-For routine same-major drift, no update is required. When the API compatibility contract rejects attachment, update the older component from an official Cybara release and retry. Existing desktop update paths retain their signed manifest, checksum, and code-signing verification.
+External intent survives desktop restarts. Restarting Desktop while the forward is unavailable remains remote-only and cannot create a replacement local gateway. To abandon the external gateway, choose **Use local gateway** explicitly. Desktop requires port 4269 to be free before changing ownership and starting the bundled sidecar.
+
+The gateway remains authoritative for its web runtime and API behavior. Same-major patch drift attaches when the API compatibility contract allows it; different major versions and incompatible or malformed API metadata fail closed. Existing release integrity and authentication requirements are unchanged.
 
 ## Desktop Auto Updates
 

--- a/nix/release.nix
+++ b/nix/release.nix
@@ -1,5 +1,5 @@
 {
-  version = "1.0.1719";
+  version = "1.0.2295";
   hashes = {
     "x86_64-linux" = "sha256-";
     "aarch64-linux" = "sha256-";

--- a/nix/release.nix
+++ b/nix/release.nix
@@ -1,9 +1,9 @@
 {
   version = "1.0.2310";
   hashes = {
-    "x86_64-linux" = "sha256-";
-    "aarch64-linux" = "sha256-";
-    "x86_64-darwin" = "sha256-";
-    "aarch64-darwin" = "sha256-";
+    "x86_64-linux" = "sha256-yKWUvq8BBp8BaWBPo+dgJY4YewDptrSZ97GT1gW54XI=";
+    "aarch64-linux" = "sha256-kFVjxLfBnmCIdwRL47HPFGSMwJNaZtlU9c4bqAuBze0=";
+    "x86_64-darwin" = "sha256-p7XrwyQjYJa1yP5IitqZ5Y/X2PQycbSiDh3l8YM99H8=";
+    "aarch64-darwin" = "sha256-L/AGStBNbBQJuO5qkvXL/HXX1MC4wQmvKF+XxeqXVT8=";
   };
 }

--- a/nix/release.nix
+++ b/nix/release.nix
@@ -1,5 +1,5 @@
 {
-  version = "1.0.2295";
+  version = "1.0.2310";
   hashes = {
     "x86_64-linux" = "sha256-";
     "aarch64-linux" = "sha256-";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cybara",
-  "version": "1.0.1719",
+  "version": "1.0.2295",
   "description": "Open-source multi-agent AI platform with CLI, web, desktop, and mobile apps, broad provider and channel support, MCP host/client, media generation, and multi-agent orchestration.",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cybara",
-  "version": "1.0.2295",
+  "version": "1.0.2310",
   "description": "Open-source multi-agent AI platform with CLI, web, desktop, and mobile apps, broad provider and channel support, MCP host/client, media generation, and multi-agent orchestration.",
   "type": "module",
   "bin": {

--- a/shared/gateway-compatibility.ts
+++ b/shared/gateway-compatibility.ts
@@ -1,5 +1,6 @@
 export const CYBARA_GATEWAY_API_VERSION = 1;
 export const CYBARA_GATEWAY_API_MIN_CLIENT_VERSION = 1;
+export const CYBARA_GATEWAY_IDENTITY_VERSION = 1;
 
 export interface GatewayApiCompatibility {
   api_version: number;

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cybara-desktop"
-version = "1.0.1719"
+version = "1.0.2295"
 description = "Cybara Desktop Client"
 authors = ["Carsen Klock @metaspartan"]
 edition = "2024"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cybara-desktop"
-version = "1.0.2295"
+version = "1.0.2310"
 description = "Cybara Desktop Client"
 authors = ["Carsen Klock @metaspartan"]
 edition = "2024"

--- a/src-tauri/permissions/desktop-gateway.toml
+++ b/src-tauri/permissions/desktop-gateway.toml
@@ -1,4 +1,4 @@
 [[permission]]
 identifier = "desktop-gateway"
 description = "Allows the Cybara interface to read local desktop gateway startup and authentication state."
-commands.allow = ["read_cybara_api_key", "get_gateway_url", "get_gateway_startup_status", "restart_gateway_sidecar"]
+commands.allow = ["read_cybara_api_key", "get_gateway_url", "get_gateway_startup_status", "restart_gateway_sidecar", "switch_to_local_gateway"]

--- a/src-tauri/src/gateway.rs
+++ b/src-tauri/src/gateway.rs
@@ -22,6 +22,7 @@ pub enum GatewayCompatibility {
     Compatible {
         gateway_version: String,
         exact_match: bool,
+        gateway_id: Option<String>,
     },
     Incompatible {
         gateway_version: Option<String>,
@@ -41,6 +42,7 @@ pub enum GatewayLivenessStatus {
 pub struct GatewayEndpoint {
     pub addr: String,
     pub url: String,
+    port: u16,
 }
 
 struct HttpResponse {
@@ -51,6 +53,7 @@ struct HttpResponse {
 
 struct GatewayHealth {
     version: Option<String>,
+    instance_id: Option<String>,
     healthy: bool,
     api_version: Option<u64>,
     min_client_api_version: Option<u64>,
@@ -62,7 +65,12 @@ impl GatewayEndpoint {
         Self {
             addr: format!("127.0.0.1:{port}"),
             url: format!("http://127.0.0.1:{port}"),
+            port,
         }
+    }
+
+    pub fn port(&self) -> u16 {
+        self.port
     }
 }
 
@@ -138,6 +146,18 @@ pub fn probe_gateway_at(addr: &str, client_version: &str) -> GatewayProbeStatus 
         health.min_client_api_version,
         health.compatibility_declared,
     );
+    let compatibility = match compatibility {
+        GatewayCompatibility::Compatible {
+            gateway_version,
+            exact_match,
+            ..
+        } => GatewayCompatibility::Compatible {
+            gateway_version,
+            exact_match,
+            gateway_id: health.instance_id.clone(),
+        },
+        incompatible => incompatible,
+    };
     let GatewayCompatibility::Compatible { .. } = compatibility else {
         return GatewayProbeStatus::CybaraGateway(compatibility);
     };
@@ -167,6 +187,28 @@ pub fn is_compatible_gateway_at(addr: &str, client_version: &str) -> bool {
         probe_gateway_at(addr, client_version),
         GatewayProbeStatus::CybaraGateway(GatewayCompatibility::Compatible { .. })
     )
+}
+
+pub fn compatible_gateway_id_at(addr: &str, client_version: &str) -> Option<String> {
+    let response = http_get(addr, "/api/health")?;
+    let health = cybara_health(&response)?;
+    if !health.healthy {
+        return None;
+    }
+    let version = health.version?;
+    if !matches!(
+        gateway_compatibility_with_api(
+            &version,
+            client_version,
+            health.api_version,
+            health.min_client_api_version,
+            health.compatibility_declared,
+        ),
+        GatewayCompatibility::Compatible { .. }
+    ) {
+        return None;
+    }
+    health.instance_id
 }
 
 fn port_accepts_connections(addr: &str) -> bool {
@@ -222,6 +264,12 @@ fn cybara_health(response: &HttpResponse) -> Option<GatewayHealth> {
         .map(str::to_string);
     Some(GatewayHealth {
         version,
+        instance_id: value
+            .get("instance_id")
+            .and_then(serde_json::Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string),
         healthy: response.status == 200 && matches!(status, "healthy" | "warning" | "critical"),
         api_version: compatibility
             .and_then(|entry| entry.get("api_version"))
@@ -314,6 +362,7 @@ fn gateway_compatibility_with_api(
     GatewayCompatibility::Compatible {
         gateway_version: gateway_version.to_string(),
         exact_match: gateway == client,
+        gateway_id: None,
     }
 }
 
@@ -351,8 +400,8 @@ impl GatewayPortSignalParser {
 mod tests {
     use super::{
         GatewayCompatibility, GatewayEndpoint, GatewayLivenessStatus, GatewayPortSignalParser,
-        GatewayProbeStatus, gateway_compatibility, gateway_liveness_at, is_compatible_gateway_at,
-        parse_gateway_port_signal, probe_gateway_at,
+        GatewayProbeStatus, compatible_gateway_id_at, gateway_compatibility, gateway_liveness_at,
+        is_compatible_gateway_at, parse_gateway_port_signal, probe_gateway_at,
     };
     use std::io::{Read, Write};
     use std::net::TcpListener;
@@ -395,6 +444,42 @@ mod tests {
     }
 
     #[test]
+    fn returns_the_stable_gateway_identity_from_health() {
+        let (endpoint, handle) = serve(vec![
+            r#"{"product":"cybara","status":"healthy","version":"1.2.3","instance_id":"gateway-one"}"#.into(),
+            r#"<!doctype html><html><script src="/assets/index.js"></script></html>"#.into(),
+        ]);
+        assert!(matches!(
+            probe_gateway_at(&endpoint.addr, "1.2.3"),
+            GatewayProbeStatus::CybaraGateway(GatewayCompatibility::Compatible {
+                gateway_id: Some(gateway_id),
+                ..
+            }) if gateway_id == "gateway-one"
+        ));
+        handle.join().expect("join identity gateway");
+    }
+
+    #[test]
+    fn lightweight_identity_probe_preserves_compatibility_checks() {
+        let (endpoint, handle) = serve(vec![
+            r#"{"product":"cybara","status":"healthy","version":"1.2.3","instance_id":"gateway-one"}"#.into(),
+        ]);
+        assert_eq!(
+            compatible_gateway_id_at(&endpoint.addr, "1.2.4"),
+            Some("gateway-one".into())
+        );
+        handle.join().expect("join lightweight identity gateway");
+
+        let (incompatible, incompatible_handle) = serve(vec![
+            r#"{"product":"cybara","status":"healthy","version":"2.0.0","instance_id":"gateway-two"}"#.into(),
+        ]);
+        assert_eq!(compatible_gateway_id_at(&incompatible.addr, "1.2.4"), None);
+        incompatible_handle
+            .join()
+            .expect("join incompatible identity gateway");
+    }
+
+    #[test]
     fn accepts_same_major_gateway_patch_drift_in_both_directions() {
         for gateway_version in ["1.0.2275", "1.0.2287"] {
             let (endpoint, handle) = serve(vec![
@@ -411,6 +496,7 @@ mod tests {
             GatewayCompatibility::Compatible {
                 gateway_version: "1.0.2275".into(),
                 exact_match: false,
+                gateway_id: None,
             }
         );
         assert_eq!(
@@ -418,6 +504,7 @@ mod tests {
             GatewayCompatibility::Compatible {
                 gateway_version: "1.0.2281".into(),
                 exact_match: true,
+                gateway_id: None,
             }
         );
     }

--- a/src-tauri/src/gateway.rs
+++ b/src-tauri/src/gateway.rs
@@ -7,6 +7,7 @@ const PROBE_TIMEOUT: Duration = Duration::from_millis(900);
 const LIVENESS_PROBE_TIMEOUT: Duration = Duration::from_secs(2);
 const GATEWAY_PORT_SIGNAL_PREFIX: &str = "CYBARA_GATEWAY_PORT=";
 const DESKTOP_GATEWAY_API_VERSION: u64 = 1;
+const GATEWAY_IDENTITY_VERSION: u64 = 1;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum GatewayProbeStatus {
@@ -54,6 +55,7 @@ struct HttpResponse {
 struct GatewayHealth {
     version: Option<String>,
     instance_id: Option<String>,
+    identity_version: Option<u64>,
     healthy: bool,
     api_version: Option<u64>,
     min_client_api_version: Option<u64>,
@@ -154,7 +156,9 @@ pub fn probe_gateway_at(addr: &str, client_version: &str) -> GatewayProbeStatus 
         } => GatewayCompatibility::Compatible {
             gateway_version,
             exact_match,
-            gateway_id: health.instance_id.clone(),
+            gateway_id: (health.identity_version == Some(GATEWAY_IDENTITY_VERSION))
+                .then_some(health.instance_id.clone())
+                .flatten(),
         },
         incompatible => incompatible,
     };
@@ -206,6 +210,9 @@ pub fn compatible_gateway_id_at(addr: &str, client_version: &str) -> Option<Stri
         ),
         GatewayCompatibility::Compatible { .. }
     ) {
+        return None;
+    }
+    if health.identity_version != Some(GATEWAY_IDENTITY_VERSION) {
         return None;
     }
     health.instance_id
@@ -264,12 +271,17 @@ fn cybara_health(response: &HttpResponse) -> Option<GatewayHealth> {
         .map(str::to_string);
     Some(GatewayHealth {
         version,
-        instance_id: value
-            .get("instance_id")
+        instance_id: (product == Some("cybara"))
+            .then(|| value.get("instance_id"))
+            .flatten()
             .and_then(serde_json::Value::as_str)
             .map(str::trim)
             .filter(|value| !value.is_empty())
             .map(str::to_string),
+        identity_version: (product == Some("cybara"))
+            .then(|| compatibility.and_then(|entry| entry.get("identity_version")))
+            .flatten()
+            .and_then(serde_json::Value::as_u64),
         healthy: response.status == 200 && matches!(status, "healthy" | "warning" | "critical"),
         api_version: compatibility
             .and_then(|entry| entry.get("api_version"))
@@ -446,7 +458,7 @@ mod tests {
     #[test]
     fn returns_the_stable_gateway_identity_from_health() {
         let (endpoint, handle) = serve(vec![
-            r#"{"product":"cybara","status":"healthy","version":"1.2.3","instance_id":"gateway-one"}"#.into(),
+            r#"{"product":"cybara","status":"healthy","version":"1.2.3","instance_id":"gateway-one","compatibility":{"api_version":1,"min_client_api_version":1,"identity_version":1}}"#.into(),
             r#"<!doctype html><html><script src="/assets/index.js"></script></html>"#.into(),
         ]);
         assert!(matches!(
@@ -462,7 +474,7 @@ mod tests {
     #[test]
     fn lightweight_identity_probe_preserves_compatibility_checks() {
         let (endpoint, handle) = serve(vec![
-            r#"{"product":"cybara","status":"healthy","version":"1.2.3","instance_id":"gateway-one"}"#.into(),
+            r#"{"product":"cybara","status":"healthy","version":"1.2.3","instance_id":"gateway-one","compatibility":{"api_version":1,"min_client_api_version":1,"identity_version":1}}"#.into(),
         ]);
         assert_eq!(
             compatible_gateway_id_at(&endpoint.addr, "1.2.4"),
@@ -471,12 +483,27 @@ mod tests {
         handle.join().expect("join lightweight identity gateway");
 
         let (incompatible, incompatible_handle) = serve(vec![
-            r#"{"product":"cybara","status":"healthy","version":"2.0.0","instance_id":"gateway-two"}"#.into(),
+            r#"{"product":"cybara","status":"healthy","version":"2.0.0","instance_id":"gateway-two","compatibility":{"api_version":1,"min_client_api_version":1,"identity_version":1}}"#.into(),
         ]);
         assert_eq!(compatible_gateway_id_at(&incompatible.addr, "1.2.4"), None);
         incompatible_handle
             .join()
             .expect("join incompatible identity gateway");
+    }
+
+    #[test]
+    fn identity_requires_declared_capability_and_product_marker() {
+        let (legacy, legacy_handle) = serve(vec![
+            r#"{"product":"cybara","status":"healthy","version":"1.2.4","instance_id":"legacy-id"}"#.into(),
+        ]);
+        assert_eq!(compatible_gateway_id_at(&legacy.addr, "1.2.4"), None);
+        legacy_handle.join().expect("join legacy gateway");
+
+        let (spoofed, spoofed_handle) = serve(vec![
+            r#"{"status":"healthy","version":"1.2.4","instance_id":"gateway-one","compatibility":{"api_version":1,"min_client_api_version":1,"identity_version":1}}"#.into(),
+        ]);
+        assert_eq!(compatible_gateway_id_at(&spoofed.addr, "1.2.4"), None);
+        spoofed_handle.join().expect("join spoofed gateway");
     }
 
     #[test]

--- a/src-tauri/src/gateway_ownership.rs
+++ b/src-tauri/src/gateway_ownership.rs
@@ -217,26 +217,36 @@ fn read_gateway_intent(path: &Path) -> Result<GatewayIntent, String> {
 }
 
 pub fn load_gateway_intent(path: &Path, default_port: u16) -> Result<LoadedGatewayIntent, String> {
+    let pending_backup = path.with_extension("json.backup.pending");
     let backup = path.with_extension("json.backup");
-    if !path.exists() && !backup.exists() {
+    let candidates = [path, pending_backup.as_path(), backup.as_path()];
+    let existing = candidates
+        .iter()
+        .copied()
+        .filter(|candidate| candidate.exists())
+        .collect::<Vec<_>>();
+    if existing.is_empty() {
         return Ok(LoadedGatewayIntent {
             intent: GatewayIntent::managed_local(default_port),
             persisted: false,
         });
     }
-    let intent = match read_gateway_intent(path) {
-        Ok(intent) => intent,
-        Err(primary_error) if backup.exists() => read_gateway_intent(&backup).map_err(|backup_error| {
-            format!(
-                "Invalid gateway intent and backup: primary: {primary_error}; backup: {backup_error}"
-            )
-        })?,
-        Err(error) => return Err(error),
-    };
-    Ok(LoadedGatewayIntent {
-        intent,
-        persisted: true,
-    })
+    let mut errors = Vec::new();
+    for candidate in existing {
+        match read_gateway_intent(candidate) {
+            Ok(intent) => {
+                return Ok(LoadedGatewayIntent {
+                    intent,
+                    persisted: true,
+                });
+            }
+            Err(error) => errors.push(format!("{}: {error}", candidate.display())),
+        }
+    }
+    Err(format!(
+        "Invalid gateway intent files: {}",
+        errors.join("; ")
+    ))
 }
 
 pub fn persist_gateway_intent(path: &Path, intent: &GatewayIntent) -> Result<(), String> {
@@ -245,25 +255,30 @@ pub fn persist_gateway_intent(path: &Path, intent: &GatewayIntent) -> Result<(),
         .ok_or_else(|| "Gateway intent path has no parent".to_string())?;
     std::fs::create_dir_all(parent).map_err(|error| error.to_string())?;
     let temporary = path.with_extension("json.tmp");
+    let pending_backup = path.with_extension("json.backup.pending");
     let backup = path.with_extension("json.backup");
     let bytes = serde_json::to_vec_pretty(intent).map_err(|error| error.to_string())?;
     let mut file = std::fs::File::create(&temporary).map_err(|error| error.to_string())?;
     std::io::Write::write_all(&mut file, &bytes).map_err(|error| error.to_string())?;
     file.sync_all().map_err(|error| error.to_string())?;
+
     if path.exists() {
-        if backup.exists() {
-            std::fs::remove_file(&backup).map_err(|error| error.to_string())?;
+        if pending_backup.exists() {
+            std::fs::remove_file(&pending_backup).map_err(|error| error.to_string())?;
         }
-        std::fs::rename(path, &backup).map_err(|error| error.to_string())?;
+        std::fs::rename(path, &pending_backup).map_err(|error| error.to_string())?;
     }
     if let Err(error) = std::fs::rename(&temporary, path) {
-        if backup.exists() {
-            let _ = std::fs::rename(&backup, path);
+        if pending_backup.exists() {
+            let _ = std::fs::rename(&pending_backup, path);
         }
         return Err(error.to_string());
     }
-    if backup.exists() {
-        std::fs::remove_file(backup).map_err(|error| error.to_string())?;
+
+    if pending_backup.exists() {
+        if !backup.exists() || std::fs::remove_file(&backup).is_ok() {
+            let _ = std::fs::rename(&pending_backup, &backup);
+        }
     }
     Ok(())
 }
@@ -274,7 +289,7 @@ mod tests {
         ExistingGatewayAction, ExternalProbeAction, GatewayIntent, GatewayOwnership,
         GatewayOwnershipController, RecoveryAction, SwitchToLocalAction, WatchdogAction,
         existing_gateway_action, external_probe_action, load_gateway_intent,
-        persist_gateway_intent, switch_to_local_action, watchdog_action,
+        persist_gateway_intent, read_gateway_intent, switch_to_local_action, watchdog_action,
     };
     use crate::gateway::{GatewayCompatibility, GatewayProbeStatus};
 
@@ -424,6 +439,14 @@ mod tests {
         let loaded = load_gateway_intent(&path, 4269).expect("load intent");
         assert_eq!(loaded.intent, intent);
         assert!(loaded.persisted);
+        let next = GatewayIntent::attached_external(4269, "gateway-next".into());
+        persist_gateway_intent(&path, &next).expect("replace intent");
+        assert_eq!(read_gateway_intent(&path).expect("read replacement"), next);
+        assert_eq!(
+            read_gateway_intent(&path.with_extension("json.backup"))
+                .expect("read previous intent backup"),
+            intent
+        );
         assert_eq!(
             GatewayOwnershipController::new(loaded.intent).recovery_action(),
             RecoveryAction::ReconnectExternal
@@ -449,6 +472,30 @@ mod tests {
         let loaded = load_gateway_intent(&path, 4269).expect("recover intent");
         assert_eq!(loaded.intent, intent);
         assert!(loaded.persisted);
+        std::fs::remove_dir_all(root).expect("remove fixture");
+    }
+
+    #[test]
+    fn missing_primary_recovers_pending_external_backup() {
+        let root = std::env::temp_dir().join(format!(
+            "cybara-pending-gateway-intent-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&root).expect("create fixture");
+        let path = root.join("gateway-intent.json");
+        let pending_backup = path.with_extension("json.backup.pending");
+        std::fs::write(
+            &pending_backup,
+            serde_json::to_vec(&GatewayIntent::attached_external(
+                4269,
+                "gateway-pending".into(),
+            ))
+            .expect("serialize pending backup"),
+        )
+        .expect("write pending backup");
+        let loaded = load_gateway_intent(&path, 4269).expect("recover pending backup");
+        assert_eq!(loaded.intent.ownership, GatewayOwnership::AttachedExternal);
+        assert_eq!(loaded.intent.gateway_id.as_deref(), Some("gateway-pending"));
         std::fs::remove_dir_all(root).expect("remove fixture");
     }
 

--- a/src-tauri/src/gateway_ownership.rs
+++ b/src-tauri/src/gateway_ownership.rs
@@ -1,0 +1,487 @@
+use crate::gateway::{GatewayCompatibility, GatewayProbeStatus};
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum GatewayOwnership {
+    #[default]
+    ManagedLocal,
+    AttachedExternal,
+}
+
+impl GatewayOwnership {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ManagedLocal => "managedLocal",
+            Self::AttachedExternal => "attachedExternal",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct GatewayIntent {
+    pub ownership: GatewayOwnership,
+    pub port: u16,
+    pub gateway_id: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LoadedGatewayIntent {
+    pub intent: GatewayIntent,
+    pub persisted: bool,
+}
+
+impl GatewayIntent {
+    pub fn managed_local(port: u16) -> Self {
+        Self {
+            ownership: GatewayOwnership::ManagedLocal,
+            port,
+            gateway_id: None,
+        }
+    }
+
+    pub fn attached_external(port: u16, gateway_id: String) -> Self {
+        Self {
+            ownership: GatewayOwnership::AttachedExternal,
+            port,
+            gateway_id: Some(gateway_id),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RecoveryAction {
+    RestartManagedSidecar,
+    ReconnectExternal,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ExistingGatewayAction {
+    AttachExternal,
+    RefuseOwnershipChange,
+}
+
+pub fn existing_gateway_action(allow_external_attach: bool) -> ExistingGatewayAction {
+    if allow_external_attach {
+        ExistingGatewayAction::AttachExternal
+    } else {
+        ExistingGatewayAction::RefuseOwnershipChange
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SwitchToLocalAction {
+    StartManagedSidecar,
+    WaitForFreePort,
+}
+
+pub fn switch_to_local_action(port_available: bool) -> SwitchToLocalAction {
+    if port_available {
+        SwitchToLocalAction::StartManagedSidecar
+    } else {
+        SwitchToLocalAction::WaitForFreePort
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ExternalProbeAction {
+    Reattach,
+    Retry,
+    Fail(String),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum WatchdogAction {
+    Healthy,
+    RestartManagedSidecar,
+    ReconnectExternal,
+}
+
+pub fn watchdog_action(
+    ownership: GatewayOwnership,
+    healthy: bool,
+    failure_threshold_reached: bool,
+) -> WatchdogAction {
+    if healthy || !failure_threshold_reached {
+        return WatchdogAction::Healthy;
+    }
+    match ownership {
+        GatewayOwnership::ManagedLocal => WatchdogAction::RestartManagedSidecar,
+        GatewayOwnership::AttachedExternal => WatchdogAction::ReconnectExternal,
+    }
+}
+
+pub fn external_probe_action(
+    expected_gateway_id: Option<&str>,
+    probe: GatewayProbeStatus,
+) -> ExternalProbeAction {
+    match probe {
+        GatewayProbeStatus::CybaraGateway(GatewayCompatibility::Compatible {
+            gateway_id: Some(gateway_id),
+            ..
+        }) if expected_gateway_id == Some(gateway_id.as_str()) => ExternalProbeAction::Reattach,
+        GatewayProbeStatus::CybaraGateway(GatewayCompatibility::Compatible { .. }) => {
+            ExternalProbeAction::Fail(
+                "A different Cybara gateway is responding at the configured external endpoint. Cybara refused to switch gateway identity. Restore the intended gateway or explicitly switch to local mode."
+                    .into(),
+            )
+        }
+        GatewayProbeStatus::CybaraGateway(GatewayCompatibility::Incompatible { reason, .. }) => {
+            ExternalProbeAction::Fail(reason)
+        }
+        GatewayProbeStatus::NonCybara => ExternalProbeAction::Fail(
+            "The configured external gateway endpoint is occupied by a non-Cybara service. Restore the forwarding connection or explicitly switch to a local gateway after freeing the port."
+                .into(),
+        ),
+        GatewayProbeStatus::Available
+        | GatewayProbeStatus::Busy
+        | GatewayProbeStatus::UnhealthyCybara { .. } => ExternalProbeAction::Retry,
+    }
+}
+
+pub struct GatewayOwnershipController {
+    intent: GatewayIntent,
+    reconnect_generation: u64,
+    reconnecting: bool,
+}
+
+impl GatewayOwnershipController {
+    pub fn new(intent: GatewayIntent) -> Self {
+        Self {
+            intent,
+            reconnect_generation: 0,
+            reconnecting: false,
+        }
+    }
+
+    pub fn intent(&self) -> GatewayIntent {
+        self.intent.clone()
+    }
+
+    pub fn recovery_action(&self) -> RecoveryAction {
+        match self.intent.ownership {
+            GatewayOwnership::ManagedLocal => RecoveryAction::RestartManagedSidecar,
+            GatewayOwnership::AttachedExternal => RecoveryAction::ReconnectExternal,
+        }
+    }
+
+    pub fn set_intent(&mut self, intent: GatewayIntent) {
+        self.intent = intent;
+        self.reconnect_generation = self.reconnect_generation.wrapping_add(1);
+        self.reconnecting = false;
+    }
+
+    pub fn begin_external_reconnect(&mut self) -> Option<u64> {
+        if self.intent.ownership != GatewayOwnership::AttachedExternal || self.reconnecting {
+            return None;
+        }
+        self.reconnect_generation = self.reconnect_generation.wrapping_add(1);
+        self.reconnecting = true;
+        Some(self.reconnect_generation)
+    }
+
+    pub fn external_reconnect_is_current(&self, generation: u64) -> bool {
+        self.intent.ownership == GatewayOwnership::AttachedExternal
+            && self.reconnecting
+            && self.reconnect_generation == generation
+    }
+
+    pub fn finish_external_reconnect(&mut self, generation: u64) -> bool {
+        if !self.external_reconnect_is_current(generation) {
+            return false;
+        }
+        self.reconnecting = false;
+        true
+    }
+}
+
+pub fn load_gateway_intent(path: &Path, default_port: u16) -> Result<LoadedGatewayIntent, String> {
+    let backup = path.with_extension("json.backup");
+    let source = if path.exists() {
+        path
+    } else if backup.exists() {
+        backup.as_path()
+    } else {
+        return Ok(LoadedGatewayIntent {
+            intent: GatewayIntent::managed_local(default_port),
+            persisted: false,
+        });
+    };
+    let bytes = std::fs::read(source).map_err(|error| error.to_string())?;
+    let intent: GatewayIntent = serde_json::from_slice(&bytes)
+        .map_err(|error| format!("Invalid gateway intent: {error}"))?;
+    if intent.port == 0 {
+        return Err("Invalid gateway intent: port must be greater than zero".into());
+    }
+    if intent.ownership == GatewayOwnership::AttachedExternal
+        && intent
+            .gateway_id
+            .as_deref()
+            .map(str::trim)
+            .unwrap_or_default()
+            .is_empty()
+    {
+        return Err("Invalid gateway intent: external gateway identity is missing".into());
+    }
+    Ok(LoadedGatewayIntent {
+        intent,
+        persisted: true,
+    })
+}
+
+pub fn persist_gateway_intent(path: &Path, intent: &GatewayIntent) -> Result<(), String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| "Gateway intent path has no parent".to_string())?;
+    std::fs::create_dir_all(parent).map_err(|error| error.to_string())?;
+    let temporary = path.with_extension("json.tmp");
+    let backup = path.with_extension("json.backup");
+    let bytes = serde_json::to_vec_pretty(intent).map_err(|error| error.to_string())?;
+    let mut file = std::fs::File::create(&temporary).map_err(|error| error.to_string())?;
+    std::io::Write::write_all(&mut file, &bytes).map_err(|error| error.to_string())?;
+    file.sync_all().map_err(|error| error.to_string())?;
+    if path.exists() {
+        if backup.exists() {
+            std::fs::remove_file(&backup).map_err(|error| error.to_string())?;
+        }
+        std::fs::rename(path, &backup).map_err(|error| error.to_string())?;
+    }
+    if let Err(error) = std::fs::rename(&temporary, path) {
+        if backup.exists() {
+            let _ = std::fs::rename(&backup, path);
+        }
+        return Err(error.to_string());
+    }
+    if backup.exists() {
+        std::fs::remove_file(backup).map_err(|error| error.to_string())?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ExistingGatewayAction, ExternalProbeAction, GatewayIntent, GatewayOwnership,
+        GatewayOwnershipController, RecoveryAction, SwitchToLocalAction, WatchdogAction,
+        existing_gateway_action, external_probe_action, load_gateway_intent,
+        persist_gateway_intent, switch_to_local_action, watchdog_action,
+    };
+    use crate::gateway::{GatewayCompatibility, GatewayProbeStatus};
+
+    #[test]
+    fn preexisting_gateway_attachment_is_allowed_only_during_initial_discovery() {
+        assert_eq!(
+            existing_gateway_action(true),
+            ExistingGatewayAction::AttachExternal
+        );
+        assert_eq!(
+            existing_gateway_action(false),
+            ExistingGatewayAction::RefuseOwnershipChange
+        );
+    }
+
+    #[test]
+    fn watchdog_restarts_only_managed_gateway_failures() {
+        assert_eq!(
+            watchdog_action(GatewayOwnership::ManagedLocal, false, true),
+            WatchdogAction::RestartManagedSidecar
+        );
+        assert_eq!(
+            watchdog_action(GatewayOwnership::AttachedExternal, false, true),
+            WatchdogAction::ReconnectExternal
+        );
+        assert_eq!(
+            watchdog_action(GatewayOwnership::AttachedExternal, true, true),
+            WatchdogAction::Healthy
+        );
+        assert_eq!(
+            watchdog_action(GatewayOwnership::ManagedLocal, false, false),
+            WatchdogAction::Healthy
+        );
+    }
+
+    #[test]
+    fn managed_local_failures_restart_the_owned_sidecar() {
+        let controller = GatewayOwnershipController::new(GatewayIntent::managed_local(4269));
+        assert_eq!(
+            controller.recovery_action(),
+            RecoveryAction::RestartManagedSidecar
+        );
+    }
+
+    #[test]
+    fn external_failures_reconnect_without_starting_a_sidecar() {
+        let mut controller = GatewayOwnershipController::new(GatewayIntent::attached_external(
+            4269,
+            "gateway-test".into(),
+        ));
+        assert_eq!(
+            controller.recovery_action(),
+            RecoveryAction::ReconnectExternal
+        );
+        let generation = controller
+            .begin_external_reconnect()
+            .expect("begin reconnect");
+        assert!(controller.external_reconnect_is_current(generation));
+        assert_eq!(controller.begin_external_reconnect(), None);
+        assert!(controller.finish_external_reconnect(generation));
+    }
+
+    #[test]
+    fn external_reconnect_retries_when_the_port_becomes_free() {
+        assert_eq!(
+            external_probe_action(Some("gateway-test"), GatewayProbeStatus::Available),
+            ExternalProbeAction::Retry
+        );
+    }
+
+    #[test]
+    fn external_reconnect_accepts_only_the_persisted_gateway_identity() {
+        let matching = GatewayProbeStatus::CybaraGateway(GatewayCompatibility::Compatible {
+            gateway_version: "1.0.2310".into(),
+            exact_match: true,
+            gateway_id: Some("gateway-test".into()),
+        });
+        let replacement = GatewayProbeStatus::CybaraGateway(GatewayCompatibility::Compatible {
+            gateway_version: "1.0.2310".into(),
+            exact_match: true,
+            gateway_id: Some("replacement-gateway".into()),
+        });
+        assert_eq!(
+            external_probe_action(Some("gateway-test"), matching),
+            ExternalProbeAction::Reattach
+        );
+        assert!(matches!(
+            external_probe_action(Some("gateway-test"), replacement),
+            ExternalProbeAction::Fail(reason) if reason.contains("different Cybara gateway")
+        ));
+    }
+
+    #[test]
+    fn external_reconnect_fails_closed_for_non_cybara_and_incompatible_services() {
+        assert!(matches!(
+            external_probe_action(Some("gateway-test"), GatewayProbeStatus::NonCybara),
+            ExternalProbeAction::Fail(reason) if reason.contains("non-Cybara service")
+        ));
+        assert_eq!(
+            external_probe_action(
+                Some("gateway-test"),
+                GatewayProbeStatus::CybaraGateway(GatewayCompatibility::Incompatible {
+                    gateway_version: Some("2.0.0".into()),
+                    reason: "Gateway major version is incompatible.".into(),
+                })
+            ),
+            ExternalProbeAction::Fail("Gateway major version is incompatible.".into())
+        );
+    }
+
+    #[test]
+    fn explicit_switch_to_local_requires_a_free_port() {
+        assert_eq!(
+            switch_to_local_action(false),
+            SwitchToLocalAction::WaitForFreePort
+        );
+        assert_eq!(
+            switch_to_local_action(true),
+            SwitchToLocalAction::StartManagedSidecar
+        );
+    }
+
+    #[test]
+    fn explicit_switch_to_local_cancels_external_reconnect() {
+        let mut controller = GatewayOwnershipController::new(GatewayIntent::attached_external(
+            4269,
+            "gateway-test".into(),
+        ));
+        let generation = controller
+            .begin_external_reconnect()
+            .expect("begin reconnect");
+        controller.set_intent(GatewayIntent::managed_local(4269));
+        assert!(!controller.external_reconnect_is_current(generation));
+        assert_eq!(
+            controller.recovery_action(),
+            RecoveryAction::RestartManagedSidecar
+        );
+    }
+
+    #[test]
+    fn external_intent_survives_application_restart() {
+        let root =
+            std::env::temp_dir().join(format!("cybara-gateway-intent-{}", std::process::id()));
+        let path = root.join("gateway-intent.json");
+        let intent = GatewayIntent::attached_external(4269, "gateway-test".into());
+        persist_gateway_intent(&path, &intent).expect("persist intent");
+        let loaded = load_gateway_intent(&path, 4269).expect("load intent");
+        assert_eq!(loaded.intent, intent);
+        assert!(loaded.persisted);
+        assert_eq!(
+            GatewayOwnershipController::new(loaded.intent).recovery_action(),
+            RecoveryAction::ReconnectExternal
+        );
+        std::fs::remove_dir_all(root).expect("remove intent fixture");
+    }
+
+    #[test]
+    fn interrupted_replacement_recovers_the_previous_external_intent() {
+        let root = std::env::temp_dir().join(format!(
+            "cybara-backed-up-gateway-intent-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&root).expect("create fixture");
+        let path = root.join("gateway-intent.json");
+        let backup = path.with_extension("json.backup");
+        let intent = GatewayIntent::attached_external(4269, "gateway-test".into());
+        std::fs::write(
+            &backup,
+            serde_json::to_vec(&intent).expect("serialize intent"),
+        )
+        .expect("write backup");
+        let loaded = load_gateway_intent(&path, 4269).expect("recover intent");
+        assert_eq!(loaded.intent, intent);
+        assert!(loaded.persisted);
+        std::fs::remove_dir_all(root).expect("remove fixture");
+    }
+
+    #[test]
+    fn invalid_persisted_intent_fails_closed() {
+        let root = std::env::temp_dir().join(format!(
+            "cybara-invalid-gateway-intent-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&root).expect("create fixture");
+        let path = root.join("gateway-intent.json");
+        std::fs::write(&path, br#"{"ownership":"attachedExternal","port":0}"#)
+            .expect("write fixture");
+        assert!(load_gateway_intent(&path, 4269).is_err());
+        std::fs::remove_dir_all(root).expect("remove fixture");
+    }
+
+    #[test]
+    fn external_intent_without_identity_fails_closed() {
+        let root = std::env::temp_dir().join(format!(
+            "cybara-missing-gateway-identity-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&root).expect("create fixture");
+        let path = root.join("gateway-intent.json");
+        std::fs::write(
+            &path,
+            br#"{"ownership":"attachedExternal","port":4269,"gateway_id":null}"#,
+        )
+        .expect("write fixture");
+        assert!(load_gateway_intent(&path, 4269).is_err());
+        std::fs::remove_dir_all(root).expect("remove fixture");
+    }
+
+    #[test]
+    fn missing_intent_defaults_to_managed_local() {
+        let path = std::env::temp_dir().join(format!(
+            "cybara-missing-gateway-intent-{}",
+            std::process::id()
+        ));
+        let loaded = load_gateway_intent(&path, 4269).expect("default intent");
+        assert_eq!(loaded.intent.ownership, GatewayOwnership::ManagedLocal);
+        assert!(!loaded.persisted);
+    }
+}

--- a/src-tauri/src/gateway_ownership.rs
+++ b/src-tauri/src/gateway_ownership.rs
@@ -196,19 +196,8 @@ impl GatewayOwnershipController {
     }
 }
 
-pub fn load_gateway_intent(path: &Path, default_port: u16) -> Result<LoadedGatewayIntent, String> {
-    let backup = path.with_extension("json.backup");
-    let source = if path.exists() {
-        path
-    } else if backup.exists() {
-        backup.as_path()
-    } else {
-        return Ok(LoadedGatewayIntent {
-            intent: GatewayIntent::managed_local(default_port),
-            persisted: false,
-        });
-    };
-    let bytes = std::fs::read(source).map_err(|error| error.to_string())?;
+fn read_gateway_intent(path: &Path) -> Result<GatewayIntent, String> {
+    let bytes = std::fs::read(path).map_err(|error| error.to_string())?;
     let intent: GatewayIntent = serde_json::from_slice(&bytes)
         .map_err(|error| format!("Invalid gateway intent: {error}"))?;
     if intent.port == 0 {
@@ -224,6 +213,26 @@ pub fn load_gateway_intent(path: &Path, default_port: u16) -> Result<LoadedGatew
     {
         return Err("Invalid gateway intent: external gateway identity is missing".into());
     }
+    Ok(intent)
+}
+
+pub fn load_gateway_intent(path: &Path, default_port: u16) -> Result<LoadedGatewayIntent, String> {
+    let backup = path.with_extension("json.backup");
+    if !path.exists() && !backup.exists() {
+        return Ok(LoadedGatewayIntent {
+            intent: GatewayIntent::managed_local(default_port),
+            persisted: false,
+        });
+    }
+    let intent = match read_gateway_intent(path) {
+        Ok(intent) => intent,
+        Err(primary_error) if backup.exists() => read_gateway_intent(&backup).map_err(|backup_error| {
+            format!(
+                "Invalid gateway intent and backup: primary: {primary_error}; backup: {backup_error}"
+            )
+        })?,
+        Err(error) => return Err(error),
+    };
     Ok(LoadedGatewayIntent {
         intent,
         persisted: true,
@@ -440,6 +449,31 @@ mod tests {
         let loaded = load_gateway_intent(&path, 4269).expect("recover intent");
         assert_eq!(loaded.intent, intent);
         assert!(loaded.persisted);
+        std::fs::remove_dir_all(root).expect("remove fixture");
+    }
+
+    #[test]
+    fn corrupt_primary_recovers_valid_external_backup() {
+        let root = std::env::temp_dir().join(format!(
+            "cybara-corrupt-primary-gateway-intent-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&root).expect("create fixture");
+        let path = root.join("gateway-intent.json");
+        let backup = path.with_extension("json.backup");
+        std::fs::write(&path, b"not json").expect("write corrupt primary");
+        std::fs::write(
+            &backup,
+            serde_json::to_vec(&GatewayIntent::attached_external(
+                4269,
+                "gateway-test".into(),
+            ))
+            .expect("serialize backup"),
+        )
+        .expect("write backup");
+        let loaded = load_gateway_intent(&path, 4269).expect("recover backup");
+        assert_eq!(loaded.intent.ownership, GatewayOwnership::AttachedExternal);
+        assert_eq!(loaded.intent.gateway_id.as_deref(), Some("gateway-test"));
         std::fs::remove_dir_all(root).expect("remove fixture");
     }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -273,14 +273,7 @@ fn restart_gateway_sidecar(app: tauri::AppHandle) -> Result<(), String> {
         gateway_ownership::GatewayOwnership::ManagedLocal => {
             reset_gateway_supervision(&app)?;
             stop_sidecar(&app);
-            set_gateway_startup_status(
-                &app,
-                GatewayStartupStatus::restarting(
-                    "Restarting the managed Cybara gateway.",
-                    gateway_ownership::GatewayOwnership::ManagedLocal,
-                ),
-            );
-            start_sidecar(app, false);
+            schedule_sidecar_restart(app, "Restarting the managed Cybara gateway.".into());
         }
         gateway_ownership::GatewayOwnership::AttachedExternal => {
             start_external_gateway_reconnect(app);
@@ -950,7 +943,7 @@ fn wait_for_existing_gateway(
                     set_gateway_startup_status(
                         &app,
                         GatewayStartupStatus::failed(
-                            "The external gateway does not publish a stable identity. Update that gateway before attaching so Cybara can prevent silent gateway replacement.",
+                            "The external gateway does not publish the supported gateway identity capability. Update that gateway before attaching so Cybara can detect accidental gateway replacement.",
                             if allow_external_attach {
                                 gateway_ownership::GatewayOwnership::AttachedExternal
                             } else {
@@ -1056,7 +1049,7 @@ fn start_sidecar(app: tauri::AppHandle, allow_external_attach: bool) {
             set_gateway_startup_status(
                 &app,
                 GatewayStartupStatus::failed(
-                    "The external gateway does not publish a stable identity. Update that gateway before attaching so Cybara can prevent silent gateway replacement.",
+                    "The external gateway does not publish the supported gateway identity capability. Update that gateway before attaching so Cybara can detect accidental gateway replacement.",
                     if allow_external_attach {
                         gateway_ownership::GatewayOwnership::AttachedExternal
                     } else {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -11,6 +11,7 @@ use tauri_plugin_shell::ShellExt;
 
 mod desktop_update;
 mod gateway;
+mod gateway_ownership;
 mod gateway_supervision;
 mod tray;
 
@@ -22,34 +23,40 @@ const MAX_NATIVE_RECORDING_BYTES: u64 = 64 * 1024 * 1024;
 struct GatewayStartupStatus {
     phase: String,
     message: Option<String>,
+    ownership: String,
+    can_switch_to_local: bool,
 }
 
 impl GatewayStartupStatus {
-    fn starting() -> Self {
-        Self {
-            phase: "starting".into(),
-            message: None,
-        }
+    fn starting(ownership: gateway_ownership::GatewayOwnership) -> Self {
+        Self::with_phase("starting", None, ownership)
     }
 
-    fn ready() -> Self {
-        Self {
-            phase: "ready".into(),
-            message: None,
-        }
+    fn ready(ownership: gateway_ownership::GatewayOwnership) -> Self {
+        Self::with_phase("ready", None, ownership)
     }
 
-    fn restarting(message: impl Into<String>) -> Self {
-        Self {
-            phase: "starting".into(),
-            message: Some(message.into()),
-        }
+    fn restarting(
+        message: impl Into<String>,
+        ownership: gateway_ownership::GatewayOwnership,
+    ) -> Self {
+        Self::with_phase("starting", Some(message.into()), ownership)
     }
 
-    fn failed(message: impl Into<String>) -> Self {
+    fn failed(message: impl Into<String>, ownership: gateway_ownership::GatewayOwnership) -> Self {
+        Self::with_phase("failed", Some(message.into()), ownership)
+    }
+
+    fn with_phase(
+        phase: &str,
+        message: Option<String>,
+        ownership: gateway_ownership::GatewayOwnership,
+    ) -> Self {
         Self {
-            phase: "failed".into(),
-            message: Some(message.into()),
+            phase: phase.into(),
+            message,
+            ownership: ownership.as_str().into(),
+            can_switch_to_local: ownership == gateway_ownership::GatewayOwnership::AttachedExternal,
         }
     }
 }
@@ -255,11 +262,64 @@ fn set_gateway_startup_status(app: &tauri::AppHandle, status: GatewayStartupStat
 fn get_gateway_startup_status(app: tauri::AppHandle) -> GatewayStartupStatus {
     app.try_state::<GatewayStartupState>()
         .and_then(|state| state.0.lock().ok().map(|guard| guard.clone()))
-        .unwrap_or_else(GatewayStartupStatus::starting)
+        .unwrap_or_else(|| {
+            GatewayStartupStatus::starting(gateway_ownership::GatewayOwnership::ManagedLocal)
+        })
 }
 
 #[tauri::command]
 fn restart_gateway_sidecar(app: tauri::AppHandle) -> Result<(), String> {
+    match gateway_intent(&app).ownership {
+        gateway_ownership::GatewayOwnership::ManagedLocal => {
+            reset_gateway_supervision(&app)?;
+            stop_sidecar(&app);
+            set_gateway_startup_status(
+                &app,
+                GatewayStartupStatus::restarting(
+                    "Restarting the managed Cybara gateway.",
+                    gateway_ownership::GatewayOwnership::ManagedLocal,
+                ),
+            );
+            start_sidecar(app, false);
+        }
+        gateway_ownership::GatewayOwnership::AttachedExternal => {
+            start_external_gateway_reconnect(app);
+        }
+    }
+    Ok(())
+}
+
+#[tauri::command]
+fn switch_to_local_gateway(app: tauri::AppHandle) -> Result<(), String> {
+    let endpoint = gateway::GatewayEndpoint::loopback(CYBARA_DEFAULT_PORT);
+    if gateway_ownership::switch_to_local_action(matches!(
+        gateway::probe_gateway_at(&endpoint.addr, env!("CARGO_PKG_VERSION")),
+        gateway::GatewayProbeStatus::Available
+    )) == gateway_ownership::SwitchToLocalAction::WaitForFreePort
+    {
+        return Err(
+            "Port 4269 must be free before switching to the managed local gateway. Stop the forwarding connection or occupying service, then try again."
+                .into(),
+        );
+    }
+    set_gateway_intent(
+        &app,
+        gateway_ownership::GatewayIntent::managed_local(CYBARA_DEFAULT_PORT),
+    )?;
+    reset_gateway_supervision(&app)?;
+    stop_sidecar(&app);
+    set_gateway_startup_status(
+        &app,
+        GatewayStartupStatus::restarting(
+            "Switching to the managed local Cybara gateway.",
+            gateway_ownership::GatewayOwnership::ManagedLocal,
+        ),
+    );
+    start_sidecar(app, false);
+    Ok(())
+}
+
+fn reset_gateway_supervision(app: &tauri::AppHandle) -> Result<(), String> {
     let state = app
         .try_state::<GatewaySupervisionState>()
         .ok_or_else(|| "Gateway supervisor is unavailable".to_string())?;
@@ -268,13 +328,6 @@ fn restart_gateway_sidecar(app: tauri::AppHandle) -> Result<(), String> {
         .lock()
         .map_err(|_| "Gateway supervisor is unavailable".to_string())?;
     *guard = gateway_supervision::GatewaySupervision::default();
-    drop(guard);
-    stop_sidecar(&app);
-    set_gateway_startup_status(
-        &app,
-        GatewayStartupStatus::restarting("Restarting the Cybara gateway."),
-    );
-    start_sidecar(app);
     Ok(())
 }
 
@@ -413,6 +466,44 @@ fn set_gateway_endpoint(app: &tauri::AppHandle, endpoint: gateway::GatewayEndpoi
     {
         *guard = endpoint;
     }
+}
+
+fn gateway_intent_path(app: &tauri::AppHandle) -> Result<PathBuf, String> {
+    app.path()
+        .app_local_data_dir()
+        .map(|path| path.join("gateway-intent.json"))
+        .map_err(|error| error.to_string())
+}
+
+fn gateway_intent(app: &tauri::AppHandle) -> gateway_ownership::GatewayIntent {
+    app.try_state::<GatewayOwnershipState>()
+        .and_then(|state| state.0.lock().ok().map(|guard| guard.intent()))
+        .unwrap_or_else(|| gateway_ownership::GatewayIntent::managed_local(CYBARA_DEFAULT_PORT))
+}
+
+fn gateway_recovery_action(app: &tauri::AppHandle) -> gateway_ownership::RecoveryAction {
+    app.try_state::<GatewayOwnershipState>()
+        .and_then(|state| state.0.lock().ok().map(|guard| guard.recovery_action()))
+        .unwrap_or(gateway_ownership::RecoveryAction::RestartManagedSidecar)
+}
+
+fn set_gateway_intent(
+    app: &tauri::AppHandle,
+    intent: gateway_ownership::GatewayIntent,
+) -> Result<(), String> {
+    let path = gateway_intent_path(app)?;
+    gateway_ownership::persist_gateway_intent(&path, &intent)?;
+    let state = app
+        .try_state::<GatewayOwnershipState>()
+        .ok_or_else(|| "Gateway ownership state is unavailable".to_string())?;
+    let mut guard = state
+        .0
+        .lock()
+        .map_err(|_| "Gateway ownership state is unavailable".to_string())?;
+    let port = intent.port;
+    guard.set_intent(intent);
+    set_gateway_endpoint(app, gateway::GatewayEndpoint::loopback(port));
+    Ok(())
 }
 
 #[tauri::command]
@@ -574,9 +665,130 @@ fn record_gateway_healthy(app: &tauri::AppHandle) {
     }
 }
 
+fn start_gateway_for_intent(app: tauri::AppHandle, allow_external_attach: bool) {
+    match gateway_recovery_action(&app) {
+        gateway_ownership::RecoveryAction::RestartManagedSidecar => {
+            start_sidecar(app, allow_external_attach)
+        }
+        gateway_ownership::RecoveryAction::ReconnectExternal => {
+            start_external_gateway_reconnect(app)
+        }
+    }
+}
+
+fn external_reconnect_delay(attempt: u32) -> Duration {
+    Duration::from_secs(1_u64 << attempt.min(4))
+}
+
+fn start_external_gateway_reconnect(app: tauri::AppHandle) {
+    let Some((generation, intent)) = app.try_state::<GatewayOwnershipState>().and_then(|state| {
+        state.0.lock().ok().and_then(|mut guard| {
+            let intent = guard.intent();
+            guard
+                .begin_external_reconnect()
+                .map(|generation| (generation, intent))
+        })
+    }) else {
+        return;
+    };
+    let endpoint = gateway::GatewayEndpoint::loopback(intent.port);
+    set_gateway_endpoint(&app, endpoint.clone());
+    set_gateway_startup_status(
+        &app,
+        GatewayStartupStatus::restarting(
+            "The attached external gateway is disconnected. Reconnecting without starting a local gateway.",
+            gateway_ownership::GatewayOwnership::AttachedExternal,
+        ),
+    );
+    std::thread::spawn(move || {
+        let mut attempt = 0;
+        loop {
+            let current = app
+                .try_state::<GatewayOwnershipState>()
+                .and_then(|state| {
+                    state
+                        .0
+                        .lock()
+                        .ok()
+                        .map(|guard| guard.external_reconnect_is_current(generation))
+                })
+                .unwrap_or(false);
+            if !current {
+                return;
+            }
+            let probe = gateway::probe_gateway_at(&endpoint.addr, env!("CARGO_PKG_VERSION"));
+            let incompatibility = match &probe {
+                gateway::GatewayProbeStatus::CybaraGateway(
+                    gateway::GatewayCompatibility::Incompatible {
+                        gateway_version,
+                        reason,
+                    },
+                ) => Some(gateway_version_failure(
+                    env!("CARGO_PKG_VERSION"),
+                    gateway_version.as_deref(),
+                    reason,
+                )),
+                _ => None,
+            };
+            match gateway_ownership::external_probe_action(intent.gateway_id.as_deref(), probe) {
+                gateway_ownership::ExternalProbeAction::Reattach => {
+                    if let Some(state) = app.try_state::<GatewayOwnershipState>()
+                        && let Ok(mut guard) = state.0.lock()
+                        && guard.finish_external_reconnect(generation)
+                    {
+                        record_gateway_healthy(&app);
+                        set_gateway_startup_status(
+                            &app,
+                            GatewayStartupStatus::ready(
+                                gateway_ownership::GatewayOwnership::AttachedExternal,
+                            ),
+                        );
+                        navigate_after_ready(&app);
+                    }
+                    return;
+                }
+                gateway_ownership::ExternalProbeAction::Retry => {}
+                gateway_ownership::ExternalProbeAction::Fail(reason) => {
+                    finish_external_reconnect_with_failure(
+                        &app,
+                        generation,
+                        incompatibility.unwrap_or(reason),
+                    );
+                    return;
+                }
+            }
+            std::thread::sleep(external_reconnect_delay(attempt));
+            attempt = attempt.saturating_add(1);
+        }
+    });
+}
+
+fn finish_external_reconnect_with_failure(
+    app: &tauri::AppHandle,
+    generation: u64,
+    message: String,
+) {
+    if let Some(state) = app.try_state::<GatewayOwnershipState>()
+        && let Ok(mut guard) = state.0.lock()
+        && guard.finish_external_reconnect(generation)
+    {
+        set_gateway_startup_status(
+            app,
+            GatewayStartupStatus::failed(
+                message,
+                gateway_ownership::GatewayOwnership::AttachedExternal,
+            ),
+        );
+    }
+}
+
 fn schedule_sidecar_restart(app: tauri::AppHandle, reason: String) {
     use gateway_supervision::RestartPlan;
 
+    if gateway_recovery_action(&app) == gateway_ownership::RecoveryAction::ReconnectExternal {
+        start_external_gateway_reconnect(app);
+        return;
+    }
     let plan = app
         .try_state::<GatewaySupervisionState>()
         .and_then(|state| {
@@ -594,7 +806,13 @@ fn schedule_sidecar_restart(app: tauri::AppHandle, reason: String) {
                 gateway_supervision::MAX_RESTART_ATTEMPTS
             );
             log::warn!("{reason} {message}");
-            set_gateway_startup_status(&app, GatewayStartupStatus::restarting(message));
+            set_gateway_startup_status(
+                &app,
+                GatewayStartupStatus::restarting(
+                    message,
+                    gateway_ownership::GatewayOwnership::ManagedLocal,
+                ),
+            );
             std::thread::spawn(move || {
                 std::thread::sleep(delay);
                 let should_start = app
@@ -607,8 +825,11 @@ fn schedule_sidecar_restart(app: tauri::AppHandle, reason: String) {
                             .map(|mut guard| guard.begin_scheduled_restart())
                     })
                     .unwrap_or(false);
-                if should_start {
-                    start_sidecar(app);
+                if should_start
+                    && gateway_intent(&app).ownership
+                        == gateway_ownership::GatewayOwnership::ManagedLocal
+                {
+                    start_sidecar(app, false);
                 }
             });
         }
@@ -618,7 +839,13 @@ fn schedule_sidecar_restart(app: tauri::AppHandle, reason: String) {
                 gateway_supervision::MAX_RESTART_ATTEMPTS
             );
             log::error!("{reason} {message}");
-            set_gateway_startup_status(&app, GatewayStartupStatus::failed(message));
+            set_gateway_startup_status(
+                &app,
+                GatewayStartupStatus::failed(
+                    message,
+                    gateway_ownership::GatewayOwnership::ManagedLocal,
+                ),
+            );
         }
         Some(RestartPlan::AlreadyScheduled | RestartPlan::ShuttingDown) | None => {}
     }
@@ -639,11 +866,27 @@ fn attach_existing_gateway(
     app: &tauri::AppHandle,
     generation: u64,
     endpoint: gateway::GatewayEndpoint,
+    gateway_id: String,
 ) {
     release_sidecar_launch(app, generation);
-    set_gateway_endpoint(app, endpoint);
+    let intent = gateway_ownership::GatewayIntent::attached_external(endpoint.port(), gateway_id);
+    if let Err(error) = set_gateway_intent(app, intent) {
+        set_gateway_startup_status(
+            app,
+            GatewayStartupStatus::failed(
+                format!(
+                    "The external gateway was verified, but its ownership could not be saved: {error}"
+                ),
+                gateway_ownership::GatewayOwnership::AttachedExternal,
+            ),
+        );
+        return;
+    }
     record_gateway_healthy(app);
-    set_gateway_startup_status(app, GatewayStartupStatus::ready());
+    set_gateway_startup_status(
+        app,
+        GatewayStartupStatus::ready(gateway_ownership::GatewayOwnership::AttachedExternal),
+    );
     navigate_after_ready(app);
 }
 
@@ -651,11 +894,13 @@ fn wait_for_existing_gateway(
     app: tauri::AppHandle,
     generation: u64,
     endpoint: gateway::GatewayEndpoint,
+    allow_external_attach: bool,
 ) {
     set_gateway_startup_status(
         &app,
         GatewayStartupStatus::restarting(
             "The existing Cybara gateway is busy. Waiting for it to respond.",
+            gateway_ownership::GatewayOwnership::AttachedExternal,
         ),
     );
     std::thread::spawn(move || {
@@ -668,15 +913,51 @@ fn wait_for_existing_gateway(
                     GatewayStartupStatus::failed(
                         "The existing service on port 4269 did not become a healthy Cybara gateway within 60 seconds. Check that gateway or the forwarding connection, then retry."
                             .to_string(),
+                        gateway_ownership::GatewayOwnership::AttachedExternal,
                     ),
                 );
                 return;
             }
             match gateway::probe_gateway_at(&endpoint.addr, env!("CARGO_PKG_VERSION")) {
                 gateway::GatewayProbeStatus::CybaraGateway(
-                    gateway::GatewayCompatibility::Compatible { .. },
+                    gateway::GatewayCompatibility::Compatible {
+                        gateway_id: Some(gateway_id),
+                        ..
+                    },
                 ) => {
-                    attach_existing_gateway(&app, generation, endpoint);
+                    if gateway_ownership::existing_gateway_action(allow_external_attach)
+                        == gateway_ownership::ExistingGatewayAction::AttachExternal
+                    {
+                        attach_existing_gateway(&app, generation, endpoint, gateway_id);
+                    } else {
+                        release_sidecar_launch(&app, generation);
+                        set_gateway_startup_status(
+                            &app,
+                            GatewayStartupStatus::failed(
+                                "A pre-existing Cybara gateway is occupying the managed local gateway port. Cybara refused to change gateway ownership during recovery.",
+                                gateway_ownership::GatewayOwnership::ManagedLocal,
+                            ),
+                        );
+                    }
+                    return;
+                }
+                gateway::GatewayProbeStatus::CybaraGateway(
+                    gateway::GatewayCompatibility::Compatible {
+                        gateway_id: None, ..
+                    },
+                ) => {
+                    release_sidecar_launch(&app, generation);
+                    set_gateway_startup_status(
+                        &app,
+                        GatewayStartupStatus::failed(
+                            "The external gateway does not publish a stable identity. Update that gateway before attaching so Cybara can prevent silent gateway replacement.",
+                            if allow_external_attach {
+                                gateway_ownership::GatewayOwnership::AttachedExternal
+                            } else {
+                                gateway_ownership::GatewayOwnership::ManagedLocal
+                            },
+                        ),
+                    );
                     return;
                 }
                 gateway::GatewayProbeStatus::Busy => {
@@ -692,13 +973,24 @@ fn wait_for_existing_gateway(
                         GatewayStartupStatus::failed(
                             "Port 4269 is occupied by a non-Cybara service. Stop it before starting Cybara."
                                 .to_string(),
+                            gateway_ownership::GatewayOwnership::AttachedExternal,
                         ),
                     );
                     return;
                 }
                 gateway::GatewayProbeStatus::Available => {
                     release_sidecar_launch(&app, generation);
-                    start_sidecar(app);
+                    if allow_external_attach {
+                        set_gateway_startup_status(
+                            &app,
+                            GatewayStartupStatus::failed(
+                                "The pre-existing gateway endpoint disappeared before its identity could be verified. Cybara refused to start a local replacement. Restore the external gateway and retry, or explicitly switch to local mode.",
+                                gateway_ownership::GatewayOwnership::AttachedExternal,
+                            ),
+                        );
+                    } else {
+                        start_sidecar(app, false);
+                    }
                     return;
                 }
                 gateway::GatewayProbeStatus::CybaraGateway(
@@ -710,11 +1002,14 @@ fn wait_for_existing_gateway(
                     release_sidecar_launch(&app, generation);
                     set_gateway_startup_status(
                         &app,
-                        GatewayStartupStatus::failed(gateway_version_failure(
-                            env!("CARGO_PKG_VERSION"),
-                            gateway_version.as_deref(),
-                            &reason,
-                        )),
+                        GatewayStartupStatus::failed(
+                            gateway_version_failure(
+                                env!("CARGO_PKG_VERSION"),
+                                gateway_version.as_deref(),
+                                &reason,
+                            ),
+                            gateway_ownership::GatewayOwnership::AttachedExternal,
+                        ),
                     );
                     return;
                 }
@@ -723,20 +1018,56 @@ fn wait_for_existing_gateway(
     });
 }
 
-fn start_sidecar(app: tauri::AppHandle) {
+fn start_sidecar(app: tauri::AppHandle, allow_external_attach: bool) {
+    if gateway_intent(&app).ownership != gateway_ownership::GatewayOwnership::ManagedLocal {
+        start_external_gateway_reconnect(app);
+        return;
+    }
     let Some(generation) = reserve_sidecar_launch(&app) else {
         return;
     };
     let preferred = gateway::GatewayEndpoint::loopback(CYBARA_DEFAULT_PORT);
     match gateway::probe_gateway_at(&preferred.addr, env!("CARGO_PKG_VERSION")) {
         gateway::GatewayProbeStatus::CybaraGateway(gateway::GatewayCompatibility::Compatible {
+            gateway_id: Some(gateway_id),
             ..
         }) => {
-            attach_existing_gateway(&app, generation, preferred);
+            if gateway_ownership::existing_gateway_action(allow_external_attach)
+                == gateway_ownership::ExistingGatewayAction::AttachExternal
+            {
+                attach_existing_gateway(&app, generation, preferred, gateway_id);
+            } else {
+                release_sidecar_launch(&app, generation);
+                set_gateway_startup_status(
+                    &app,
+                    GatewayStartupStatus::failed(
+                        "A pre-existing Cybara gateway is occupying the managed local gateway port. Cybara refused to change gateway ownership during recovery.",
+                        gateway_ownership::GatewayOwnership::ManagedLocal,
+                    ),
+                );
+            }
+            return;
+        }
+        gateway::GatewayProbeStatus::CybaraGateway(gateway::GatewayCompatibility::Compatible {
+            gateway_id: None,
+            ..
+        }) => {
+            release_sidecar_launch(&app, generation);
+            set_gateway_startup_status(
+                &app,
+                GatewayStartupStatus::failed(
+                    "The external gateway does not publish a stable identity. Update that gateway before attaching so Cybara can prevent silent gateway replacement.",
+                    if allow_external_attach {
+                        gateway_ownership::GatewayOwnership::AttachedExternal
+                    } else {
+                        gateway_ownership::GatewayOwnership::ManagedLocal
+                    },
+                ),
+            );
             return;
         }
         gateway::GatewayProbeStatus::Busy | gateway::GatewayProbeStatus::UnhealthyCybara { .. } => {
-            wait_for_existing_gateway(app, generation, preferred);
+            wait_for_existing_gateway(app, generation, preferred, allow_external_attach);
             return;
         }
         gateway::GatewayProbeStatus::NonCybara => {
@@ -746,6 +1077,7 @@ fn start_sidecar(app: tauri::AppHandle) {
                 GatewayStartupStatus::failed(
                     "Port 4269 is occupied by a non-Cybara service. Stop it before starting Cybara."
                         .to_string(),
+                    gateway_ownership::GatewayOwnership::ManagedLocal,
                 ),
             );
             return;
@@ -759,15 +1091,33 @@ fn start_sidecar(app: tauri::AppHandle) {
             release_sidecar_launch(&app, generation);
             set_gateway_startup_status(
                 &app,
-                GatewayStartupStatus::failed(gateway_version_failure(
-                    env!("CARGO_PKG_VERSION"),
-                    gateway_version.as_deref(),
-                    &reason,
-                )),
+                GatewayStartupStatus::failed(
+                    gateway_version_failure(
+                        env!("CARGO_PKG_VERSION"),
+                        gateway_version.as_deref(),
+                        &reason,
+                    ),
+                    gateway_ownership::GatewayOwnership::ManagedLocal,
+                ),
             );
             return;
         }
         gateway::GatewayProbeStatus::Available => {}
+    }
+
+    if let Err(error) = set_gateway_intent(
+        &app,
+        gateway_ownership::GatewayIntent::managed_local(CYBARA_DEFAULT_PORT),
+    ) {
+        release_sidecar_launch(&app, generation);
+        set_gateway_startup_status(
+            &app,
+            GatewayStartupStatus::failed(
+                format!("The managed gateway ownership could not be saved: {error}"),
+                gateway_ownership::GatewayOwnership::ManagedLocal,
+            ),
+        );
+        return;
     }
 
     log::info!("Starting Cybara gateway sidecar on port {CYBARA_DEFAULT_PORT}");
@@ -900,7 +1250,10 @@ fn start_sidecar(app: tauri::AppHandle) {
             Duration::from_secs(25),
         ) {
             record_gateway_healthy(&app);
-            set_gateway_startup_status(&app, GatewayStartupStatus::ready());
+            set_gateway_startup_status(
+                &app,
+                GatewayStartupStatus::ready(gateway_ownership::GatewayOwnership::ManagedLocal),
+            );
             navigate_after_ready(&app);
         } else {
             stop_sidecar_generation(&app, generation);
@@ -910,6 +1263,16 @@ fn start_sidecar(app: tauri::AppHandle) {
             );
         }
     });
+}
+
+fn attached_external_gateway_is_current(app: &tauri::AppHandle) -> bool {
+    let intent = gateway_intent(app);
+    if intent.ownership != gateway_ownership::GatewayOwnership::AttachedExternal {
+        return true;
+    }
+    let endpoint = gateway_endpoint(app);
+    gateway::compatible_gateway_id_at(&endpoint.addr, env!("CARGO_PKG_VERSION")).as_deref()
+        == intent.gateway_id.as_deref()
 }
 
 fn start_gateway_watchdog(app: tauri::AppHandle) {
@@ -931,7 +1294,14 @@ fn start_gateway_watchdog(app: tauri::AppHandle) {
                 continue;
             }
             let endpoint = gateway_endpoint(&app);
-            let liveness = gateway::gateway_liveness_at(&endpoint.addr);
+            let liveness = if gateway_intent(&app).ownership
+                == gateway_ownership::GatewayOwnership::AttachedExternal
+                && !attached_external_gateway_is_current(&app)
+            {
+                gateway::GatewayLivenessStatus::Unhealthy
+            } else {
+                gateway::gateway_liveness_at(&endpoint.addr)
+            };
             let should_restart = app
                 .try_state::<GatewaySupervisionState>()
                 .and_then(|state| {
@@ -950,11 +1320,18 @@ fn start_gateway_watchdog(app: tauri::AppHandle) {
                 })
                 .unwrap_or(false);
             if should_restart {
-                stop_sidecar(&app);
-                schedule_sidecar_restart(
-                    app.clone(),
-                    "Gateway liveness probe failed repeatedly.".into(),
-                );
+                match gateway_recovery_action(&app) {
+                    gateway_ownership::RecoveryAction::RestartManagedSidecar => {
+                        stop_sidecar(&app);
+                        schedule_sidecar_restart(
+                            app.clone(),
+                            "Gateway liveness probe failed repeatedly.".into(),
+                        );
+                    }
+                    gateway_ownership::RecoveryAction::ReconnectExternal => {
+                        start_external_gateway_reconnect(app.clone());
+                    }
+                }
             }
         }
     });
@@ -994,6 +1371,7 @@ fn main() {
             get_gateway_url,
             get_gateway_startup_status,
             restart_gateway_sidecar,
+            switch_to_local_gateway,
             start_native_recording,
             stop_native_recording,
             write_theme_file,
@@ -1009,11 +1387,40 @@ fn main() {
                 gateway_supervision::GatewaySupervision::default(),
             )));
             app.manage(PendingOpen(std::sync::Mutex::new(None)));
+            let intent_path = app.path().app_local_data_dir()?.join("gateway-intent.json");
+            let intent_result =
+                gateway_ownership::load_gateway_intent(&intent_path, CYBARA_DEFAULT_PORT);
+            let intent_error = intent_result.as_ref().err().cloned();
+            let loaded_intent = intent_result.unwrap_or_else(|error| {
+                log::error!("{error}");
+                gateway_ownership::LoadedGatewayIntent {
+                    intent: gateway_ownership::GatewayIntent::attached_external(
+                        CYBARA_DEFAULT_PORT,
+                        "invalid-persisted-gateway-intent".into(),
+                    ),
+                    persisted: true,
+                }
+            });
+            let allow_external_attach = !loaded_intent.persisted;
+            let intent = loaded_intent.intent;
+            app.manage(GatewayOwnershipState(std::sync::Mutex::new(
+                gateway_ownership::GatewayOwnershipController::new(intent.clone()),
+            )));
             app.manage(GatewayStartupState(std::sync::Mutex::new(
-                GatewayStartupStatus::starting(),
+                intent_error
+                    .as_ref()
+                    .map(|error| {
+                        GatewayStartupStatus::failed(
+                            format!(
+                                "The saved external gateway intent could not be read: {error}. Cybara refused to start a local replacement."
+                            ),
+                            gateway_ownership::GatewayOwnership::AttachedExternal,
+                        )
+                    })
+                    .unwrap_or_else(|| GatewayStartupStatus::starting(intent.ownership)),
             )));
             app.manage(GatewayRuntimeState(std::sync::Mutex::new(
-                gateway::GatewayEndpoint::loopback(CYBARA_DEFAULT_PORT),
+                gateway::GatewayEndpoint::loopback(intent.port),
             )));
             app.manage(desktop_update::DesktopUpdateManager::default());
             tray::setup(app)?;
@@ -1023,7 +1430,9 @@ fn main() {
             }
 
             start_gateway_watchdog(app.handle().clone());
-            start_sidecar(app.handle().clone());
+            if intent_error.is_none() {
+                start_gateway_for_intent(app.handle().clone(), allow_external_attach);
+            }
 
             Ok(())
         })
@@ -1065,6 +1474,8 @@ struct ManagedSidecar {
 struct SidecarState(std::sync::Mutex<ManagedSidecar>);
 
 struct GatewaySupervisionState(std::sync::Mutex<gateway_supervision::GatewaySupervision>);
+
+struct GatewayOwnershipState(std::sync::Mutex<gateway_ownership::GatewayOwnershipController>);
 
 struct PendingOpen(std::sync::Mutex<Option<String>>);
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1031,12 +1031,10 @@ fn start_sidecar(app: tauri::AppHandle, allow_external_attach: bool) {
                 attach_existing_gateway(&app, generation, preferred, gateway_id);
             } else {
                 release_sidecar_launch(&app, generation);
-                set_gateway_startup_status(
-                    &app,
-                    GatewayStartupStatus::failed(
-                        "A pre-existing Cybara gateway is occupying the managed local gateway port. Cybara refused to change gateway ownership during recovery.",
-                        gateway_ownership::GatewayOwnership::ManagedLocal,
-                    ),
+                schedule_sidecar_restart(
+                    app,
+                    "The previous managed gateway is still releasing port 4269; Cybara refused to adopt it and will retry within the bounded recovery budget."
+                        .into(),
                 );
             }
             return;

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Cybara",
-  "version": "1.0.1719",
+  "version": "1.0.2295",
   "identifier": "com.cybara.desktop",
   "build": {
     "frontendDist": "../ui/dist",
@@ -46,8 +46,18 @@
       "bin/ui/dist": "ui/dist",
       "bin/secp256k1.wasm": "secp256k1.wasm"
     },
-    "targets": ["dmg", "app", "msi", "nsis", "deb", "rpm", "appimage"],
-    "externalBin": ["bin/cybara"],
+    "targets": [
+      "dmg",
+      "app",
+      "msi",
+      "nsis",
+      "deb",
+      "rpm",
+      "appimage"
+    ],
+    "externalBin": [
+      "bin/cybara"
+    ],
     "fileAssociations": [
       {
         "ext": [

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Cybara",
-  "version": "1.0.2295",
+  "version": "1.0.2310",
   "identifier": "com.cybara.desktop",
   "build": {
     "frontendDist": "../ui/dist",

--- a/src/api/routes/health.ts
+++ b/src/api/routes/health.ts
@@ -1,5 +1,6 @@
 import { agentManager } from "../../core/agent";
 import { getAppVersion } from "../../core/build-info";
+import { config } from "../../core/config";
 import { tables } from "../../core/database";
 import { type ProviderType, providerManager, providers } from "../../core/providers";
 import { getSystemMonitorSnapshot } from "../../core/system-monitor";
@@ -21,6 +22,14 @@ interface ProcessMemoryUsage {
   heapTotal: number;
   external: number;
   rss: number;
+}
+
+function gatewayInstanceId(): string {
+  const stored = config.get<unknown>("gateway_instance_id");
+  if (typeof stored === "string" && stored.trim()) return stored.trim();
+  const created = crypto.randomUUID();
+  config.set("gateway_instance_id", created);
+  return created;
 }
 
 export function getProcessMemoryUsage(): ProcessMemoryUsage {
@@ -55,6 +64,7 @@ function healthResponse(): unknown {
     timestamp: now.toISOString(),
     uptime: process.uptime(),
     version: getAppVersion(),
+    instance_id: gatewayInstanceId(),
     compatibility: {
       api_version: CYBARA_GATEWAY_API_VERSION,
       min_client_api_version: CYBARA_GATEWAY_API_MIN_CLIENT_VERSION,

--- a/src/api/routes/health.ts
+++ b/src/api/routes/health.ts
@@ -15,6 +15,7 @@ import { makeRawHttpResponse } from "./raw-http-response";
 import {
   CYBARA_GATEWAY_API_MIN_CLIENT_VERSION,
   CYBARA_GATEWAY_API_VERSION,
+  CYBARA_GATEWAY_IDENTITY_VERSION,
 } from "../../../shared/gateway-compatibility";
 
 interface ProcessMemoryUsage {
@@ -68,6 +69,7 @@ function healthResponse(): unknown {
     compatibility: {
       api_version: CYBARA_GATEWAY_API_VERSION,
       min_client_api_version: CYBARA_GATEWAY_API_MIN_CLIENT_VERSION,
+      identity_version: CYBARA_GATEWAY_IDENTITY_VERSION,
     },
     system,
     checks: {

--- a/tests/api/health-request-handler.test.ts
+++ b/tests/api/health-request-handler.test.ts
@@ -24,7 +24,11 @@ describe("lightweight health request handler", () => {
       product?: unknown;
       status?: unknown;
       instance_id?: unknown;
-      compatibility?: { api_version?: unknown; min_client_api_version?: unknown };
+      compatibility?: {
+        api_version?: unknown;
+        min_client_api_version?: unknown;
+        identity_version?: unknown;
+      };
       checks?: { memory?: { rss?: unknown }; database?: { status?: unknown } };
     };
     expect(response.status).toBe(200);
@@ -40,7 +44,11 @@ describe("lightweight health request handler", () => {
     });
     expect((repeated.body as { instance_id?: unknown }).instance_id).toBe(body.instance_id);
     expect(["healthy", "warning"]).toContain(body.status);
-    expect(body.compatibility).toEqual({ api_version: 1, min_client_api_version: 1 });
+    expect(body.compatibility).toEqual({
+      api_version: 1,
+      min_client_api_version: 1,
+      identity_version: 1,
+    });
     expect(typeof body.checks?.memory?.rss).toBe("number");
     expect(body.checks?.database?.status).toBe("healthy");
   });

--- a/tests/api/health-request-handler.test.ts
+++ b/tests/api/health-request-handler.test.ts
@@ -23,12 +23,22 @@ describe("lightweight health request handler", () => {
     const body = response.body as {
       product?: unknown;
       status?: unknown;
+      instance_id?: unknown;
       compatibility?: { api_version?: unknown; min_client_api_version?: unknown };
       checks?: { memory?: { rss?: unknown }; database?: { status?: unknown } };
     };
     expect(response.status).toBe(200);
     expect(response.headers["Content-Type"]).toBe("application/json");
     expect(body.product).toBe("cybara");
+    expect(typeof body.instance_id).toBe("string");
+    expect(String(body.instance_id)).toMatch(/^[0-9a-f-]{36}$/);
+    const repeated = await handleLightweightHealthRequest({
+      method: "GET",
+      url: "http://localhost:4269/api/health",
+      headers: { host: "localhost:4269" },
+      ip: "127.0.0.1",
+    });
+    expect((repeated.body as { instance_id?: unknown }).instance_id).toBe(body.instance_id);
     expect(["healthy", "warning"]).toContain(body.status);
     expect(body.compatibility).toEqual({ api_version: 1, min_client_api_version: 1 });
     expect(typeof body.checks?.memory?.rss).toBe("number");

--- a/tests/tauri/wiring.test.ts
+++ b/tests/tauri/wiring.test.ts
@@ -104,6 +104,17 @@ describe("Tauri wiring", () => {
     expect(gatewaySource).toContain("installGatewayLogCapture({ environment: process.env })");
   });
 
+  test("managed gateway restart waits through supervised recovery", () => {
+    const mainRs = readFileSync(join(ROOT_DIR, "src-tauri", "src", "main.rs"), "utf8");
+    const restartStart = mainRs.indexOf("fn restart_gateway_sidecar");
+    const restartEnd = mainRs.indexOf("fn switch_to_local_gateway", restartStart);
+    const restartSource = mainRs.slice(restartStart, restartEnd);
+
+    expect(restartSource).toContain("stop_sidecar(&app)");
+    expect(restartSource).toContain("schedule_sidecar_restart");
+    expect(restartSource).not.toContain("start_sidecar(app, false)");
+  });
+
   test("main.rs exposes a narrow desktop API key reader command", () => {
     const mainRsPath = join(ROOT_DIR, "src-tauri", "src", "main.rs");
     const mainRs = readFileSync(mainRsPath, "utf8");

--- a/tests/tauri/wiring.test.ts
+++ b/tests/tauri/wiring.test.ts
@@ -113,6 +113,8 @@ describe("Tauri wiring", () => {
     expect(restartSource).toContain("stop_sidecar(&app)");
     expect(restartSource).toContain("schedule_sidecar_restart");
     expect(restartSource).not.toContain("start_sidecar(app, false)");
+    expect(mainRs).toContain("previous managed gateway is still releasing port 4269");
+    expect(mainRs).toContain("Cybara refused to adopt it");
   });
 
   test("main.rs exposes a narrow desktop API key reader command", () => {

--- a/tests/tauri/wiring.test.ts
+++ b/tests/tauri/wiring.test.ts
@@ -88,6 +88,12 @@ describe("Tauri wiring", () => {
     expect(mainRs).toContain("child.kill()");
     expect(mainRs).toContain("get_gateway_startup_status");
     expect(mainRs).toContain("restart_gateway_sidecar");
+    expect(mainRs).toContain("switch_to_local_gateway");
+    expect(mainRs).toContain("GatewayOwnership::AttachedExternal");
+    expect(mainRs).toContain("start_external_gateway_reconnect");
+    expect(mainRs).toContain("attached_external_gateway_is_current");
+    expect(mainRs).toContain("allow_external_attach");
+    expect(mainRs).toContain("gateway-intent.json");
     expect(mainRs).toContain('log::warn!(target: "cybara::sidecar"');
     expect(mainRs).toContain('log::info!(target: "cybara::sidecar"');
     expect(mainRs).toContain('Ok(value) if value == "0" || value.eq_ignore_ascii_case("false")');
@@ -132,7 +138,9 @@ describe("Tauri wiring", () => {
     expect(mainRs).toContain("gateway::GatewayProbeStatus::NonCybara");
     expect(mainRs).toContain("gateway::GatewayCompatibility::Compatible");
     expect(mainRs).toContain("gateway_version_failure");
-    expect(mainRs).toContain("wait_for_existing_gateway(app, generation, preferred)");
+    expect(mainRs).toContain(
+      "wait_for_existing_gateway(app, generation, preferred, allow_external_attach)"
+    );
     expect(mainRs).not.toContain("const CYBARA_FALLBACK_PORT_COUNT");
     expect(mainRs).toContain("GatewayPortSignalParser::default()");
     expect(mainRs).toContain("port_receiver.recv_timeout(Duration::from_secs(30))");
@@ -225,6 +233,7 @@ describe("Tauri wiring", () => {
     expect(gatewayPermission).toContain('"get_gateway_url"');
     expect(gatewayPermission).toContain('"get_gateway_startup_status"');
     expect(gatewayPermission).toContain('"restart_gateway_sidecar"');
+    expect(gatewayPermission).toContain('"switch_to_local_gateway"');
     expect(updaterPermission).toContain('"get_desktop_update_state"');
     expect(updaterPermission).toContain('"check_desktop_update"');
     expect(updaterPermission).toContain('"install_desktop_update"');

--- a/tests/ui/desktop-gateway-recovery.test.ts
+++ b/tests/ui/desktop-gateway-recovery.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   gatewayStartupPollInterval,
   isGatewayRecovering,
+  switchToLocalGateway,
 } from "../../ui/src/lib/desktopGatewayStartup";
 
 describe("desktop gateway recovery", () => {
@@ -11,9 +12,42 @@ describe("desktop gateway recovery", () => {
   });
 
   test("blocks the desktop surface only during a supervised recovery", () => {
-    expect(isGatewayRecovering({ phase: "starting", message: "Restarting" })).toBe(true);
-    expect(isGatewayRecovering({ phase: "starting", message: null })).toBe(false);
-    expect(isGatewayRecovering({ phase: "ready", message: null })).toBe(false);
-    expect(isGatewayRecovering({ phase: "failed", message: "Stopped" })).toBe(false);
+    expect(
+      isGatewayRecovering({
+        phase: "starting",
+        message: "Restarting",
+        ownership: "attachedExternal",
+        canSwitchToLocal: true,
+      })
+    ).toBe(true);
+    expect(
+      isGatewayRecovering({
+        phase: "starting",
+        message: null,
+        ownership: "managedLocal",
+        canSwitchToLocal: false,
+      })
+    ).toBe(false);
+    expect(
+      isGatewayRecovering({
+        phase: "ready",
+        message: null,
+        ownership: "managedLocal",
+        canSwitchToLocal: false,
+      })
+    ).toBe(false);
+    expect(
+      isGatewayRecovering({
+        phase: "failed",
+        message: "Stopped",
+        ownership: "attachedExternal",
+        canSwitchToLocal: true,
+      })
+    ).toBe(false);
+  });
+
+  test("exposes an explicit switch-to-local command", () => {
+    expect(String(switchToLocalGateway)).toContain("switch_to_local_gateway");
+    expect(String(switchToLocalGateway)).toContain("String(error)");
   });
 });

--- a/tests/ui/onboarding-agents-wiring.test.ts
+++ b/tests/ui/onboarding-agents-wiring.test.ts
@@ -40,6 +40,8 @@ describe("onboarding boot: no shell flash + full-screen spinner", () => {
     expect(app).toContain("readGatewayStartupStatus");
     expect(app).toContain('gatewayStartup?.phase === "failed"');
     expect(app).toContain("<GatewayStartupFailure");
+    expect(app).toContain("gatewayStartup.canSwitchToLocal");
+    expect(app).toContain("Use local gateway");
   });
 });
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cybara-ui",
   "private": true,
-  "version": "1.0.1719",
+  "version": "1.0.2295",
   "type": "module",
   "scripts": {
     "dev": "bunx --bun vite",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cybara-ui",
   "private": true,
-  "version": "1.0.2295",
+  "version": "1.0.2310",
   "type": "module",
   "scripts": {
     "dev": "bunx --bun vite",

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -22,6 +22,7 @@ import {
   gatewayStartupPollInterval,
   isGatewayRecovering,
   readGatewayStartupStatus,
+  switchToLocalGateway,
 } from "@/lib/desktopGatewayStartup";
 import { isTauriDesktopRuntime } from "@/lib/desktopHost";
 import { preventFileDropNavigation } from "@/lib/fileDrop";
@@ -95,6 +96,7 @@ function ChatRoute() {
 function SetupGuard({ children }: { children: React.ReactNode }) {
   const location = useLocation();
   const cachedSetupComplete = readSetupComplete();
+  const [gatewaySwitchError, setGatewaySwitchError] = useState<string | null>(null);
   const setupStatusQuery = useQuery({
     queryKey: ["setup", "status"],
     queryFn: async () => {
@@ -132,6 +134,7 @@ function SetupGuard({ children }: { children: React.ReactNode }) {
     return (
       <GatewayStartupFailure
         message={gatewayStartup.message || "The packaged gateway exited before it was ready."}
+        canSwitchToLocal={gatewayStartup.canSwitchToLocal}
       />
     );
   }
@@ -143,6 +146,30 @@ function SetupGuard({ children }: { children: React.ReactNode }) {
         <p className="max-w-md text-center text-sm text-[var(--text-secondary)]">
           {gatewayStartup?.message}
         </p>
+        {gatewayStartup?.canSwitchToLocal ? (
+          <button
+            type="button"
+            onClick={() => {
+              if (
+                !window.confirm(
+                  "Stop following the external gateway and start a new local gateway?"
+                )
+              ) {
+                return;
+              }
+              setGatewaySwitchError(null);
+              void switchToLocalGateway().then(setGatewaySwitchError);
+            }}
+            className="rounded-md border border-[var(--surface-border)] px-3 py-2 text-sm font-medium text-[var(--text-primary)] hover:bg-[var(--surface-hover)]"
+          >
+            Use local gateway
+          </button>
+        ) : null}
+        {gatewaySwitchError ? (
+          <p role="alert" className="max-w-md text-center text-sm text-destructive">
+            {gatewaySwitchError}
+          </p>
+        ) : null}
       </div>
     );
   }

--- a/ui/src/components/GatewayStartupFailure.tsx
+++ b/ui/src/components/GatewayStartupFailure.tsx
@@ -1,18 +1,35 @@
 import { AlertTriangle, RefreshCw } from "lucide-react";
 import { useState } from "react";
-import { restartDesktopGateway } from "@/lib/desktopGatewayStartup";
+import { restartDesktopGateway, switchToLocalGateway } from "@/lib/desktopGatewayStartup";
 
 export interface GatewayStartupFailureProps {
   message: string;
+  canSwitchToLocal?: boolean;
 }
 
-export function GatewayStartupFailure({ message }: GatewayStartupFailureProps) {
+export function GatewayStartupFailure({
+  message,
+  canSwitchToLocal = false,
+}: GatewayStartupFailureProps) {
   const [retrying, setRetrying] = useState(false);
+  const [switchError, setSwitchError] = useState<string | null>(null);
 
   async function retry(): Promise<void> {
     setRetrying(true);
     if (!(await restartDesktopGateway())) {
       window.location.reload();
+    }
+  }
+
+  async function switchToLocal(): Promise<void> {
+    if (!window.confirm("Stop following the external gateway and start a new local gateway?"))
+      return;
+    setRetrying(true);
+    setSwitchError(null);
+    const error = await switchToLocalGateway();
+    if (error) {
+      setSwitchError(error);
+      setRetrying(false);
     }
   }
 
@@ -22,19 +39,38 @@ export function GatewayStartupFailure({ message }: GatewayStartupFailureProps) {
         <div className="flex items-start gap-3">
           <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-amber-500" />
           <div className="min-w-0">
-            <h1 className="text-base font-semibold">Gateway could not start</h1>
+            <h1 className="text-base font-semibold">
+              {canSwitchToLocal ? "External gateway unavailable" : "Gateway could not start"}
+            </h1>
             <p className="mt-2 text-sm leading-6 text-muted-foreground">{message}</p>
           </div>
         </div>
-        <button
-          type="button"
-          onClick={() => void retry()}
-          disabled={retrying}
-          className="mt-5 inline-flex h-9 items-center gap-2 rounded-md bg-primary px-3 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-        >
-          <RefreshCw className="h-4 w-4" />
-          {retrying ? "Restarting…" : "Retry"}
-        </button>
+        <div className="mt-5 flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={() => void retry()}
+            disabled={retrying}
+            className="inline-flex h-9 items-center gap-2 rounded-md bg-primary px-3 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <RefreshCw className="h-4 w-4" />
+            {retrying ? "Retrying…" : "Retry"}
+          </button>
+          {canSwitchToLocal ? (
+            <button
+              type="button"
+              onClick={() => void switchToLocal()}
+              disabled={retrying}
+              className="inline-flex h-9 items-center rounded-md border border-border px-3 text-sm font-medium transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              Use local gateway
+            </button>
+          ) : null}
+        </div>
+        {switchError ? (
+          <p role="alert" className="mt-3 text-sm text-destructive">
+            {switchError}
+          </p>
+        ) : null}
       </div>
     </div>
   );

--- a/ui/src/lib/desktopGatewayStartup.ts
+++ b/ui/src/lib/desktopGatewayStartup.ts
@@ -6,6 +6,8 @@ export type GatewayStartupPhase = "starting" | "ready" | "failed";
 export interface GatewayStartupStatus {
   phase: GatewayStartupPhase;
   message: string | null;
+  ownership: "managedLocal" | "attachedExternal";
+  canSwitchToLocal: boolean;
 }
 
 export function gatewayStartupPollInterval(desktopRuntime: boolean): number | false {
@@ -22,6 +24,16 @@ export async function readGatewayStartupStatus(): Promise<GatewayStartupStatus |
     return await invoke<GatewayStartupStatus>("get_gateway_startup_status");
   } catch {
     return null;
+  }
+}
+
+export async function switchToLocalGateway(): Promise<string | null> {
+  if (!isTauriDesktopRuntime()) return "Desktop gateway controls are unavailable.";
+  try {
+    await invoke("switch_to_local_gateway");
+    return null;
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
   }
 }
 


### PR DESCRIPTION
## Problem

Tauri currently attaches to a healthy pre-existing gateway, but does not preserve ownership. If that gateway or its user-managed loopback forward disappears, the watchdog enters normal sidecar recovery. Once the port becomes free, Desktop can launch the bundled gateway and silently switch the user to unrelated local state.

This is especially visible with a central gateway exposed as `127.0.0.1:4269` through a private-network, SSH, or VPN forward. Loopback location alone does not establish ownership.

## New behavior

Tauri now has two explicit gateway ownership modes:

- **Managed Local**: Desktop owns the bundled sidecar and may restart only that process.
- **Attached External**: Desktop attached to a gateway it did not launch and may only reconnect to that same gateway.

External ownership is persisted in desktop-local application data with the endpoint port and an identity-capability identifier. On restart, external intent enters reconnect mode directly and never attempts bundled-sidecar startup.

When an attached gateway disappears:

- Desktop shows a disconnected/reconnecting state;
- probes use bounded exponential backoff up to 16 seconds;
- a free port remains a retry condition, never a signal to start the sidecar;
- the same gateway identifier reattaches automatically;
- a different Cybara gateway, incompatible gateway, or non-Cybara service fails closed;
- normal watchdog checks verify identity even if replacement occurs without a visible outage.

The user can explicitly choose **Use local gateway**. This requires confirmation and a free port before ownership changes and the bundled sidecar may start.

## Persistence and recovery

`gateway-intent.json` is written through a synced temporary file. During replacement, the current primary moves to a separate pending-backup slot while the stable backup remains intact. Loading recovers from the primary, pending backup, or stable backup in fail-closed order. Existing malformed or unreadable intent files fail closed and do not start a local gateway. Missing intent is the only state that permits first-run discovery of a pre-existing external gateway.

The gateway health contract publishes a non-secret `instance_id` plus an explicit `identity_version` capability. Identity pinning is used only when that capability and `product: cybara` are declared; this does not silently change the API-v1 compatibility contract.

## Security

- external processes are never killed or stopped;
- authentication behavior is unchanged and remains the security boundary;
- `instance_id` detects accidental endpoint replacement; it is not claimed as authentication;
- existing version/API compatibility checks remain mandatory;
- arbitrary/non-Cybara services remain rejected;
- a different healthy Cybara gateway at the same loopback endpoint is rejected;
- delayed managed restart tasks re-check ownership before launching;
- managed restart waits through supervised backoff instead of racing the old process as it releases the port;
- managed recovery cannot silently adopt a pre-existing gateway;
- invalid persisted intent fails closed;
- no IP address, forwarding technology, user, or host is special-cased.

## Native macOS

Native macOS already distinguishes attached and managed ownership and does not restart an attached external gateway. This change uses that architecture as the Tauri model and does not alter native macOS behavior.

## Tests

Passed locally on the final head:

- isolated Rust gateway/ownership/supervision suite: 38 tests
- focused Bun/Tauri/UI/API suite: 37 tests
- root TypeScript typecheck
- UI TypeScript typecheck
- root lint
- UI lint
- format check
- source LOC gate
- production UI build

Rust coverage includes managed crash restart, supervised managed shutdown retry, initial external attachment, external disconnect, free-port retry without launch, same-identifier reattachment, replacement-identifier rejection, explicit identity capability and product marker checks, non-Cybara and incompatible refusal, persistent external intent, interrupted replacement recovery from pending/stable backups, malformed intent failure, explicit local switch and free-port requirement, and delayed ownership changes.

GitHub quality and Native macOS CI, GitGuardian, OSV, and Gitzilla are green on the current head.

## Review concerns

Maintainers should review:

- the addition of unauthenticated `instance_id` and versioned `identity_version` to `/api/health` as non-secret installation metadata;
- first-run discovery policy: only absence of persisted intent permits adopting a pre-existing external gateway;
- fail-closed handling of external gateways that do not publish the supported identity capability;
- explicit switch-to-local requiring the user to free port 4269 first.
