### PR TITLE
Release

### DIFF
--- a/apps/mobile/src/lib/chat-scroll.ts
+++ b/apps/mobile/src/lib/chat-scroll.ts
@@ -57,6 +57,7 @@ export class MobileChatScrollController {
         },
         CHAT_FOLLOW_THRESHOLD_PX
       );
+    if (this.following) this.onContentSizeChange();
   };
 
   readonly followLatest = (): void => {

--- a/apps/mobile/src/lib/chat-scroll.ts
+++ b/apps/mobile/src/lib/chat-scroll.ts
@@ -1,0 +1,71 @@
+import { CHAT_FOLLOW_THRESHOLD_PX, isChatNearBottom } from "cybara-shared/chat-scroll-follow";
+
+interface ChatScrollEvent {
+  nativeEvent: {
+    contentOffset: { y: number };
+    contentSize: { height: number };
+    layoutMeasurement: { height: number };
+  };
+}
+
+interface ChatScrollScheduler {
+  request: (callback: () => void) => number;
+  cancel: (id: number) => void;
+}
+
+export class MobileChatScrollController {
+  private following = true;
+  private interacting = false;
+  private frame: number | null = null;
+
+  constructor(
+    private scrollToEnd: () => void,
+    private scheduler: ChatScrollScheduler
+  ) {}
+
+  private cancelPendingScroll(): void {
+    if (this.frame === null) return;
+    this.scheduler.cancel(this.frame);
+    this.frame = null;
+  }
+
+  readonly onContentSizeChange = (): void => {
+    if (!this.following || this.interacting || this.frame !== null) return;
+    this.frame = this.scheduler.request(() => {
+      this.frame = null;
+      if (this.following && !this.interacting) this.scrollToEnd();
+    });
+  };
+
+  readonly onScrollBeginDrag = (): void => {
+    this.interacting = true;
+    this.following = false;
+    this.cancelPendingScroll();
+  };
+
+  readonly onScrollEndDrag = ({ nativeEvent }: ChatScrollEvent): void => {
+    if (!this.interacting) return;
+    const { contentOffset, contentSize, layoutMeasurement } = nativeEvent;
+    this.interacting = false;
+    this.following =
+      [contentOffset.y, contentSize.height, layoutMeasurement.height].every(Number.isFinite) &&
+      isChatNearBottom(
+        {
+          scrollTop: contentOffset.y,
+          scrollHeight: contentSize.height,
+          clientHeight: layoutMeasurement.height,
+        },
+        CHAT_FOLLOW_THRESHOLD_PX
+      );
+  };
+
+  readonly followLatest = (): void => {
+    this.interacting = false;
+    this.following = true;
+    this.onContentSizeChange();
+  };
+
+  readonly dispose = (): void => {
+    this.cancelPendingScroll();
+  };
+}

--- a/apps/mobile/src/lib/chat-send-recovery.ts
+++ b/apps/mobile/src/lib/chat-send-recovery.ts
@@ -1,0 +1,77 @@
+import type { CybaraMobileApi, MobileMessageImage, SessionMessageSummary } from "./api";
+
+interface MobileChatSubmission {
+  sessionId: string;
+  message: string;
+  images: MobileMessageImage[];
+  previousMessageIds: string[];
+  clientPendingId: string | null;
+}
+
+function matchesSubmittedMessage(
+  message: SessionMessageSummary,
+  submission: MobileChatSubmission
+): boolean {
+  if (
+    message.role !== "user" ||
+    message.content !== submission.message ||
+    submission.previousMessageIds.includes(message.id)
+  ) {
+    return false;
+  }
+  const images = message.images ?? [];
+  return (
+    images.length === submission.images.length &&
+    images.every((image, index) => {
+      const submitted = submission.images[index];
+      if (!submitted) return false;
+      return image.data
+        ? image.data === submitted.data
+        : Boolean(image.url && image.url === submitted.url);
+    })
+  );
+}
+
+async function mobileChatSubmissionWasReceived(
+  api: Pick<CybaraMobileApi, "session" | "pendingChatMessages">,
+  submission: MobileChatSubmission
+): Promise<boolean> {
+  const [session, pending] = await Promise.allSettled([
+    api.session(submission.sessionId),
+    api.pendingChatMessages(submission.sessionId),
+  ]);
+  if (
+    session.status === "fulfilled" &&
+    session.value.messages.some((message) => matchesSubmittedMessage(message, submission))
+  ) {
+    return true;
+  }
+  return (
+    submission.clientPendingId !== null &&
+    pending.status === "fulfilled" &&
+    pending.value.pendingMessages.some(
+      (message) =>
+        message.sessionId === submission.sessionId &&
+        message.clientPendingId === submission.clientPendingId
+    )
+  );
+}
+
+interface MobileChatRecoveryActions {
+  offerRestore: (restore: () => void) => void;
+  restoreText: (value: string) => void;
+  restoreImages: (images: MobileMessageImage[]) => void;
+}
+
+export async function recoverMobileChatSubmission(
+  api: Pick<CybaraMobileApi, "session" | "pendingChatMessages">,
+  submission: MobileChatSubmission,
+  actions: MobileChatRecoveryActions
+): Promise<boolean> {
+  if (await mobileChatSubmissionWasReceived(api, submission)) return true;
+  actions.offerRestore(() => {
+    actions.restoreText(submission.message);
+    actions.restoreImages(submission.images);
+  });
+  return false;
+}

--- a/apps/mobile/src/screens/DashboardScreen.tsx
+++ b/apps/mobile/src/screens/DashboardScreen.tsx
@@ -866,6 +866,7 @@ export function DashboardScreen({
 
       {detailRoute?.kind === "session" ? (
         <SessionDetailPanel
+          key={detailRoute.id}
           accentColor={accentColor}
           api={api}
           agents={summary?.agents ?? []}
@@ -1496,6 +1497,7 @@ function DetailContent({
   if (route.kind === "session") {
     return (
       <SessionDetailPanel
+        key={route.id}
         accentColor={accentColor}
         api={api}
         agents={summary?.agents ?? []}

--- a/apps/mobile/src/screens/dashboardSessionDetail.tsx
+++ b/apps/mobile/src/screens/dashboardSessionDetail.tsx
@@ -1,10 +1,5 @@
 import { normalizeChatAppearanceSettings } from "cybara-shared/chat-appearance";
 import {
-  CHAT_FOLLOW_THRESHOLD_PX,
-  type ChatScrollMetrics,
-  isChatNearBottom,
-} from "cybara-shared/chat-scroll-follow";
-import {
   ArrowDown,
   ArrowUp,
   Bot,
@@ -45,8 +40,6 @@ import {
   Keyboard,
   KeyboardAvoidingView,
   Modal,
-  type NativeScrollEvent,
-  type NativeSyntheticEvent,
   Platform,
   Pressable,
   ScrollView,
@@ -89,13 +82,14 @@ import {
   sessionProviderModelLabel,
 } from "../lib/dashboard";
 import { haptics } from "../lib/haptics";
+import { MobileChatScrollController } from "../lib/chat-scroll";
+import { recoverMobileChatSubmission } from "../lib/chat-send-recovery";
 import { colors, spacing } from "../theme/liquidGlass";
 import { ChatMessageRow, MobilePlanSummaryCard } from "./dashboardChat";
 import { absoluteTimestampLabel, relativeTimestamp } from "./dashboardHelpers";
 import {
   clearCachedMobileLiveAssistant,
   liveAssistantMessage,
-  mergeLiveActivity,
   mobileAgentUsingBrowser,
   mobilePreSteerProcessActivities,
 } from "./dashboardLiveChat";
@@ -266,31 +260,15 @@ export function SessionDetailPanel({
   const [toolApprovalUpdating, setToolApprovalUpdating] = useState(false);
   const [pendingToolApprovalMode, setPendingToolApprovalMode] = useState<string | null>(null);
   const scrollRef = useRef<ScrollView>(null);
-  const followChatBottomRef = useRef(true);
-  const chatScrollGestureActiveRef = useRef(false);
-  const pendingScrollToEndRef = useRef<number | null>(null);
-  const headerActionRef = useRef<() => void>(() => {});
-  const updateChatFollowFromScroll = useCallback(
-    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
-      const { contentOffset, contentSize, layoutMeasurement } = event.nativeEvent;
-      const metrics: ChatScrollMetrics = {
-        clientHeight: layoutMeasurement.height,
-        scrollHeight: contentSize.height,
-        scrollTop: contentOffset.y,
-      };
-      followChatBottomRef.current = isChatNearBottom(metrics, CHAT_FOLLOW_THRESHOLD_PX);
-    },
-    []
+  const [chatScroll] = useState(
+    () =>
+      new MobileChatScrollController(() => scrollRef.current?.scrollToEnd({ animated: false }), {
+        request: requestAnimationFrame,
+        cancel: cancelAnimationFrame,
+      })
   );
-  const scrollChatToEnd = useCallback((): void => {
-    if (!followChatBottomRef.current || chatScrollGestureActiveRef.current) return;
-    if (pendingScrollToEndRef.current !== null) return;
-    pendingScrollToEndRef.current = requestAnimationFrame(() => {
-      pendingScrollToEndRef.current = null;
-      if (!followChatBottomRef.current || chatScrollGestureActiveRef.current) return;
-      scrollRef.current?.scrollToEnd({ animated: false });
-    });
-  }, []);
+  useEffect(() => () => chatScroll.dispose(), [chatScroll]);
+  const headerActionRef = useRef<() => void>(() => {});
   const {
     detail,
     setDetail,
@@ -316,11 +294,6 @@ export function SessionDetailPanel({
     setPendingSessionAgentId,
     onSessionUpdated: onSessionUpdated ?? ignoreSessionDetail,
   });
-
-  useEffect(() => {
-    followChatBottomRef.current = true;
-    chatScrollGestureActiveRef.current = false;
-  }, [sessionId]);
 
   useEffect(() => {
     let active = true;
@@ -377,6 +350,7 @@ export function SessionDetailPanel({
     pendingImages,
     setPendingImages,
     removePendingImage,
+    appendPendingImages,
     openAttachmentMenu,
   } = useMobileChatComposer({ setLoadError });
 
@@ -391,12 +365,14 @@ export function SessionDetailPanel({
   };
 
   const sendMessage = async () => {
-    const message = draft.trim();
+    const message = draftRef.current.trim();
     const attachments = pendingImages;
+    const previousMessageIds = detail?.messages.map((entry) => entry.id) ?? [];
     const chatBusy = sending || sessionActive || pendingMessages.length > 0;
     const queuedSend = followUpBehaviorEnabled && chatBusy;
     if (!message && attachments.length === 0) return;
     if (chatBusy && !followUpBehaviorEnabled) return;
+    chatScroll.followLatest();
     haptics.messageSent();
     resetComposerDraft();
     setPendingImages([]);
@@ -520,17 +496,38 @@ export function SessionDetailPanel({
         responseHapticActiveRef.current = false;
         haptics.agentCompleted();
       }
-    } catch (error) {
-      const messageText = error instanceof Error ? error.message : String(error);
-      setComposerDraft(message);
-      if (attachments.length > 0) setPendingImages(attachments);
-      setLoadError(messageText);
+    } catch {
+      const received = await recoverMobileChatSubmission(
+        api,
+        {
+          sessionId,
+          message,
+          images: attachments,
+          previousMessageIds,
+          clientPendingId: optimisticPendingMessageId,
+        },
+        {
+          restoreText: appendTextToComposer,
+          restoreImages: appendPendingImages,
+          offerRestore: (restore) => {
+            if (!scrollRef.current) return;
+            Alert.alert(
+              "Message delivery unconfirmed",
+              "Check the chat before sending again. You can restore the prompt if it is missing.",
+              [
+                { text: "Dismiss", style: "cancel" },
+                { text: "Restore prompt", onPress: restore },
+              ]
+            );
+          },
+        }
+      );
       if (optimisticPendingMessageId) {
         setPendingMessages((current) =>
           current.filter((entry) => entry.id !== optimisticPendingMessageId)
         );
       }
-      if (optimisticMessageId) {
+      if (!received && optimisticMessageId) {
         clearCachedMobileOptimisticTranscript(sessionId, optimisticMessageId);
         setDetail((current) =>
           current
@@ -541,23 +538,12 @@ export function SessionDetailPanel({
             : current
         );
       }
-      const failedAt = Date.now();
-      if (responseHapticActiveRef.current) {
+      if (!received && responseHapticActiveRef.current) {
         responseHapticActiveRef.current = false;
         haptics.warning();
       }
-      commitLiveAssistant((current) => {
-        const base = liveAssistantMessage(sessionId, current, failedAt);
-        return {
-          ...base,
-          processActivities: mergeLiveActivity(base.processActivities || [], {
-            id: `live-error-${failedAt}`,
-            phase: "error",
-            text: messageText,
-            timestamp: failedAt,
-          }),
-        };
-      }, failedAt);
+      await loadSession(false);
+      refreshSummary();
     } finally {
       if (!queuedSend) {
         setSending(false);
@@ -1519,31 +1505,12 @@ export function SessionDetailPanel({
           },
         ]}
         keyboardShouldPersistTaps="handled"
-        onContentSizeChange={() => {
-          if (!followChatBottomRef.current) return;
-          scrollChatToEnd();
-        }}
-        onMomentumScrollBegin={() => {
-          chatScrollGestureActiveRef.current = true;
-        }}
-        onMomentumScrollEnd={(event) => {
-          updateChatFollowFromScroll(event);
-          chatScrollGestureActiveRef.current = false;
-        }}
-        onScroll={(event) => {
-          if (!chatScrollGestureActiveRef.current) return;
-          updateChatFollowFromScroll(event);
-        }}
-        onScrollBeginDrag={() => {
-          chatScrollGestureActiveRef.current = true;
-          followChatBottomRef.current = false;
-        }}
-        onScrollEndDrag={(event) => {
-          updateChatFollowFromScroll(event);
-          chatScrollGestureActiveRef.current = false;
-          if (followChatBottomRef.current) scrollChatToEnd();
-        }}
-        scrollEventThrottle={16}
+        onContentSizeChange={chatScroll.onContentSizeChange}
+        onLayout={chatScroll.onContentSizeChange}
+        onScrollBeginDrag={chatScroll.onScrollBeginDrag}
+        onScrollEndDrag={chatScroll.onScrollEndDrag}
+        onMomentumScrollBegin={chatScroll.onScrollBeginDrag}
+        onMomentumScrollEnd={chatScroll.onScrollEndDrag}
         showsVerticalScrollIndicator={false}
         style={styles.chatScroll}
       >

--- a/apps/mobile/src/screens/dashboardSessionDetail.tsx
+++ b/apps/mobile/src/screens/dashboardSessionDetail.tsx
@@ -90,6 +90,7 @@ import { absoluteTimestampLabel, relativeTimestamp } from "./dashboardHelpers";
 import {
   clearCachedMobileLiveAssistant,
   liveAssistantMessage,
+  mergeLiveActivity,
   mobileAgentUsingBrowser,
   mobilePreSteerProcessActivities,
 } from "./dashboardLiveChat";
@@ -496,7 +497,8 @@ export function SessionDetailPanel({
         responseHapticActiveRef.current = false;
         haptics.agentCompleted();
       }
-    } catch {
+    } catch (error) {
+      const failureText = error instanceof Error ? error.message : String(error);
       const received = await recoverMobileChatSubmission(
         api,
         {
@@ -527,20 +529,36 @@ export function SessionDetailPanel({
           current.filter((entry) => entry.id !== optimisticPendingMessageId)
         );
       }
-      if (!received && optimisticMessageId) {
-        clearCachedMobileOptimisticTranscript(sessionId, optimisticMessageId);
-        setDetail((current) =>
-          current
-            ? {
-                ...current,
-                messages: current.messages.filter((entry) => entry.id !== optimisticMessageId),
-              }
-            : current
-        );
-      }
-      if (!received && responseHapticActiveRef.current) {
-        responseHapticActiveRef.current = false;
-        haptics.warning();
+      if (!received) {
+        const failedAt = Date.now();
+        setLoadError(failureText);
+        if (optimisticMessageId) {
+          clearCachedMobileOptimisticTranscript(sessionId, optimisticMessageId);
+          setDetail((current) =>
+            current
+              ? {
+                  ...current,
+                  messages: current.messages.filter((entry) => entry.id !== optimisticMessageId),
+                }
+              : current
+          );
+        }
+        if (responseHapticActiveRef.current) {
+          responseHapticActiveRef.current = false;
+          haptics.warning();
+        }
+        commitLiveAssistant((current) => {
+          const base = liveAssistantMessage(sessionId, current, failedAt);
+          return {
+            ...base,
+            processActivities: mergeLiveActivity(base.processActivities || [], {
+              id: `live-error-${failedAt}`,
+              phase: "error",
+              text: failureText,
+              timestamp: failedAt,
+            }),
+          };
+        }, failedAt);
       }
       await loadSession(false);
       refreshSummary();

--- a/apps/mobile/src/screens/useMobileChatComposer.ts
+++ b/apps/mobile/src/screens/useMobileChatComposer.ts
@@ -34,6 +34,7 @@ interface MobileChatComposerController {
   pendingImages: MobileMessageImage[];
   setPendingImages: Dispatch<SetStateAction<MobileMessageImage[]>>;
   removePendingImage: (index: number) => void;
+  appendPendingImages: (images: MobileMessageImage[]) => void;
   openAttachmentMenu: () => void;
 }
 
@@ -199,6 +200,7 @@ export function useMobileChatComposer({
     pendingImages,
     setPendingImages,
     removePendingImage,
+    appendPendingImages,
     openAttachmentMenu,
   };
 }

--- a/tests/mobile/chat-interaction-wiring.test.ts
+++ b/tests/mobile/chat-interaction-wiring.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+
+const source = await Bun.file(
+  new URL("../../apps/mobile/src/screens/dashboardSessionDetail.tsx", import.meta.url)
+).text();
+const dashboard = await Bun.file(
+  new URL("../../apps/mobile/src/screens/DashboardScreen.tsx", import.meta.url)
+).text();
+
+describe("mobile chat interaction wiring", () => {
+  test("only an explicit recovery action can restore a failed send to the composer", () => {
+    const send = source.slice(
+      source.indexOf("const sendMessage = async () =>"),
+      source.indexOf("const steerPendingMessage = async")
+    );
+    expect(send).not.toContain("setComposerDraft(message);");
+    expect(send).not.toContain("setPendingImages(attachments);");
+    expect(send).not.toContain('phase: "error"');
+    expect(send).toContain("const message = draftRef.current.trim();");
+    expect(send.indexOf("resetComposerDraft();")).toBeLessThan(send.indexOf("await api.sendChat("));
+    expect(send).toContain("await recoverMobileChatSubmission(");
+    expect(send).toContain('text: "Restore prompt", onPress: restore');
+    expect(send).toContain("restoreText: appendTextToComposer");
+    expect(send).toContain("restoreImages: appendPendingImages");
+  });
+
+  test("switching sessions resets the scroll and composer state", () => {
+    expect(dashboard).toContain("key={detailRoute.id}");
+    expect(dashboard).toContain("key={route.id}");
+    expect(source).toContain("() => chatScroll.dispose()");
+  });
+});

--- a/tests/mobile/chat-interaction-wiring.test.ts
+++ b/tests/mobile/chat-interaction-wiring.test.ts
@@ -15,13 +15,27 @@ describe("mobile chat interaction wiring", () => {
     );
     expect(send).not.toContain("setComposerDraft(message);");
     expect(send).not.toContain("setPendingImages(attachments);");
-    expect(send).not.toContain('phase: "error"');
     expect(send).toContain("const message = draftRef.current.trim();");
     expect(send.indexOf("resetComposerDraft();")).toBeLessThan(send.indexOf("await api.sendChat("));
     expect(send).toContain("await recoverMobileChatSubmission(");
     expect(send).toContain('text: "Restore prompt", onPress: restore');
     expect(send).toContain("restoreText: appendTextToComposer");
     expect(send).toContain("restoreImages: appendPendingImages");
+  });
+
+  test("an unconfirmed delivery reports the failure and ends the live indicator", () => {
+    const send = source.slice(
+      source.indexOf("const sendMessage = async () =>"),
+      source.indexOf("const steerPendingMessage = async")
+    );
+    const unconfirmed = send.slice(send.indexOf("if (!received) {"));
+    expect(send).toContain("} catch (error) {");
+    expect(send).toContain("if (!received) {");
+    expect(unconfirmed).toContain("setLoadError(failureText);");
+    expect(unconfirmed).toContain('phase: "error"');
+    expect(unconfirmed).toContain("text: failureText");
+    expect(unconfirmed).toContain("clearCachedMobileOptimisticTranscript(sessionId");
+    expect(send.indexOf('phase: "error"')).toBeGreaterThan(send.indexOf("if (!received) {"));
   });
 
   test("switching sessions resets the scroll and composer state", () => {

--- a/tests/mobile/lib/chat-scroll.test.ts
+++ b/tests/mobile/lib/chat-scroll.test.ts
@@ -96,6 +96,22 @@ describe("mobile chat scroll", () => {
     expect(harness.scrolls()).toBe(1);
   });
 
+  test("releasing a drag near the bottom snaps to the newest message", () => {
+    const harness = createScrollHarness();
+    harness.controller.onScrollBeginDrag();
+    harness.controller.onScrollEndDrag(scrollEvent(2304));
+    harness.flush();
+    expect(harness.scrolls()).toBe(1);
+  });
+
+  test("releasing a drag away from the bottom leaves the reading position alone", () => {
+    const harness = createScrollHarness();
+    harness.controller.onScrollBeginDrag();
+    harness.controller.onScrollEndDrag(scrollEvent(2303));
+    harness.flush();
+    expect(harness.scrolls()).toBe(0);
+  });
+
   test("layout scroll events cannot resume following while reading", () => {
     const harness = createScrollHarness();
     harness.controller.onScrollBeginDrag();

--- a/tests/mobile/lib/chat-scroll.test.ts
+++ b/tests/mobile/lib/chat-scroll.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, test } from "bun:test";
+import { MobileChatScrollController } from "../../../apps/mobile/src/lib/chat-scroll";
+
+function createScrollHarness() {
+  let nextFrame = 0;
+  let scrolls = 0;
+  const callbacks = new Map<number, () => void>();
+  const controller = new MobileChatScrollController(() => scrolls++, {
+    request: (callback) => {
+      callbacks.set(++nextFrame, callback);
+      return nextFrame;
+    },
+    cancel: (id) => {
+      callbacks.delete(id);
+    },
+  });
+  return {
+    controller,
+    callbacks,
+    scrolls: () => scrolls,
+    flush: () => {
+      const pending = [...callbacks.values()];
+      callbacks.clear();
+      for (const callback of pending) callback();
+    },
+  };
+}
+
+function scrollEvent(offset: number, contentHeight = 3000, viewportHeight = 600) {
+  return {
+    nativeEvent: {
+      contentOffset: { y: offset },
+      contentSize: { height: contentHeight },
+      layoutMeasurement: { height: viewportHeight },
+    },
+  };
+}
+
+describe("mobile chat scroll", () => {
+  test("opens at the latest message and follows growing replies", () => {
+    const harness = createScrollHarness();
+    harness.controller.onContentSizeChange();
+    harness.controller.onContentSizeChange();
+    harness.flush();
+    expect(harness.scrolls()).toBe(1);
+    harness.controller.onContentSizeChange();
+    harness.flush();
+    expect(harness.scrolls()).toBe(2);
+  });
+
+  test("streaming, polling, and image layout changes never pull a reader back down", () => {
+    const harness = createScrollHarness();
+    harness.controller.onScrollBeginDrag();
+    harness.controller.onScrollEndDrag(scrollEvent(1000));
+    for (let update = 0; update < 20; update++) {
+      harness.controller.onContentSizeChange();
+      harness.flush();
+    }
+    expect(harness.scrolls()).toBe(0);
+  });
+
+  test("touching the transcript cancels a previously scheduled scroll", () => {
+    const harness = createScrollHarness();
+    harness.controller.onContentSizeChange();
+    const pendingCallback = [...harness.callbacks.values()][0];
+    harness.controller.onScrollBeginDrag();
+    expect(harness.callbacks.size).toBe(0);
+    pendingCallback?.();
+    harness.controller.onContentSizeChange();
+    harness.flush();
+    expect(harness.scrolls()).toBe(0);
+  });
+
+  test("momentum pauses following until the gesture finishes near the bottom", () => {
+    const harness = createScrollHarness();
+    harness.controller.onScrollBeginDrag();
+    harness.controller.onScrollEndDrag(scrollEvent(2380));
+    harness.controller.onContentSizeChange();
+    harness.controller.onScrollBeginDrag();
+    harness.flush();
+    expect(harness.scrolls()).toBe(0);
+    harness.controller.onScrollEndDrag(scrollEvent(1000));
+    harness.controller.onContentSizeChange();
+    harness.flush();
+    expect(harness.scrolls()).toBe(0);
+  });
+
+  test("returning to the bottom resumes following", () => {
+    const harness = createScrollHarness();
+    harness.controller.onScrollBeginDrag();
+    harness.controller.onScrollEndDrag(scrollEvent(1000));
+    harness.controller.onScrollBeginDrag();
+    harness.controller.onScrollEndDrag(scrollEvent(2304));
+    harness.controller.onContentSizeChange();
+    harness.flush();
+    expect(harness.scrolls()).toBe(1);
+  });
+
+  test("layout scroll events cannot resume following while reading", () => {
+    const harness = createScrollHarness();
+    harness.controller.onScrollBeginDrag();
+    harness.controller.onScrollEndDrag(scrollEvent(1000));
+    harness.controller.onScrollEndDrag(scrollEvent(2400));
+    harness.controller.onContentSizeChange();
+    harness.flush();
+    expect(harness.scrolls()).toBe(0);
+  });
+
+  test("sending a prompt explicitly resumes following", () => {
+    const harness = createScrollHarness();
+    harness.controller.onScrollBeginDrag();
+    harness.controller.onScrollEndDrag(scrollEvent(1000));
+    harness.controller.followLatest();
+    harness.flush();
+    expect(harness.scrolls()).toBe(1);
+    harness.controller.onContentSizeChange();
+    harness.flush();
+    expect(harness.scrolls()).toBe(2);
+  });
+
+  test.each([
+    NaN,
+    Infinity,
+    -Infinity,
+    2303,
+  ])("does not follow invalid or distant offsets: %s", (offset) => {
+    const harness = createScrollHarness();
+    harness.controller.onScrollBeginDrag();
+    harness.controller.onScrollEndDrag(scrollEvent(offset));
+    harness.controller.onContentSizeChange();
+    harness.flush();
+    expect(harness.scrolls()).toBe(0);
+  });
+
+  test.each([
+    scrollEvent(0, 0),
+    scrollEvent(0, 100),
+    scrollEvent(2450),
+  ])("handles empty transcripts, short replies, and bottom overscroll", (event) => {
+    const harness = createScrollHarness();
+    harness.controller.onScrollBeginDrag();
+    harness.controller.onScrollEndDrag(event);
+    harness.controller.onContentSizeChange();
+    harness.flush();
+    expect(harness.scrolls()).toBe(1);
+  });
+
+  test("unmount cancels pending work and a new chat starts at the bottom", () => {
+    const previous = createScrollHarness();
+    previous.controller.onContentSizeChange();
+    previous.controller.dispose();
+    previous.flush();
+    expect(previous.scrolls()).toBe(0);
+    const next = createScrollHarness();
+    next.controller.onContentSizeChange();
+    next.flush();
+    expect(next.scrolls()).toBe(1);
+  });
+});

--- a/tests/mobile/lib/chat-send-recovery.test.ts
+++ b/tests/mobile/lib/chat-send-recovery.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, test } from "bun:test";
+import {
+  CybaraMobileApi,
+  type MobileMessageImage,
+  type MobilePendingChatMessage,
+  type SessionMessageSummary,
+} from "../../../apps/mobile/src/lib/api";
+import { recoverMobileChatSubmission } from "../../../apps/mobile/src/lib/chat-send-recovery";
+
+function createComposerHarness(initialDraft = "") {
+  let draft = initialDraft;
+  let writes = 0;
+  const images: MobileMessageImage[] = [];
+  const restores: Array<() => void> = [];
+  return {
+    draft: () => draft,
+    writes: () => writes,
+    images,
+    restores,
+    type: (value: string) => {
+      draft = value;
+    },
+    actions: {
+      offerRestore: (restore: () => void) => {
+        restores.push(restore);
+      },
+      restoreText: (value: string) => {
+        writes++;
+        draft = [draft, value].filter(Boolean).join("\n\n");
+      },
+      restoreImages: (attachments: MobileMessageImage[]) => {
+        images.push(...attachments);
+      },
+    },
+  };
+}
+
+function createGateway(
+  options: {
+    messages?: SessionMessageSummary[];
+    pendingMessages?: MobilePendingChatMessage[];
+    sessionUnavailable?: boolean;
+    pendingUnavailable?: boolean;
+  } = {}
+) {
+  return {
+    session: async () => {
+      if (options.sessionUnavailable) throw new Error("Offline");
+      return { id: "s1", title: null, messages: options.messages ?? [] };
+    },
+    pendingChatMessages: async () => {
+      if (options.pendingUnavailable) throw new Error("Offline");
+      return { sessionId: "s1", pendingMessages: options.pendingMessages ?? [] };
+    },
+  };
+}
+
+const submission = {
+  sessionId: "s1",
+  message: "Explain this in detail",
+  images: [],
+  previousMessageIds: ["old-prompt"],
+  clientPendingId: null,
+};
+
+describe("mobile chat send recovery", () => {
+  test("a lost response after gateway acceptance keeps the composer empty", async () => {
+    const messages: SessionMessageSummary[] = [];
+    const server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      async fetch(request) {
+        const path = new URL(request.url).pathname;
+        if (path === "/api/chat" && request.method === "POST") {
+          const body: unknown = await request.json();
+          if (typeof body !== "object" || body === null || !("message" in body)) {
+            return new Response(null, { status: 400 });
+          }
+          messages.push({ id: "received-prompt", role: "user", content: String(body.message) });
+          return new Response("Interrupted response", { status: 502 });
+        }
+        if (path === "/api/sessions/s1") return Response.json({ id: "s1", messages });
+        if (path === "/api/chat/sessions/s1/pending") {
+          return Response.json({ sessionId: "s1", pendingMessages: [] });
+        }
+        return new Response(null, { status: 404 });
+      },
+    });
+    try {
+      const api = new CybaraMobileApi({
+        id: "test",
+        name: "Test gateway",
+        baseUrl: server.url.origin,
+        apiKey: "test-key",
+        createdAt: "2026-09-11T00:00:00.000Z",
+      });
+      const composer = createComposerHarness();
+      await expect(
+        api.sendChat({ sessionId: submission.sessionId, message: submission.message })
+      ).rejects.toThrow("502");
+      await recoverMobileChatSubmission(api, submission, composer.actions);
+      expect(messages).toHaveLength(1);
+      expect(composer.draft()).toBe("");
+      expect(composer.writes()).toBe(0);
+      expect(composer.restores).toHaveLength(0);
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  test("an unavailable gateway never restores a sent prompt automatically", async () => {
+    const composer = createComposerHarness();
+    await recoverMobileChatSubmission(
+      createGateway({ sessionUnavailable: true, pendingUnavailable: true }),
+      submission,
+      composer.actions
+    );
+    expect(composer.draft()).toBe("");
+    expect(composer.writes()).toBe(0);
+    expect(composer.restores).toHaveLength(1);
+  });
+
+  test("late errors preserve the next prompt and its attachments", async () => {
+    const composer = createComposerHarness("My next question");
+    composer.images.push({ data: "new-image", mimeType: "image/png" });
+    await recoverMobileChatSubmission(
+      createGateway(),
+      { ...submission, images: [{ data: "old-image", mimeType: "image/png" }] },
+      composer.actions
+    );
+    expect(composer.draft()).toBe("My next question");
+    expect(composer.images).toEqual([{ data: "new-image", mimeType: "image/png" }]);
+    expect(composer.writes()).toBe(0);
+  });
+
+  test("explicit restoration preserves text typed after the recovery offer", async () => {
+    const composer = createComposerHarness();
+    const images = [{ data: "old-image", mimeType: "image/png" }];
+    await recoverMobileChatSubmission(createGateway(), { ...submission, images }, composer.actions);
+    composer.type("New draft");
+    composer.restores[0]?.();
+    expect(composer.draft()).toBe(`New draft\n\n${submission.message}`);
+    expect(composer.images).toEqual(images);
+    expect(composer.writes()).toBe(1);
+  });
+
+  test("image-only prompts can be restored explicitly without adding blank lines", async () => {
+    const composer = createComposerHarness();
+    const images = [{ data: "image", mimeType: "image/png" }];
+    await recoverMobileChatSubmission(
+      createGateway(),
+      { ...submission, message: "", images },
+      composer.actions
+    );
+    expect(composer.images).toEqual([]);
+    composer.restores[0]?.();
+    expect(composer.draft()).toBe("");
+    expect(composer.images).toEqual(images);
+  });
+
+  test("a confirmed queue receipt prevents restoring a queued prompt", async () => {
+    const composer = createComposerHarness("New draft");
+    await recoverMobileChatSubmission(
+      createGateway({
+        sessionUnavailable: true,
+        pendingMessages: [
+          {
+            id: "pending-1",
+            sessionId: "s1",
+            clientPendingId: "client-1",
+            content: submission.message,
+            createdAt: 1,
+            updatedAt: 1,
+            mode: "queued",
+            sequence: 1,
+          },
+        ],
+      }),
+      { ...submission, clientPendingId: "client-1" },
+      composer.actions
+    );
+    expect(composer.draft()).toBe("New draft");
+    expect(composer.restores).toHaveLength(0);
+  });
+
+  test.each([
+    { id: "old-prompt", role: "user", content: submission.message },
+    { id: "reply", role: "assistant", content: submission.message },
+    { id: "other-prompt", role: "user", content: "Something else" },
+  ])("older or unrelated messages are not delivery receipts", async (message) => {
+    const composer = createComposerHarness();
+    await recoverMobileChatSubmission(
+      createGateway({ messages: [message] }),
+      submission,
+      composer.actions
+    );
+    expect(composer.restores).toHaveLength(1);
+    expect(composer.writes()).toBe(0);
+  });
+
+  test("a confirmed transcript receipt works when the queue endpoint is unavailable", async () => {
+    const composer = createComposerHarness();
+    const images = [{ data: "photo", mimeType: "image/png" }];
+    await recoverMobileChatSubmission(
+      createGateway({
+        pendingUnavailable: true,
+        messages: [{ id: "received", role: "user", content: submission.message, images }],
+      }),
+      { ...submission, images },
+      composer.actions
+    );
+    expect(composer.restores).toHaveLength(0);
+    expect(composer.writes()).toBe(0);
+  });
+});

--- a/tests/mobile/sessions.test.ts
+++ b/tests/mobile/sessions.test.ts
@@ -113,11 +113,13 @@ describe("mobile: chat management", () => {
     const screen = read("screens/dashboardSessionDetail.tsx");
     const runtime = read("screens/useMobileSessionRuntime.ts");
 
-    expect(screen).toContain("followChatBottomRef.current = true;");
-    expect(screen).toContain("if (!followChatBottomRef.current) return;");
-    expect(screen).toContain("if (!chatScrollGestureActiveRef.current) return;");
-    expect(screen).toContain("onScrollBeginDrag={() => {");
-    expect(screen).toContain("followChatBottomRef.current = false;");
+    expect(screen).toContain("new MobileChatScrollController(");
+    expect(screen).toContain("onContentSizeChange={chatScroll.onContentSizeChange}");
+    expect(screen).toContain("onScrollBeginDrag={chatScroll.onScrollBeginDrag}");
+    expect(screen).toContain("onScrollEndDrag={chatScroll.onScrollEndDrag}");
+    expect(screen).toContain("onMomentumScrollBegin={chatScroll.onScrollBeginDrag}");
+    expect(screen).toContain("onMomentumScrollEnd={chatScroll.onScrollEndDrag}");
+    expect(screen).toContain("chatScroll.followLatest();");
     expect(screen).toContain("Math.max(composerBarHeight, MOBILE_CHAT_CHROME.composerHeight)");
     expect(runtime).not.toContain("scrollToEnd");
     expect(runtime).not.toContain("requestAnimationFrame");

--- a/tests/ui/chat-finish-handoff.test.ts
+++ b/tests/ui/chat-finish-handoff.test.ts
@@ -108,10 +108,10 @@ describe("chat live auto-scroll", () => {
 
   test("mobile: follows live growth with one stable non-animated scroll owner", () => {
     const source = readMobileChatSource();
-    expect(source).toContain("onContentSizeChange={() => {");
-    expect(source).toContain("if (!followChatBottomRef.current) return;");
-    expect(source).toContain("if (!chatScrollGestureActiveRef.current) return;");
-    expect(source).toContain("scrollRef.current?.scrollToEnd({ animated: false });");
+    expect(source).toContain("onContentSizeChange={chatScroll.onContentSizeChange}");
+    expect(source).toContain("onScrollBeginDrag={chatScroll.onScrollBeginDrag}");
+    expect(source).toContain("onScrollEndDrag={chatScroll.onScrollEndDrag}");
+    expect(source).toContain("scrollRef.current?.scrollToEnd({ animated: false })");
     expect(source).not.toContain("scrollRef.current?.scrollToEnd({ animated: true });");
   });
 });

--- a/tests/ui/chat-scroll-follow-parity.test.ts
+++ b/tests/ui/chat-scroll-follow-parity.test.ts
@@ -30,11 +30,12 @@ describe("chat follow parity", () => {
 
   test("mobile only pins to the bottom while the reader is following", () => {
     const source = read("apps/mobile/src/screens/dashboardSessionDetail.tsx");
-    expect(source).toContain("cybara-shared/chat-scroll-follow");
-    expect(source).toContain("if (!followChatBottomRef.current) return;");
-    expect(source).toContain("followChatBottomRef.current = isChatNearBottom(");
-    expect(source).toContain("if (!chatScrollGestureActiveRef.current) return;");
-    expect(source).toContain("onMomentumScrollEnd={(event) => {");
+    const controller = read("apps/mobile/src/lib/chat-scroll.ts");
+    expect(controller).toContain("cybara-shared/chat-scroll-follow");
+    expect(controller).toContain("isChatNearBottom(");
+    expect(controller).toContain("if (!this.interacting) return;");
+    expect(source).toContain("onScrollBeginDrag={chatScroll.onScrollBeginDrag}");
+    expect(source).toContain("onMomentumScrollEnd={chatScroll.onScrollEndDrag}");
   });
 
   test("macos gates every transcript autoscroll on the follow state", () => {


### PR DESCRIPTION


<!-- GITZILLA_SUMMARY -->
> [!NOTE]
> **Low Risk**
>
> **Overview**
> This pull request extracts chat interaction logic from `dashboardSessionDetail.tsx` into two new reusable library modules: `chat-scroll.ts` (72 lines) handling scroll behavior and `chat-send-recovery.ts` (77 lines) handling message send recovery. The screen is refactored to consume these helpers, resulting in a net reduction of approximately 15 lines (78 added, 93 removed). Three new dedicated unit test files are introduced covering chat-scroll behavior (175 lines), chat-send-recovery logic (215 lines), and interaction wiring (46 lines), alongside minor updates to existing chat and session test suites to align with the new module boundaries.
>
> <sup>Written by [Gitzilla](https://gitzilla.ai) for commit 0cea4c2. This will update automatically on new runs. Configure in the [Gitzilla dashboard](https://gitzilla.ai/dashboard).</sup>
<!-- /GITZILLA_SUMMARY -->