### PR TITLE
Release

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -350,6 +350,7 @@ const routes: Record<string, RouteHandler> = {
     dangerous_tool_policy: config.getDangerousToolPolicy(),
     tool_approval_mode: config.getToolApprovalMode(),
     web_tool_url_policy: config.getWebToolUrlPolicy(),
+    sensitive_file_policy: config.getSensitiveFilePolicy(),
     sandbox_runtime: redactSandboxRuntimeConfig(config.getSandboxRuntime()),
     workspace_indexer: config.getWorkspaceIndexerSettings(),
     memory: config.getMemoryBehaviorSettings(),
@@ -459,6 +460,10 @@ const routes: Record<string, RouteHandler> = {
       }
       if (key === "web_tool_url_policy") {
         config.setWebToolUrlPolicy(value);
+        continue;
+      }
+      if (key === "sensitive_file_policy") {
+        config.setSensitiveFilePolicy(value);
         continue;
       }
       if (key === "sandbox_runtime") {

--- a/src/api/routes/runtime-routes.ts
+++ b/src/api/routes/runtime-routes.ts
@@ -232,7 +232,7 @@ export const runtimeRoutes: Record<string, RouteHandler> = {
   },
   "POST /api/browser/sandbox/stop": async () => {
     await stopSandboxBrowser();
-    return { success: true, status: getSandboxBrowserStatus() };
+    return { success: true, status: await getSandboxBrowserStatus() };
   },
   "GET /api/browser/tabs": async (_body, params) => {
     const sessionId = browserSessionId(params?.sessionId);

--- a/src/core/browser/sandbox-browser.ts
+++ b/src/core/browser/sandbox-browser.ts
@@ -9,6 +9,47 @@ export const DEFAULT_SANDBOX_CDP_PORT = 9222;
 export const DEFAULT_SANDBOX_NOVNC_PORT = 6080;
 
 const DOCKER_CMD = process.env.CYBARA_SANDBOX_DOCKER_CMD || "docker";
+const DOCKER_PROBE_TIMEOUT_MS = 4000;
+const DOCKER_UNAVAILABLE_CACHE_MS = 15_000;
+
+let dockerUnavailableUntil = 0;
+
+function dockerCommand(): string {
+  return process.env.CYBARA_SANDBOX_DOCKER_CMD || DOCKER_CMD;
+}
+
+function dockerProbeTimeoutMs(): number {
+  const configured = Number(process.env.CYBARA_SANDBOX_DOCKER_TIMEOUT_MS);
+  return Number.isFinite(configured) && configured > 0 ? configured : DOCKER_PROBE_TIMEOUT_MS;
+}
+
+interface DockerProbeResult {
+  exitCode: number | null;
+  stdout: string;
+  timedOut: boolean;
+}
+
+async function runDockerProbe(args: string[]): Promise<DockerProbeResult> {
+  let proc: ReturnType<typeof Bun.spawn>;
+  try {
+    proc = Bun.spawn([dockerCommand(), ...args], { stdout: "pipe", stderr: "pipe" });
+  } catch {
+    return { exitCode: null, stdout: "", timedOut: false };
+  }
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<"timeout">((resolveTimeout) => {
+    timer = setTimeout(() => resolveTimeout("timeout"), dockerProbeTimeoutMs());
+  });
+  const outcome = await Promise.race([proc.exited, timeout]);
+  if (timer) clearTimeout(timer);
+  if (outcome === "timeout") {
+    proc.kill("SIGKILL");
+    return { exitCode: null, stdout: "", timedOut: true };
+  }
+  const stdout =
+    proc.stdout instanceof ReadableStream ? await readSubprocessStreamAsText(proc.stdout) : "";
+  return { exitCode: outcome, stdout, timedOut: false };
+}
 
 export interface SandboxBrowserOptions {
   image?: string;
@@ -99,32 +140,25 @@ export function sandboxContextDir(): string {
   return resolveSandboxContextDir();
 }
 
-function dockerAvailable(): boolean {
-  try {
-    const result = Bun.spawnSync([DOCKER_CMD, "version", "--format", "{{.Server.Version}}"], {
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    return result.exitCode === 0;
-  } catch {
-    return false;
-  }
+async function dockerAvailable(): Promise<boolean> {
+  if (Date.now() < dockerUnavailableUntil) return false;
+  const result = await runDockerProbe(["version", "--format", "{{.Server.Version}}"]);
+  const available = result.exitCode === 0;
+  dockerUnavailableUntil = available ? 0 : Date.now() + DOCKER_UNAVAILABLE_CACHE_MS;
+  return available;
 }
 
-function imageBuilt(image: string): boolean {
-  const result = Bun.spawnSync([DOCKER_CMD, "image", "inspect", image], {
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  return result.exitCode === 0;
+async function imageBuilt(image: string): Promise<boolean> {
+  return (await runDockerProbe(["image", "inspect", image])).exitCode === 0;
 }
 
-function containerRunning(container: string): boolean {
-  const result = Bun.spawnSync([DOCKER_CMD, "inspect", "-f", "{{.State.Running}}", container], {
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  return result.exitCode === 0 && result.stdout.toString().trim() === "true";
+async function containerRunning(container: string): Promise<boolean> {
+  const result = await runDockerProbe(["inspect", "-f", "{{.State.Running}}", container]);
+  return result.exitCode === 0 && result.stdout.trim() === "true";
+}
+
+export function resetSandboxDockerAvailabilityForTests(): void {
+  dockerUnavailableUntil = 0;
 }
 
 async function waitForCdp(cdpPort: number, timeoutMs: number): Promise<boolean> {
@@ -154,7 +188,7 @@ export async function buildSandboxImage(opts?: SandboxBrowserOptions): Promise<v
   if (!existsSync(join(context, "Dockerfile"))) {
     throw new Error(`Sandbox browser Dockerfile not found at ${context}`);
   }
-  const proc = Bun.spawn([DOCKER_CMD, "build", "-t", image, context], {
+  const proc = Bun.spawn([dockerCommand(), "build", "-t", image, context], {
     stdout: "pipe",
     stderr: "pipe",
   });
@@ -165,7 +199,9 @@ export async function buildSandboxImage(opts?: SandboxBrowserOptions): Promise<v
   }
 }
 
-export function getSandboxBrowserStatus(opts?: SandboxBrowserOptions): SandboxBrowserStatus {
+export async function getSandboxBrowserStatus(
+  opts?: SandboxBrowserOptions
+): Promise<SandboxBrowserStatus> {
   const { image, container, cdpPort, novncPort } = resolved(opts);
   const base: SandboxBrowserStatus = {
     dockerAvailable: false,
@@ -176,14 +212,14 @@ export function getSandboxBrowserStatus(opts?: SandboxBrowserOptions): SandboxBr
     cdpUrl: sandboxCdpUrl(cdpPort),
     novncUrl: sandboxNovncUrl(novncPort),
   };
-  if (!dockerAvailable()) {
+  if (!(await dockerAvailable())) {
     return { ...base, reason: "Docker is not available on this host" };
   }
   return {
     ...base,
     dockerAvailable: true,
-    imageBuilt: imageBuilt(image),
-    running: containerRunning(container),
+    imageBuilt: await imageBuilt(image),
+    running: await containerRunning(container),
   };
 }
 
@@ -191,16 +227,16 @@ export async function startSandboxBrowser(
   opts?: SandboxBrowserOptions
 ): Promise<SandboxBrowserStatus> {
   const params = resolved(opts);
-  if (!dockerAvailable()) {
+  if (!(await dockerAvailable())) {
     throw new Error("Docker is not available. Install Docker to use the sandbox browser.");
   }
-  if (containerRunning(params.container)) {
+  if (await containerRunning(params.container)) {
     return getSandboxBrowserStatus(opts);
   }
-  if (!imageBuilt(params.image)) {
+  if (!(await imageBuilt(params.image))) {
     await buildSandboxImage(opts);
   }
-  const proc = Bun.spawn([DOCKER_CMD, ...buildDockerRunArgs(params)], {
+  const proc = Bun.spawn([dockerCommand(), ...buildDockerRunArgs(params)], {
     stdout: "pipe",
     stderr: "pipe",
   });
@@ -218,8 +254,8 @@ export async function startSandboxBrowser(
 
 export async function stopSandboxBrowser(opts?: SandboxBrowserOptions): Promise<void> {
   const { container } = resolved(opts);
-  if (!dockerAvailable()) return;
-  const proc = Bun.spawn([DOCKER_CMD, "rm", "-f", container], {
+  if (!(await dockerAvailable())) return;
+  const proc = Bun.spawn([dockerCommand(), "rm", "-f", container], {
     stdout: "pipe",
     stderr: "pipe",
   });

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -34,6 +34,7 @@ interface PlatformConfig {
   dangerous_tool_policy?: DangerousToolPolicyConfig;
   tool_approval_mode?: ToolApprovalMode;
   web_tool_url_policy?: WebToolUrlPolicyConfig;
+  sensitive_file_policy?: SensitiveFilePolicyConfig;
   [key: string]: unknown;
 }
 
@@ -109,6 +110,24 @@ export type SpeechRealtimeProvider = "managed" | "openai" | "gemini" | "moshi";
 export interface DangerousToolPolicyConfig {
   enabled: boolean;
   mode: DangerousToolPolicyMode;
+}
+
+export interface SensitiveFilePolicyConfig {
+  allow_env_file_reads: boolean;
+  allow_all_sensitive_reads: boolean;
+}
+
+export const DEFAULT_SENSITIVE_FILE_POLICY: SensitiveFilePolicyConfig = {
+  allow_env_file_reads: false,
+  allow_all_sensitive_reads: false,
+};
+
+export function normalizeSensitiveFilePolicy(value: unknown): SensitiveFilePolicyConfig {
+  const parsed = asObject(value);
+  return {
+    allow_env_file_reads: parsed?.allow_env_file_reads === true,
+    allow_all_sensitive_reads: parsed?.allow_all_sensitive_reads === true,
+  };
 }
 
 export interface WebToolUrlPolicyConfig {
@@ -881,6 +900,7 @@ class ConfigManager {
       tool_approval_mode: DEFAULT_TOOL_APPROVAL_MODE,
       follow_up_behavior_enabled: true,
       web_tool_url_policy: { ...DEFAULT_WEB_TOOL_URL_POLICY },
+      sensitive_file_policy: { ...DEFAULT_SENSITIVE_FILE_POLICY },
       sandbox_runtime: { ...DEFAULT_SANDBOX_RUNTIME },
       workspace_indexer: { ...DEFAULT_WORKSPACE_INDEXER_SETTINGS },
       memory: { ...DEFAULT_MEMORY_BEHAVIOR_SETTINGS },
@@ -997,6 +1017,16 @@ class ConfigManager {
   setWebToolUrlPolicy(policy: unknown): WebToolUrlPolicyConfig {
     const normalized = normalizeWebToolUrlPolicy(policy);
     this.set("web_tool_url_policy", normalized);
+    return normalized;
+  }
+
+  getSensitiveFilePolicy(): SensitiveFilePolicyConfig {
+    return normalizeSensitiveFilePolicy(this.get<unknown>("sensitive_file_policy"));
+  }
+
+  setSensitiveFilePolicy(policy: unknown): SensitiveFilePolicyConfig {
+    const normalized = normalizeSensitiveFilePolicy(policy);
+    this.set("sensitive_file_policy", normalized);
     return normalized;
   }
 

--- a/src/core/tools/handlers/file.ts
+++ b/src/core/tools/handlers/file.ts
@@ -16,6 +16,7 @@ import { readFileLines } from "../file-read";
 import { searchFiles } from "../file-search";
 import type { ToolContext } from "../index";
 import { assertReadablePath, assertWritablePath } from "../path-policy";
+import { readablePathOptions } from "../sensitive-read-policy";
 
 const workspace = homeDir;
 
@@ -190,7 +191,7 @@ function resolveSearchResultPath(searchDir: string, resultPath: string): string 
 
 function isReadableSearchResult(searchDir: string, resultPath: string): boolean {
   try {
-    assertReadablePath(resolveSearchResultPath(searchDir, resultPath));
+    assertReadablePath(resolveSearchResultPath(searchDir, resultPath), readablePathOptions());
     return true;
   } catch {
     return false;
@@ -349,7 +350,7 @@ export async function handleRead(
       'Validation error: path is required. Provide a file path (for example: {"path":"src/index.ts"}).'
     );
   }
-  assertReadablePath(path);
+  assertReadablePath(path, readablePathOptions());
   if (!existsSync(path)) {
     throw fileNotFoundError(path);
   }
@@ -530,7 +531,7 @@ export async function handleFileSearch(
   }
 
   const searchDir = cwd || context?.workspaceDir || workspace;
-  const safeSearchDir = assertReadablePath(searchDir);
+  const safeSearchDir = assertReadablePath(searchDir, readablePathOptions());
 
   if (!pattern) {
     return {
@@ -616,7 +617,10 @@ export async function handleGrep(
   const caseSensitive = args.caseSensitive as boolean | undefined;
   const shouldRecursive = args.recursive !== false;
 
-  const searchDir = assertReadablePath(expandTilde(path) || toolContext?.workspaceDir || workspace);
+  const searchDir = assertReadablePath(
+    expandTilde(path) || toolContext?.workspaceDir || workspace,
+    readablePathOptions()
+  );
   const extensions = fileType ? fileType.split(",").map((t) => t.trim()) : null;
 
   const results: Array<{ path: string; line: number; content: string }> = [];
@@ -849,7 +853,7 @@ async function searchDirectory(
         }
       } else if (entry.isFile()) {
         try {
-          assertReadablePath(fullPath);
+          assertReadablePath(fullPath, readablePathOptions());
         } catch {
           continue;
         }

--- a/src/core/tools/handlers/security-scan.ts
+++ b/src/core/tools/handlers/security-scan.ts
@@ -2,6 +2,7 @@ import { statSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { agentManager } from "../../agent";
 import { assertReadablePath } from "../path-policy";
+import { readablePathOptions } from "../sensitive-read-policy";
 import type { ToolContext } from "../types";
 
 type SecurityToolAction = "info" | "scan" | "validate";
@@ -80,10 +81,13 @@ function resolveTarget(args: Record<string, unknown>, context: ToolContext): str
   const workspace = context.workspaceDir ? resolve(context.workspaceDir) : process.cwd();
   const requested = stringValue(args.target);
   const target = requested ? resolve(workspace, requested) : workspace;
-  return assertReadablePath(target, {
-    workspaceRoot: workspace,
-    confineToWorkspace: context.confineToWorkspace === true,
-  });
+  return assertReadablePath(
+    target,
+    readablePathOptions({
+      workspaceRoot: workspace,
+      confineToWorkspace: context.confineToWorkspace === true,
+    })
+  );
 }
 
 function timeoutMs(args: Record<string, unknown>): number {

--- a/src/core/tools/handlers/transcribe.ts
+++ b/src/core/tools/handlers/transcribe.ts
@@ -1,6 +1,7 @@
 import { existsSync, statSync } from "fs";
 import { basename } from "path";
 import { assertReadablePath } from "../path-policy";
+import { readablePathOptions } from "../sensitive-read-policy";
 import { validateUrl } from "../../../api/security";
 import { config } from "../../config";
 import { fetchPublicHttpUrl, type PublicHttpFetcher } from "../../outbound-url-policy";
@@ -104,7 +105,7 @@ async function loadAudio(
   const url = typeof args.url === "string" ? args.url.trim() : "";
 
   if (path) {
-    assertReadablePath(path);
+    assertReadablePath(path, readablePathOptions());
     if (!existsSync(path)) throw new Error(`Audio file not found: ${path}`);
     if (statSync(path).size > MAX_AUDIO_BYTES) {
       throw new Error(`Audio file exceeds 25MB limit: ${path}`);

--- a/src/core/tools/path-policy.ts
+++ b/src/core/tools/path-policy.ts
@@ -1,8 +1,12 @@
 import { existsSync, realpathSync } from "fs";
 import { homedir } from "os";
 import { resolve, isAbsolute, dirname, join } from "path";
+import { runtimeHomeDir } from "../cybara-home";
+import { cybaraDir } from "../paths";
 
 export type PathPolicyDenialReason = "sensitive-path" | "outside-workspace" | "empty-path";
+
+export type SensitiveReadMode = "blocked" | "env-files" | "all";
 
 export interface PathPolicyDecision {
   allowed: boolean;
@@ -10,8 +14,11 @@ export interface PathPolicyDecision {
   resolvedPath: string;
 }
 
+const ENV_FILE_PATTERN = /^\.env(\..*)?$/i;
+const ENV_TEMPLATE_PATTERN = /^\.env(\..*)?\.(example|sample|template|dist)$/i;
+
 const DENY_FILENAME_PATTERNS: readonly RegExp[] = [
-  /^\.env(\..*)?$/i,
+  ENV_FILE_PATTERN,
   /^id_[a-z0-9-]+$/i,
   /^authorized_keys$/i,
   /^known_hosts$/i,
@@ -36,7 +43,6 @@ const DENY_PATH_SEGMENTS: readonly string[] = [
   ".ssh",
   ".gnupg",
   ".aws",
-  ".cybara",
   "Library/Cookies",
   "Library/Keychains",
 ];
@@ -46,6 +52,7 @@ export interface PathPolicyOptions {
   workspaceRoot?: string;
   extraDenyPrefixes?: string[];
   disabled?: boolean;
+  sensitiveReads?: SensitiveReadMode;
 }
 
 function normalize(p: string): string {
@@ -91,9 +98,23 @@ function policyPaths(rawPath: string): string[] {
   return paths;
 }
 
+function basenameOf(resolvedPath: string): string {
+  return resolvedPath.toLowerCase().split("/").pop() ?? "";
+}
+
+export function isEnvTemplateFile(path: string): boolean {
+  return ENV_TEMPLATE_PATTERN.test(basenameOf(path.replace(/\\/g, "/")));
+}
+
+export function isEnvFile(path: string): boolean {
+  const basename = basenameOf(path.replace(/\\/g, "/"));
+  return ENV_FILE_PATTERN.test(basename) && !ENV_TEMPLATE_PATTERN.test(basename);
+}
+
 function matchesDenyPattern(resolvedPath: string): boolean {
   const lower = resolvedPath.toLowerCase();
-  const basename = lower.split("/").pop() ?? "";
+  const basename = basenameOf(lower);
+  if (ENV_TEMPLATE_PATTERN.test(basename)) return false;
   for (const pattern of DENY_FILENAME_PATTERNS) {
     if (pattern.source.includes("\\/") || pattern.source.includes("/")) {
       if (pattern.test(lower) || pattern.test(resolvedPath)) return true;
@@ -104,15 +125,34 @@ function matchesDenyPattern(resolvedPath: string): boolean {
   return false;
 }
 
-function homePolicyRoots(): string[] {
-  const roots = [normalize(homedir())];
-  try {
-    const realHome = normalize(realpathSync.native(homedir()));
-    if (!roots.includes(realHome)) roots.push(realHome);
-  } catch {
-    return roots;
+function withRealPaths(paths: string[]): string[] {
+  const roots: string[] = [];
+  for (const path of paths) {
+    const normalized = normalize(path);
+    if (!roots.includes(normalized)) roots.push(normalized);
+    try {
+      const real = normalize(realpathSync.native(path));
+      if (!roots.includes(real)) roots.push(real);
+    } catch {
+      continue;
+    }
   }
   return roots;
+}
+
+function homePolicyRoots(): string[] {
+  return withRealPaths([homedir(), runtimeHomeDir]);
+}
+
+function cybaraPolicyRoots(): string[] {
+  return withRealPaths([join(homedir(), ".cybara"), join(runtimeHomeDir, ".cybara"), cybaraDir]);
+}
+
+function isUnderCybaraDir(resolvedPath: string, subdir?: string): boolean {
+  return cybaraPolicyRoots().some((root) => {
+    const marker = subdir ? `${root}/${subdir.toLowerCase()}` : root;
+    return resolvedPath === marker || resolvedPath.startsWith(`${marker}/`);
+  });
 }
 
 function isUnderHomeSubdir(resolvedPath: string, segment: string): boolean {
@@ -140,6 +180,10 @@ export function checkWritePath(
 
   for (const candidate of candidates) {
     if (matchesDenyPattern(candidate)) {
+      return { allowed: false, reason: "sensitive-path", resolvedPath: resolved };
+    }
+
+    if (isUnderCybaraDir(candidate)) {
       return { allowed: false, reason: "sensitive-path", resolvedPath: resolved };
     }
 
@@ -205,13 +249,22 @@ export function assertWritablePath(
   return decision.resolvedPath;
 }
 
-const READABLE_CYBARA_SUBDIRS: readonly string[] = [
-  ".cybara/memory",
-  ".cybara/skills",
-  ".cybara/tool-results",
-];
-const READABLE_CYBARA_IMAGE_SUBDIRS: readonly string[] = [".cybara/screenshots"];
+const READABLE_CYBARA_SUBDIRS: readonly string[] = ["memory", "skills", "tool-results"];
+const READABLE_CYBARA_IMAGE_SUBDIRS: readonly string[] = ["screenshots"];
 const READABLE_IMAGE_PATTERN = /\.(png|jpe?g|gif|webp|heic|heif)$/i;
+
+export const SENSITIVE_READ_DENIAL =
+  "Refused: reading this path is blocked — it points at a sensitive credential or key file. If this is intended, allow sensitive file reads under Settings → Safety → Sensitive file access.";
+
+function permittedBySensitiveReadMode(
+  candidates: string[],
+  mode: SensitiveReadMode | undefined
+): boolean {
+  if (!mode || mode === "blocked") return false;
+  if (candidates.some((candidate) => isUnderCybaraDir(candidate))) return false;
+  if (mode === "all") return true;
+  return candidates.every((candidate) => isEnvFile(candidate));
+}
 
 export function assertReadablePath(
   rawPath: string | undefined,
@@ -220,13 +273,16 @@ export function assertReadablePath(
   const decision = checkWritePath(rawPath, options);
   if (!decision.allowed && decision.reason === "sensitive-path" && rawPath) {
     const candidates = policyPaths(rawPath);
+    if (permittedBySensitiveReadMode(candidates, options?.sensitiveReads)) {
+      return decision.resolvedPath;
+    }
     const inReadableSubdir = candidates.every((candidate) =>
-      READABLE_CYBARA_SUBDIRS.some((subdir) => isUnderHomeSubdir(candidate, subdir))
+      READABLE_CYBARA_SUBDIRS.some((subdir) => isUnderCybaraDir(candidate, subdir))
     );
     const inReadableImageSubdir =
       READABLE_IMAGE_PATTERN.test(decision.resolvedPath) &&
       candidates.every((candidate) =>
-        READABLE_CYBARA_IMAGE_SUBDIRS.some((subdir) => isUnderHomeSubdir(candidate, subdir))
+        READABLE_CYBARA_IMAGE_SUBDIRS.some((subdir) => isUnderCybaraDir(candidate, subdir))
       );
     const hitsFilenameDeny = candidates.some((candidate) => matchesDenyPattern(candidate));
     if ((inReadableSubdir || inReadableImageSubdir) && !hitsFilenameDeny) {
@@ -236,7 +292,7 @@ export function assertReadablePath(
   if (!decision.allowed) {
     const message =
       decision.reason === "sensitive-path"
-        ? "Refused: reading this path is blocked — it points at a sensitive credential or key file."
+        ? SENSITIVE_READ_DENIAL
         : describeDenial(decision.reason!);
     throw new Error(message);
   }

--- a/src/core/tools/sensitive-read-policy.ts
+++ b/src/core/tools/sensitive-read-policy.ts
@@ -1,0 +1,12 @@
+import { config, type SensitiveFilePolicyConfig } from "../config";
+import type { PathPolicyOptions, SensitiveReadMode } from "./path-policy";
+
+export function sensitiveReadMode(policy: SensitiveFilePolicyConfig): SensitiveReadMode {
+  if (policy.allow_all_sensitive_reads) return "all";
+  if (policy.allow_env_file_reads) return "env-files";
+  return "blocked";
+}
+
+export function readablePathOptions(extra: PathPolicyOptions = {}): PathPolicyOptions {
+  return { ...extra, sensitiveReads: sensitiveReadMode(config.getSensitiveFilePolicy()) };
+}

--- a/tests/api/routes-system.test.ts
+++ b/tests/api/routes-system.test.ts
@@ -467,6 +467,24 @@ describe("Config API", () => {
     expect(resetRes.status).toBe(200);
   });
 
+  test("PUT /api/config normalizes the sensitive file policy", async () => {
+    const putRes = await fixture.api("PUT", "/api/config", {
+      sensitive_file_policy: { allow_env_file_reads: true, allow_all_sensitive_reads: "no" },
+    });
+    expect(putRes.status).toBe(200);
+    const getRes = await fixture.api("GET", "/api/config");
+    expect(getRes.data.sensitive_file_policy).toEqual({
+      allow_env_file_reads: true,
+      allow_all_sensitive_reads: false,
+    });
+    const resetRes = await fixture.api("PUT", "/api/config", { sensitive_file_policy: {} });
+    expect(resetRes.status).toBe(200);
+    expect((await fixture.api("GET", "/api/config")).data.sensitive_file_policy).toEqual({
+      allow_env_file_reads: false,
+      allow_all_sensitive_reads: false,
+    });
+  });
+
   test("PUT /api/config normalizes computer-use driver command override", async () => {
     const putRes = await fixture.api("PUT", "/api/config", {
       computer_use: {

--- a/tests/core/path-policy.test.ts
+++ b/tests/core/path-policy.test.ts
@@ -8,6 +8,7 @@ import {
 import { homedir, tmpdir } from "os";
 import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "fs";
 import { join } from "path";
+import { cybaraDir } from "../../src/core/paths";
 
 describe("checkWritePath", () => {
   test("allows a normal project file", () => {
@@ -30,6 +31,46 @@ describe("checkWritePath", () => {
     expect(checkWritePath(".env").allowed).toBe(false);
     expect(checkWritePath(".env.local").allowed).toBe(false);
     expect(checkWritePath(".env.production").allowed).toBe(false);
+  });
+
+  test("treats .env example and template files as ordinary readable files", () => {
+    for (const name of [
+      ".env.example",
+      ".env.sample",
+      ".env.template",
+      ".env.dist",
+      ".env.local.example",
+    ]) {
+      expect(checkWritePath(`/Users/dev/project/${name}`).allowed).toBe(true);
+      expect(assertReadablePath(`/Users/dev/project/${name}`)).toBe(`/Users/dev/project/${name}`);
+    }
+    expect(checkWritePath("/Users/dev/project/.env").allowed).toBe(false);
+    expect(checkWritePath("/Users/dev/project/.env.production").allowed).toBe(false);
+  });
+
+  test("sensitive read modes open .env files or everything except Cybara's own data", () => {
+    const envPath = "/Users/dev/project/.env";
+    const keyPath = "/Users/dev/project/id_rsa";
+    expect(() => assertReadablePath(envPath)).toThrow("Settings → Safety");
+    expect(() => assertReadablePath(envPath, { sensitiveReads: "blocked" })).toThrow("Refused");
+    expect(assertReadablePath(envPath, { sensitiveReads: "env-files" })).toBe(envPath);
+    expect(
+      assertReadablePath("/Users/dev/project/.env.local", { sensitiveReads: "env-files" })
+    ).toBe("/Users/dev/project/.env.local");
+    expect(() => assertReadablePath(keyPath, { sensitiveReads: "env-files" })).toThrow("Refused");
+    expect(assertReadablePath(keyPath, { sensitiveReads: "all" })).toBe(keyPath);
+    expect(assertReadablePath(envPath, { sensitiveReads: "all" })).toBe(envPath);
+    const secureKey = join(homedir(), ".cybara", "secure", "storage.key");
+    expect(() => assertReadablePath(secureKey, { sensitiveReads: "all" })).toThrow("Refused");
+    const configuredSecureKey = join(cybaraDir, "secure", "storage.key");
+    expect(() => assertReadablePath(configuredSecureKey, { sensitiveReads: "all" })).toThrow(
+      "Refused"
+    );
+    expect(checkWritePath(join(cybaraDir, "data", "platform.db")).allowed).toBe(false);
+    expect(
+      assertReadablePath(join(cybaraDir, "memory", "notes.md"), { sensitiveReads: "all" })
+    ).toBe(join(cybaraDir, "memory", "notes.md"));
+    expect(() => assertWritablePath(envPath, { sensitiveReads: "all" })).toThrow("Refused");
   });
 
   test("denies other credential files", () => {

--- a/tests/core/sandbox-browser.test.ts
+++ b/tests/core/sandbox-browser.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync } from "fs";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
 import {
   buildDockerRunArgs,
   sandboxCdpUrl,
@@ -7,6 +8,8 @@ import {
   sandboxNovncUrl,
   SANDBOX_BROWSER_IMAGE,
   SANDBOX_BROWSER_CONTAINER,
+  getSandboxBrowserStatus,
+  resetSandboxDockerAvailabilityForTests,
 } from "../../src/core/browser/sandbox-browser";
 
 describe("sandbox browser launcher", () => {
@@ -69,6 +72,55 @@ describe("sandbox browser launcher", () => {
       else process.env.CYBARA_RESOURCE_DIR = savedResourceDir;
       if (savedConfiguredDir === undefined) delete process.env.CYBARA_SANDBOX_BROWSER_DIR;
       else process.env.CYBARA_SANDBOX_BROWSER_DIR = savedConfiguredDir;
+    }
+  });
+
+  test("a hanging docker CLI cannot block status checks or the event loop", async () => {
+    const savedCommand = process.env.CYBARA_SANDBOX_DOCKER_CMD;
+    const savedTimeout = process.env.CYBARA_SANDBOX_DOCKER_TIMEOUT_MS;
+    const directory = mkdtempSync(join(process.env.TMPDIR || "/tmp", "cybara-docker-hang-"));
+    const fakeDocker = join(directory, "docker");
+    writeFileSync(fakeDocker, "#!/bin/sh\nsleep 30\n");
+    chmodSync(fakeDocker, 0o755);
+    process.env.CYBARA_SANDBOX_DOCKER_CMD = fakeDocker;
+    process.env.CYBARA_SANDBOX_DOCKER_TIMEOUT_MS = "300";
+    resetSandboxDockerAvailabilityForTests();
+    try {
+      let ticks = 0;
+      const ticker = setInterval(() => {
+        ticks += 1;
+      }, 50);
+      const started = Date.now();
+      const status = await getSandboxBrowserStatus();
+      clearInterval(ticker);
+      expect(status.dockerAvailable).toBe(false);
+      expect(status.reason).toContain("not available");
+      expect(Date.now() - started).toBeLessThan(2000);
+      expect(ticks).toBeGreaterThan(2);
+      const cachedStart = Date.now();
+      expect((await getSandboxBrowserStatus()).dockerAvailable).toBe(false);
+      expect(Date.now() - cachedStart).toBeLessThan(100);
+    } finally {
+      if (savedCommand === undefined) delete process.env.CYBARA_SANDBOX_DOCKER_CMD;
+      else process.env.CYBARA_SANDBOX_DOCKER_CMD = savedCommand;
+      if (savedTimeout === undefined) delete process.env.CYBARA_SANDBOX_DOCKER_TIMEOUT_MS;
+      else process.env.CYBARA_SANDBOX_DOCKER_TIMEOUT_MS = savedTimeout;
+      resetSandboxDockerAvailabilityForTests();
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("a failing docker CLI reports unavailable immediately", async () => {
+    const savedCommand = process.env.CYBARA_SANDBOX_DOCKER_CMD;
+    process.env.CYBARA_SANDBOX_DOCKER_CMD = "/nonexistent/cybara-no-docker";
+    resetSandboxDockerAvailabilityForTests();
+    try {
+      const status = await getSandboxBrowserStatus();
+      expect(status.dockerAvailable).toBe(false);
+    } finally {
+      if (savedCommand === undefined) delete process.env.CYBARA_SANDBOX_DOCKER_CMD;
+      else process.env.CYBARA_SANDBOX_DOCKER_CMD = savedCommand;
+      resetSandboxDockerAvailabilityForTests();
     }
   });
 });

--- a/tests/core/sensitive-read-policy.test.ts
+++ b/tests/core/sensitive-read-policy.test.ts
@@ -1,0 +1,70 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { config } from "../../src/core/config";
+import { handleRead } from "../../src/core/tools/handlers/file";
+import { readablePathOptions, sensitiveReadMode } from "../../src/core/tools/sensitive-read-policy";
+
+const directory = mkdtempSync(join(tmpdir(), "cybara-sensitive-read-"));
+const envPath = join(directory, ".env");
+const examplePath = join(directory, ".env.example");
+const keyPath = join(directory, "id_ed25519");
+const originalPolicy = config.getSensitiveFilePolicy();
+
+describe("sensitive file read policy", () => {
+  beforeAll(() => {
+    writeFileSync(envPath, "API_KEY=secret-value\n");
+    writeFileSync(examplePath, "API_KEY=\n");
+    writeFileSync(keyPath, "-----BEGIN OPENSSH PRIVATE KEY-----\n");
+  });
+
+  afterAll(() => {
+    config.setSensitiveFilePolicy(originalPolicy);
+    rmSync(directory, { recursive: true, force: true });
+  });
+
+  test("maps the stored policy onto a read mode", () => {
+    expect(
+      sensitiveReadMode({ allow_env_file_reads: false, allow_all_sensitive_reads: false })
+    ).toBe("blocked");
+    expect(
+      sensitiveReadMode({ allow_env_file_reads: true, allow_all_sensitive_reads: false })
+    ).toBe("env-files");
+    expect(
+      sensitiveReadMode({ allow_env_file_reads: false, allow_all_sensitive_reads: true })
+    ).toBe("all");
+    expect(readablePathOptions({ confineToWorkspace: true }).confineToWorkspace).toBe(true);
+  });
+
+  test("blocks .env by default but always allows .env.example, and the denial names the setting", async () => {
+    config.setSensitiveFilePolicy({});
+    expect((await handleRead({ path: examplePath })).content).toContain("API_KEY=");
+    await expect(handleRead({ path: envPath })).rejects.toThrow("Settings → Safety");
+  });
+
+  test("the .env switch opens env files only", async () => {
+    config.setSensitiveFilePolicy({ allow_env_file_reads: true });
+    expect((await handleRead({ path: envPath })).content).toContain("secret-value");
+    await expect(handleRead({ path: keyPath })).rejects.toThrow("Refused");
+  });
+
+  test("the all-sensitive switch opens key files too, while Cybara's own data stays blocked", async () => {
+    config.setSensitiveFilePolicy({ allow_all_sensitive_reads: true });
+    expect((await handleRead({ path: keyPath })).content).toContain("PRIVATE KEY");
+    await expect(handleRead({ path: "~/.cybara/secure/storage.key" })).rejects.toThrow("Refused");
+  });
+
+  test("normalizes stored policy values", () => {
+    expect(
+      config.setSensitiveFilePolicy({ allow_env_file_reads: "yes", allow_all_sensitive_reads: 1 })
+    ).toEqual({
+      allow_env_file_reads: false,
+      allow_all_sensitive_reads: false,
+    });
+    expect(config.setSensitiveFilePolicy(null)).toEqual({
+      allow_env_file_reads: false,
+      allow_all_sensitive_reads: false,
+    });
+  });
+});

--- a/tests/core/tool-dispatch-robustness.test.ts
+++ b/tests/core/tool-dispatch-robustness.test.ts
@@ -288,7 +288,7 @@ describe("tool dispatch robustness", () => {
                       type: "function",
                       function: {
                         name: "read",
-                        arguments: JSON.stringify({ path: ".env.example" }),
+                        arguments: JSON.stringify({ path: ".env" }),
                       },
                     },
                   ],

--- a/ui/src/pages/Settings.tsx
+++ b/ui/src/pages/Settings.tsx
@@ -22,6 +22,7 @@ import {
 } from "./settings/RuntimeSettings";
 import { SpeechSettingsSection } from "./settings/SpeechSettingsSection";
 import { ThemeSettings } from "./settings/ThemeSettings";
+import { SensitiveFileSettings } from "./settings/SensitiveFileSettings";
 import { WebToolPolicySettings } from "./settings/WebToolPolicySettings";
 import { WebResearchSettings } from "./settings/WebResearchSettings";
 import { SystemPromptSection } from "./settings/SystemPromptSection";
@@ -1347,6 +1348,7 @@ export function Settings() {
           <>
             <FeatureSettings />
             <ToolCapabilitySettings />
+            <SensitiveFileSettings />
             <WebResearchSettings />
             <WebToolPolicySettings />
             <SandboxBrowserSettings />

--- a/ui/src/pages/settings/SensitiveFileSettings.tsx
+++ b/ui/src/pages/settings/SensitiveFileSettings.tsx
@@ -1,0 +1,122 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/Card";
+import { Switch } from "@/components/ui/Switch";
+import { extractApiError, settingsApi } from "@/lib/api";
+import { useUIStore } from "@/stores/uiStore";
+import { KeyRound } from "lucide-react";
+import { useEffect, useState } from "react";
+
+interface SensitiveFilePolicy {
+  allow_env_file_reads: boolean;
+  allow_all_sensitive_reads: boolean;
+}
+
+const DEFAULT_POLICY: SensitiveFilePolicy = {
+  allow_env_file_reads: false,
+  allow_all_sensitive_reads: false,
+};
+
+function readPolicy(value: unknown): SensitiveFilePolicy {
+  const raw = (value ?? {}) as Partial<SensitiveFilePolicy>;
+  return {
+    allow_env_file_reads: raw.allow_env_file_reads === true,
+    allow_all_sensitive_reads: raw.allow_all_sensitive_reads === true,
+  };
+}
+
+export function SensitiveFileSettings() {
+  const [policy, setPolicy] = useState<SensitiveFilePolicy>(DEFAULT_POLICY);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const { addToast } = useUIStore();
+
+  useEffect(() => {
+    let active = true;
+    void settingsApi
+      .getConfig()
+      .then((result) => {
+        if (!active) return;
+        setPolicy(readPolicy(result.data?.sensitive_file_policy));
+      })
+      .catch((error: unknown) => {
+        if (!active) return;
+        addToast(
+          "error",
+          error instanceof Error ? error.message : "Sensitive file access failed to load"
+        );
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [addToast]);
+
+  const save = async (next: SensitiveFilePolicy) => {
+    setSaving(true);
+    try {
+      const result = await settingsApi.updateConfig({ sensitive_file_policy: next });
+      if (!result.success || !result.data?.success) {
+        throw new Error(extractApiError(result, "Sensitive file access update failed"));
+      }
+      setPolicy(next);
+      addToast("success", "Sensitive file access updated");
+    } catch (error) {
+      addToast(
+        "error",
+        error instanceof Error ? error.message : "Sensitive file access update failed"
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Card variant="liquid">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <KeyRound className="w-5 h-5" />
+          Sensitive file access
+        </CardTitle>
+        <CardDescription>
+          Agents cannot read credential files such as .env, SSH keys, or cloud tokens unless you
+          allow it here. Example and template files like .env.example are always readable.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex items-center justify-between gap-4 border-b border-[var(--surface-border)] pb-4">
+          <div>
+            <p className="text-sm font-medium text-[var(--text-primary)]">
+              Allow reading .env files
+            </p>
+            <p className="mt-0.5 text-xs text-[var(--text-muted)]">
+              Lets tools read .env, .env.local and similar files in your projects. Their contents
+              are sent to the model provider you use.
+            </p>
+          </div>
+          <Switch
+            checked={policy.allow_env_file_reads || policy.allow_all_sensitive_reads}
+            disabled={loading || saving || policy.allow_all_sensitive_reads}
+            onChange={(value) => void save({ ...policy, allow_env_file_reads: value })}
+          />
+        </div>
+        <div className="flex items-center justify-between gap-4">
+          <div>
+            <p className="text-sm font-medium text-[var(--text-primary)]">
+              Allow reading all sensitive files
+            </p>
+            <p className="mt-0.5 text-xs text-[var(--text-muted)]">
+              Also allows SSH keys, cloud credentials, and token files. Cybara's own secure storage
+              stays blocked. Writes to these files remain refused.
+            </p>
+          </div>
+          <Switch
+            checked={policy.allow_all_sensitive_reads}
+            disabled={loading || saving}
+            onChange={(value) => void save({ ...policy, allow_all_sensitive_reads: value })}
+          />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION


<!-- GITZILLA_SUMMARY -->
> [!NOTE]
> **Low Risk**
>
> **Overview**
> This pull request introduces a sensitive file read protection system, centered around a new `sensitive-read-policy` module that defines configurable patterns (regex/name based) and enforcement behavior for blocking or warning on reads of sensitive files. The path policy (`src/core/tools/path-policy.ts`) is extended to consult this new policy during path resolution and tool dispatch, with corresponding test coverage added in `tests/core/path-policy.test.ts` and `tests/core/sensitive-read-policy.test.ts`. Several tool handlers (`file.ts`, `security-scan.ts`, `transcribe.ts`) are updated to apply the policy, while `src/core/config.ts` adds the underlying configuration schema and `ui/src/pages/settings/SensitiveFileSettings.tsx` plus updates to `Settings.tsx` expose the feature in the UI. Additional changes include sandbox browser fixes/refactors in `src/core/browser/sandbox-browser.ts`, a small adjustment in the runtime routes, and new tests for the system routes and sandbox browser behavior.
>
> <sup>Written by [Gitzilla](https://gitzilla.ai) for commit f87fcbb. This will update automatically on new runs. Configure in the [Gitzilla dashboard](https://gitzilla.ai/dashboard).</sup>
<!-- /GITZILLA_SUMMARY -->